### PR TITLE
Handle failed report request to Abacus

### DIFF
--- a/lib/cf/bridge/src/index.js
+++ b/lib/cf/bridge/src/index.js
@@ -7,7 +7,10 @@ const request = require('abacus-request');
 const urienv = require('abacus-urienv');
 const cluster = require('abacus-cluster');
 
-const keys = require('underscore').keys;
+const _ = require('underscore');
+const keys = _.keys;
+const head = _.head;
+const tail = _.tail;
 
 // Create an express router
 const routes = router();
@@ -32,7 +35,6 @@ const reportingInterval = 10000;
 /* eslint no-var: 0 */
 var lastRecorded;
 
-
 routes.get('/v1/cf/bridge', throttle(function *(req) {
   const doc = 'Hello';
   return {
@@ -54,8 +56,7 @@ const obtainToken = (callback) => {
     if (error) {
       console.warn('Cannot obtain token from %s; error %s; response code %s',
         uris.uaa, error, response ? response.statusCode : 'unknown');
-      // TODO: use retry to get rid of 1s timeout
-      const refreshTokenTimeout = setTimeout(obtainToken, 1000, callback);
+      const refreshTokenTimeout = setTimeout(obtainToken, 3000, callback);
       callback(error, null, refreshTokenTimeout);
       return;
     }
@@ -71,8 +72,7 @@ const obtainToken = (callback) => {
       return;
     }
 
-    // TODO: use retry to get rid of 1s timeout
-    const refreshTokenTimeout = setTimeout(obtainToken, 1000, callback);
+    const refreshTokenTimeout = setTimeout(obtainToken, 3000, callback);
     callback('Unexpected response ' + response.statusCode,
       null, refreshTokenTimeout);
   });
@@ -183,74 +183,60 @@ const foreachPage = (processPage) => {
   };
 };
 
-const reportAppUsage = (cb = () => {}) => {
-  // Match & report recorded usage data
+const reportSingleAppUsage = (appGuid, events, cb) => {
+  if (events.length === 0) {
+    delete settings.appUsage[appGuid];
+    debug('All events processed for application %s', appGuid);
+    return;
+  }
+
+  const event = head(events);
+  debug('Processing app: %s event: %j', appGuid, event);
+
+  const memBytes = event.entity.memory_in_mb_per_instance * 1048576;
+  const eventTime = Date.parse(event.metadata.created_at);
+  const stopEvent = event.entity.state === 'STOPPED';
+
+  const appUsage = {
+    usage: {
+      usage: [{
+        start: eventTime,
+        end: eventTime,
+        region: 'eu-gb',
+        organization_id: event.entity.org_guid,
+        space_id: event.entity.space_guid,
+        resource_id: 'linux-container',
+        plan_id: 'basic',
+        resource_instance_id: event.entity.app_guid,
+        measured_usage: [
+          {
+            measure: 'instance_memory',
+            quantity: stopEvent ? 0 : memBytes
+          },
+          {
+            measure: 'running_instances',
+            quantity: stopEvent ? 0 : event.entity.instance_count
+          }
+        ]
+      }]
+    }
+  };
+
+  reportUsage(appUsage, (error, response) => {
+    if (!error && response.statusCode === 201) {
+      debug('Scheduling reported event %j for removal ...', head(events));
+      reportSingleAppUsage(appGuid, tail(events), cb);
+      cb(error, response);
+    } else
+    cb(error, response);
+  });
+};
+
+const reportAppsUsage = (cb = () => {}) => {
   keys(settings.appUsage).forEach((appGuid) => {
     let appEvents = settings.appUsage[appGuid];
-    debug('Processing app %s: %j', appGuid, appEvents);
-    for (var i = 0; i < appEvents.length; i++) {
-      const event = appEvents[i];
-      debug('Processing event %j', event);
 
-      const memBytes = event.entity.memory_in_mb_per_instance * 1048576;
-      const eventTime = Date.parse(event.metadata.created_at);
-
-      if (event.entity.state === 'STOPPED')
-        reportUsage({
-          usage: {
-            usage: [{
-              start: eventTime,
-              end: eventTime,
-              region: 'eu-gb',
-              organization_id: event.entity.org_guid,
-              space_id: event.entity.space_guid,
-              resource_id: 'linux-container',
-              plan_id: 'basic',
-              resource_instance_id: event.entity.app_guid,
-              measured_usage: [
-                {
-                  measure: 'instance_memory',
-                  quantity: 0
-                },
-                {
-                  measure: 'running_instances',
-                  quantity: 0
-                }
-              ]
-            }]
-          }
-        },
-        cb);
-      else
-        reportUsage({
-          usage: {
-            usage: [{
-              start: eventTime,
-              end: eventTime,
-              region: 'eu-gb',
-              organization_id: event.entity.org_guid,
-              space_id: event.entity.space_guid,
-              resource_id: 'linux-container',
-              plan_id: 'basic',
-              resource_instance_id: event.entity.app_guid,
-              measured_usage: [
-                {
-                  measure: 'instance_memory',
-                  quantity: memBytes
-                },
-                {
-                  measure: 'running_instances',
-                  quantity: event.entity.instance_count
-                }
-              ]
-            }]
-          }
-        },
-        cb);
-
-      const removedEvents = appEvents.splice(i--, 1);
-      debug('Removed reported event %j', removedEvents);
-    }
+    reportSingleAppUsage(appGuid, appEvents, cb);
   });
 };
 
@@ -275,7 +261,7 @@ const scheduleUsageReporting = () => {
     readUsage();
   }, 5000);
 
-  module.usageReporter = setInterval(reportAppUsage, reportingInterval);
+  module.usageReporter = setInterval(reportAppsUsage, reportingInterval);
 
   // Cancel scheduled timers
   process.on('exit', stopReporting);
@@ -307,7 +293,7 @@ module.exports = bridge;
 module.exports.obtainToken = obtainToken;
 module.exports.settings = settings;
 module.exports.readUsage = readUsage;
-module.exports.reportAppUsage = reportAppUsage;
+module.exports.reportAppUsage = reportAppsUsage;
 module.exports.stopReporting = stopReporting;
 module.exports.runCLI = runCLI;
 

--- a/lib/cf/bridge/src/test/obtain-token-test.js
+++ b/lib/cf/bridge/src/test/obtain-token-test.js
@@ -43,8 +43,6 @@ describe('CF Token refresh', () => {
     });
 
     it('obtains uaa token', function(done) {
-      this.timeout(5000);
-
       const bridge = require('..');
 
       bridge.obtainToken(function(err, token, timeout) {
@@ -53,6 +51,35 @@ describe('CF Token refresh', () => {
         expect(err).to.equal(null);
         expect(token).to.be.an('string');
         expect(token).to.equal('bearer token');
+        done();
+      });
+    });
+  });
+
+  context('on bad response code', () => {
+    beforeEach(() => {
+      // Mock the request module
+      const request = require('abacus-request');
+      reqmock = extend(clone(request), {
+        get: spy((uri, opts, cb) => {
+          cb(null, {
+            statusCode: 500,
+            body: {}
+          });
+        })
+      });
+      require.cache[require.resolve('abacus-request')].exports = reqmock;
+    });
+
+    it('fails to obtains uaa token', function(done) {
+      const bridge = require('..');
+
+      bridge.obtainToken(function(err, token, timeout) {
+        clearTimeout(timeout);
+
+        expect(err).to.equal('Unexpected response 500');
+        expect(token).to.equal(null);
+
         done();
       });
     });
@@ -69,8 +96,6 @@ describe('CF Token refresh', () => {
     });
 
     it('fails to obtain uaa token', function(done) {
-      this.timeout(5000);
-
       const bridge = require('..');
 
       bridge.obtainToken(function(err, token, timeout) {

--- a/lib/cf/bridge/src/test/report-usage-test.js
+++ b/lib/cf/bridge/src/test/report-usage-test.js
@@ -12,7 +12,8 @@ describe('Report usage', () => {
   let bridge;
   let expectedError;
   let expectedStatusCode;
-  let expectedUsageReport;
+  let expectedUsageRequest;
+  let expectedAppUsage;
 
   const checkUsageReport = (done) => {
     return (err, response) => {
@@ -31,8 +32,11 @@ describe('Report usage', () => {
       expect(args[0][1].body).to.contain.all.keys('usage');
       expect(args[0][1].body.usage.length).to.equal(1);
 
-      if (expectedUsageReport)
-        expect(args[0][1].body.usage[0]).to.deep.equal(expectedUsageReport);
+      if (expectedUsageRequest)
+        expect(args[0][1].body.usage[0]).to.deep.equal(expectedUsageRequest);
+
+      if (expectedAppUsage)
+        expect(bridge.settings.appUsage).to.deep.equal(expectedAppUsage);
 
       done();
     };
@@ -57,7 +61,8 @@ describe('Report usage', () => {
     bridge = undefined;
     expectedError = undefined;
     expectedStatusCode = undefined;
-    expectedUsageReport = undefined;
+    expectedUsageRequest = undefined;
+    expectedAppUsage = undefined;
   });
 
   context('on success', () => {
@@ -104,7 +109,7 @@ describe('Report usage', () => {
       beforeEach(() => {
         expectedError = null;
         expectedStatusCode = 201;
-        expectedUsageReport = {
+        expectedUsageRequest = {
           start: 1439897300000,
           end: 1439897300000,
           region: 'eu-gb',
@@ -124,6 +129,7 @@ describe('Report usage', () => {
             }
           ]
         };
+        expectedAppUsage = {};
 
         bridge = require('..');
         bridge.settings.oauthToken = 'token';
@@ -167,7 +173,7 @@ describe('Report usage', () => {
       beforeEach(() => {
         expectedError = null;
         expectedStatusCode = 201;
-        expectedUsageReport = {
+        expectedUsageRequest = {
           start: 1439897300000,
           end: 1439897300000,
           region: 'eu-gb',
@@ -187,6 +193,7 @@ describe('Report usage', () => {
             }
           ]
         };
+        expectedAppUsage = {};
 
         bridge = require('..');
         bridge.settings.oauthToken = 'token';
@@ -200,7 +207,7 @@ describe('Report usage', () => {
     });
   });
 
-  context('on bad status code', () => {
+  context('on bad response code', () => {
     const appUsage = {
       '35c4ff0f': [
         {
@@ -232,6 +239,7 @@ describe('Report usage', () => {
     beforeEach(() => {
       expectedError = null;
       expectedStatusCode = 500;
+      expectedAppUsage = clone(appUsage);
 
       // Mock the request module
       const request = require('abacus-request');
@@ -283,6 +291,27 @@ describe('Report usage', () => {
 
     beforeEach(() => {
       expectedError = 'error';
+      expectedUsageRequest = {
+        start: 1439897300000,
+        end: 1439897300000,
+        region: 'eu-gb',
+        organization_id: 'e8139b76-e829-4af3-b332-87316b1c0a6c',
+        space_id: 'a7e44fcd-25bf-4023-8a87-03fba4882995',
+        resource_id: 'linux-container',
+        plan_id: 'basic',
+        resource_instance_id: '35c4ff0f',
+        measured_usage: [
+          {
+            measure: 'instance_memory',
+            quantity: 0
+          },
+          {
+            measure: 'running_instances',
+            quantity: 0
+          }
+        ]
+      };
+      expectedAppUsage = clone(appUsage);
 
       // Mock the request module
       const request = require('abacus-request');


### PR DESCRIPTION
* Keep usage events in memory when POST to Abacus fails, so that reporting is retried on next iteration
* Refactor reporting logic
[#101018516]

Signed-off-by: Georgi Sabev <georgethebeatle@gmail.com>