### PR TITLE
Enable cfpush without starting apps

### DIFF
--- a/bin/cfpush
+++ b/bin/cfpush
@@ -14,10 +14,10 @@ for MODULE in $(node_modules/abacus-etc/apprc node_modules/abacus-etc/apps.rc $C
   APPS=$(echo $(node_modules/abacus-etc/apprc node_modules/$APPNAME/.apprc $CONF APPS) - 1 | bc)
   (cd $MODULE && npm run cfpack)
   if [ "$APPS" == "0" ]; then
-    (cd $MODULE && npm run cfpush -- -n $APPNAME -i $INSTANCES -c $CONF &)
+    (cd $MODULE && npm run cfpush -- -n $APPNAME -i $INSTANCES -c $CONF ${@:2} &)
   else
     for I in $(seq 0 $APPS); do
-      (cd $MODULE && npm run cfpush -- -n $APPNAME-$I -i $INSTANCES -c $CONF &)
+      (cd $MODULE && npm run cfpush -- -n $APPNAME-$I -i $INSTANCES -c $CONF ${@:2} &)
     done
   fi
 done

--- a/tools/cfpush/src/index.js
+++ b/tools/cfpush/src/index.js
@@ -90,8 +90,6 @@ var runCLI = function() {
       process.exit(1);
     }
 
-    console.log('commander', commander, 'stage', commander.stage);
-
     // Generate the updated manifest.yml
     remanifest(commander.root,
       commander.name, commander.instances, commander.conf, function(err) {


### PR DESCRIPTION
Allows use of `cfpush` to only stage the apps:
```
npm run cfpush -- large -s
```

This enables deployment of abacus from slow/unrealiable client networks since cfpush is taking less time. The load is shifted to `cfstart` which is idempotent in contrast to `cfpush`