### PR TITLE
App instance count can be used in app templates

### DIFF
--- a/bin/cfpush
+++ b/bin/cfpush
@@ -1,5 +1,16 @@
 #!/bin/bash
 
-# Push all the Abacus apps to Cloud Foundry
-etc/apps | awk '{ printf "(cd %s && npm run cfpush)\n", $2 }' | bash -xe
+APPS_FILE=etc/apps
+if [ -n "$1" ]
+  then APPS_FILE=$1
+fi
 
+echo "Using apps list $APPS_FILE"
+
+# Push all the Abacus apps to Cloud Foundry
+$APPS_FILE | awk '{ if (NF==3) { \
+                      printf "(cd %s && npm run cfpush -- -i %s)\n", $2, $3 \
+                    } else { \
+                      printf "(cd %s && npm run cfpush)\n", $2 \
+                    } \
+                  }' | bash -xe

--- a/etc/apps
+++ b/etc/apps
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Print the names and paths of the Abacus apps
+# Print the names, paths and instance count of the Abacus apps
 cat <<EOF
 abacus-dbserver lib/utils/dbserver 1
 abacus-provisioning-stub lib/stubs/provisioning 1

--- a/etc/apps
+++ b/etc/apps
@@ -2,13 +2,12 @@
 
 # Print the names and paths of the Abacus apps
 cat <<EOF
-abacus-dbserver lib/utils/dbserver
-abacus-provisioning-stub lib/stubs/provisioning
-abacus-account-stub lib/stubs/account
-abacus-usage-collector lib/metering/collector
-abacus-usage-meter lib/metering/meter
-abacus-usage-accumulator lib/aggregation/accumulator
-abacus-usage-aggregator lib/aggregation/aggregator
-abacus-usage-reporting lib/aggregation/reporting
+abacus-dbserver lib/utils/dbserver 1
+abacus-provisioning-stub lib/stubs/provisioning 1
+abacus-account-stub lib/stubs/account 1
+abacus-usage-collector lib/metering/collector 1
+abacus-usage-meter lib/metering/meter 1
+abacus-usage-accumulator lib/aggregation/accumulator 1
+abacus-usage-aggregator lib/aggregation/aggregator 1
+abacus-usage-reporting lib/aggregation/reporting 1
 EOF
-

--- a/etc/apps-dev
+++ b/etc/apps-dev
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Print the names and paths of the Abacus apps
+cat <<EOF
+abacus-dbserver lib/utils/dbserver
+abacus-provisioning-stub lib/stubs/provisioning
+abacus-account-stub lib/stubs/account
+abacus-usage-collector lib/metering/collector
+abacus-usage-meter lib/metering/meter
+abacus-usage-accumulator lib/aggregation/accumulator
+abacus-usage-aggregator lib/aggregation/aggregator
+abacus-usage-reporting lib/aggregation/reporting
+EOF
+

--- a/etc/apps-dev
+++ b/etc/apps-dev
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Print the names and paths of the Abacus apps
+# Print the names, paths and instance count of the Abacus apps
 cat <<EOF
 abacus-dbserver lib/utils/dbserver
 abacus-provisioning-stub lib/stubs/provisioning
@@ -11,4 +11,3 @@ abacus-usage-accumulator lib/aggregation/accumulator
 abacus-usage-aggregator lib/aggregation/aggregator
 abacus-usage-reporting lib/aggregation/reporting
 EOF
-


### PR DESCRIPTION
App templates can now be specified to cfpush script. Their format: <app name> <directory> <instance count>

Signed-off-by: Georgi Sabev <georgethebeatle@gmail.com>