### PR TITLE
Avoid race conditions on usage events read

### DIFF
--- a/lib/cf/bridge/src/index.js
+++ b/lib/cf/bridge/src/index.js
@@ -12,6 +12,9 @@ const keys = _.keys;
 const head = _.head;
 const tail = _.tail;
 
+// Setup debug log
+const debug = require('abacus-debug')('abacus-cf-bridge');
+
 // Create an express router
 const routes = router();
 
@@ -27,13 +30,13 @@ const settings = {
   appUsage: {}
 };
 
-// Setup debug log
-const debug = require('abacus-debug')('abacus-cf-bridge');
-
 const reportingInterval = 10000;
+const guidMaxAge = 60000;
 
-/* eslint no-var: 0 */
-var lastRecorded;
+const lastRecorded = {
+  guid: null,
+  timestamp: 0
+};
 
 routes.get('/v1/cf/bridge', throttle(function *(req) {
   const doc = 'Hello';
@@ -90,8 +93,8 @@ const readAppUsage = (processResponse, nextPageUri=null, cb = () => {}) => {
   let uri = nextPageUri ? ':api' + nextPageUri :
     ':api/v2/app_usage_events?order-direction=asc&results-per-page=50';
 
-  if (lastRecorded && !nextPageUri)
-    uri += '&after_guid=' + lastRecorded;
+  if (lastRecorded.guid && !nextPageUri)
+    uri += '&after_guid=' + lastRecorded.guid;
 
   debug('Requesting page: %s', request.route(uri, {api: uris.api}));
 
@@ -114,6 +117,7 @@ const readAppUsage = (processResponse, nextPageUri=null, cb = () => {}) => {
         response.body);
     if (response.statusCode === 200)
       processResponse(response.body);
+
     cb(null, response);
   });
 };
@@ -131,12 +135,35 @@ const forEachResource = (processResources) => {
   };
 };
 
+/**
+ * "The list of usage events returned from the API is not guaranteed to be
+ * complete. Events may still be processing at the time of the query, so
+ * events that occurred before the final event may still appear
+ * [...]
+ * it is recommended that operators select their ‘after_guid’ from an event
+ * far enough back in time to ensure that all events have been processed"
+ *
+ * https://www.cloudfoundry.org/how-to-bill-on-cloud-foundry/
+ */
+const storeElderGuid = (guid) => {
+  const now = new Date().getTime();
+  const age = now - lastRecorded.timestamp;
+
+  // Update stored guid only if old enough
+  if (age > guidMaxAge) {
+    lastRecorded.guid = guid;
+    lastRecorded.timestamp = now;
+    debug('Last processed guid set to %s', guid);
+  }
+};
+
 const saveResourceUsageEvent = (resource) => {
   let resourceId = resource.entity.app_guid;
   if(!settings.appUsage[resourceId])
    settings.appUsage[resourceId] = [];
   settings.appUsage[resourceId].push(resource);
-  lastRecorded = resource.metadata.guid;
+
+  storeElderGuid(resource.metadata.guid);
 
   let map = keys(settings.appUsage).reduce((m, e) => {
     m[e] = settings.appUsage[e].length;
@@ -233,9 +260,14 @@ const reportSingleAppUsage = (appGuid, events, cb) => {
 };
 
 const reportAppsUsage = (cb = () => {}) => {
-  keys(settings.appUsage).forEach((appGuid) => {
-    let appEvents = settings.appUsage[appGuid];
+  const appGuids = keys(settings.appUsage);
+  if (appGuids.length === 0) {
+    debug('No usage events to report');
+    return;
+  }
 
+  appGuids.forEach((appGuid) => {
+    let appEvents = settings.appUsage[appGuid];
     reportSingleAppUsage(appGuid, appEvents, cb);
   });
 };
@@ -256,8 +288,10 @@ const scheduleUsageReporting = () => {
   module.tokenRefresher = setTimeout(obtainToken, 200,
     (err, token) => debug('Callback: %j %s', err, token));
 
+  // Prevent recording of young guids in storeElderGuid
+  lastRecorded.timestamp = new Date().getTime();
+
   module.usageEventPoller = setInterval(function() {
-    // Record usage data in local list
     readUsage();
   }, 5000);
 
@@ -295,5 +329,6 @@ module.exports.settings = settings;
 module.exports.readUsage = readUsage;
 module.exports.reportAppUsage = reportAppsUsage;
 module.exports.stopReporting = stopReporting;
+module.exports.lastRecorded = lastRecorded;
 module.exports.runCLI = runCLI;
 

--- a/lib/cf/bridge/src/test/read-resource-test.js
+++ b/lib/cf/bridge/src/test/read-resource-test.js
@@ -267,4 +267,89 @@ describe('CF app usage read', () => {
       });
     });
   });
+
+  context('usage event listing', () => {
+    const appUsage = {
+      total_results: 1,
+      total_pages: 1,
+      prev_url: null,
+      next_url: null,
+      resources: [
+        {
+          metadata: {
+            guid: '904419c4',
+            url: '/v2/app_usage_events/904419c4',
+            created_at: '2015-08-18T11:28:20Z'
+          },
+          entity: {
+            state: 'STARTED',
+            memory_in_mb_per_instance: 512,
+            instance_count: 1,
+            app_guid: '35c4ff0f',
+            app_name: 'app',
+            space_guid: 'a7e44fcd-25bf-4023-8a87-03fba4882995',
+            space_name: 'diego',
+            org_guid: 'e8139b76-e829-4af3-b332-87316b1c0a6c',
+            buildpack_guid: null,
+            buildpack_name: null,
+            package_state: 'PENDING',
+            parent_app_guid: null,
+            parent_app_name: null,
+            process_type: 'web'
+          }
+        }
+      ]
+    };
+    let timestamp;
+    let bridge;
+
+    beforeEach(() => {
+      // Mock the request module
+      const request = require('abacus-request');
+      reqmock = extend(clone(request), {
+        get: spy((uri, opts, cb) => {
+          cb(null, {statusCode: 200, body: appUsage});
+        })
+      });
+      require.cache[require.resolve('abacus-request')].exports = reqmock;
+
+      bridge = require('..');
+      bridge.settings.oauthToken = 'token';
+    });
+
+    context('when we just recorded guid', () => {
+      beforeEach(() => {
+        timestamp = new Date().getTime() - 5000;
+        bridge.lastRecorded.guid = null;
+        bridge.lastRecorded.timestamp = timestamp;
+      });
+
+      it('does not update last recorded guid', function(done) {
+        bridge.readUsage(() => {
+          expect(bridge.lastRecorded.guid).to.equal(null);
+          expect(bridge.lastRecorded.timestamp).to.equal(timestamp);
+
+          done();
+        });
+      });
+    });
+
+    context('when we recorded the guid far back in time', () => {
+      beforeEach(() => {
+        timestamp = new Date().getTime() - 600000;
+        bridge.lastRecorded.guid = null;
+        bridge.lastRecorded.timestamp = timestamp;
+      });
+
+      it('updates last recorded guid', function(done) {
+        bridge.readUsage(() => {
+          expect(bridge.lastRecorded.guid).to.equal('904419c4');
+          expect(bridge.lastRecorded.timestamp).not.to.equal(timestamp);
+
+          done();
+        });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Events are read with old GUID set far back in time (1 min)
https://www.cloudfoundry.org/how-to-bill-on-cloud-foundry/

[#101018516]

Signed-off-by: Georgi Sabev <georgethebeatle@gmail.com>