### PR TITLE
Includes account_id as a part of the rated document

### DIFF
--- a/demo/client/src/test/test.js
+++ b/demo/client/src/test/test.js
@@ -161,6 +161,7 @@ describe('abacus-demo-client', () => {
     // Expected usage report for the test organization
     const report = {
       organization_id: 'us-south:a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+      account_id: '1234',
       windows: buildWindow(46.09),
       resources: [{
         resource_id: 'object-storage',
@@ -344,4 +345,3 @@ describe('abacus-demo-client', () => {
     });
   });
 });
-

--- a/lib/aggregation/rate/src/index.js
+++ b/lib/aggregation/rate/src/index.js
@@ -63,43 +63,43 @@ const rscope = (udoc) => secured() ? {
 } : undefined;
 
 // Return the keys and times of our docs
-const ikey = (udoc) => 
+const ikey = (udoc) =>
   udoc.organization_id;
 
-const itime = (udoc) => 
+const itime = (udoc) =>
   seqid();
 
-const okeys = (udoc, ikey) => 
+const okeys = (udoc, ikey) =>
   [udoc.organization_id];
 
-const otimes = (udoc, itime) => 
+const otimes = (udoc, itime) =>
   [itime];
 
-// Maintain a cache of pricing countries
-const countries = lru({
+// Maintain a cache of accounts
+const accounts = lru({
   max: 100000,
   length: (n) => 1,
   dispose: (key, n) => {
   },
   maxAge: 1000 * 3600 * 6
 });
-
-// Return the pricing country configured for an organization's account
+/* eslint complexity: [1, 6] */
+// Return the account for an organization
 // using batch and group by organization
-const pricingCountry = yieldable(batch(batch.groupBy(function *(calls) {
-  // Get pricing country for a given organization
+const orgAccounts = yieldable(batch(batch.groupBy(function *(calls) {
+  // Get account for a given organization
   const oid = calls[0][0];
-  debug('Retrieving pricing country for org %s', oid);
+  debug('Retrieving account for org %s', oid);
 
   // Look in our cache first
-  const cc = countries.get(oid);
-  if(cc) return map(calls, () => [undefined, cc]);
+  const ca = accounts.get(oid);
+  if(ca) return map(calls, () => [undefined, ca]);
 
   const unlock = yield lock(oid);
   try {
     // Look in our cache again
-    const cc = countries.get(oid);
-    if(cc) return map(calls, () => [undefined, cc]);
+    const ca = accounts.get(oid);
+    if(ca) return map(calls, () => [undefined, ca]);
 
     // Forward authorization header field to account
     const o = systemToken ?
@@ -109,13 +109,16 @@ const pricingCountry = yieldable(batch(batch.groupBy(function *(calls) {
         org_id: oid
       }));
 
-    // Default to USA
-    const c = !account.body || !account.body.pricing_country ?
-      'USA' : account.body.pricing_country;
+    const a = {};
+    a.account_id = !account.body || !account.body.account_id ? 'Unknown'
+          : account.body.account_id;
+    a.pricing_country = !account.body || !account.body.pricing_country ? 'USA'
+          : account.body.pricing_country;
 
     // Cache and return
-    countries.set(oid, c);
-    return map(calls, () => [undefined, c]);
+    accounts.set(oid, a);
+    console.log(JSON.stringify(a, null, 3));
+    return map(calls, () => [undefined, a]);
   }
   finally {
     unlock();
@@ -150,9 +153,9 @@ const ratefn = (metrics, metric) => {
 // Rates the given aggregated usage
 const rateUsage = function *(u, auth) {
   debug('Rating usage %o from %d', u, u.end);
-
+  const account = yield orgAccounts(u.organization_id);
   // Retrieve the pricing country configured for the org's account
-  const country = yield pricingCountry(u.organization_id);
+  const country = account.pricing_country;
   debug('Pricing country %o', country);
 
   // Retrieve all resources' metrics and price
@@ -209,6 +212,7 @@ const rateUsage = function *(u, auth) {
 
   // Extend the aggregated usage with the computed costs
   const ru = extend({}, u, {
+    account_id: account.account_id,
     resources: map(u.resources, rateResource),
     spaces: map(u.spaces, (space) => {
       return extend({}, space, {

--- a/lib/aggregation/rate/src/test/test.js
+++ b/lib/aggregation/rate/src/test/test.js
@@ -31,6 +31,7 @@ const reqmock = extend({}, request, {
   batch_get: spy((reqs, cb) => cb(undefined, [[undefined, {
     statusCode: 200,
     body: {
+      account_id : 'DummyAccount',
       pricing_country: 'USA'
     }
   }]]))
@@ -890,7 +891,8 @@ describe('abacus-usage-rate', () => {
                 }]
               }]
             }]
-        }]
+        }],
+        account_id: 'DummyAccount'
       }];
 
       const verify = (secured, done) => {
@@ -978,7 +980,6 @@ describe('abacus-usage-rate', () => {
               brequest.get(val.headers.location, {}, (err, val) => {
                 expect(err).to.equal(undefined);
                 expect(val.statusCode).to.equal(200);
-
                 expect(omit(
                   val.body, 'id', 'processed')).to.deep.equal(uval);
 

--- a/test/aggregation/rate/src/test/test.js
+++ b/test/aggregation/rate/src/test/test.js
@@ -17,6 +17,7 @@ const BigNumber = require('bignumber.js');
 const map = _.map;
 const range = _.range;
 const omit = _.omit;
+const extend = _.extend;
 
 // Batch the requests
 const brequest = batch(request);
@@ -424,11 +425,11 @@ describe('abacus-usage-rate-itest', () => {
     });
 
     // The expected output based upon the arguments passed
-    const expected = clone(
+    const expected = extend({}, { account_id: '1234' }, clone(
       clone(
         aggregatedTemplate(orgs - 1, resourceInstances - 1, usage - 1),
       addWindows),
-    pruneWindows);
+    pruneWindows));
 
     // Post an aggregated usage doc, throttled to default concurrent requests
     const post = throttle((o, ri, u, cb) => {

--- a/test/perf/src/test/test.js
+++ b/test/perf/src/test/test.js
@@ -142,6 +142,7 @@ describe('abacus-perf-test', () => {
     // Return the expected usage report for the test organization
     const report = (o, nri, n) => ({
       organization_id: orgid(o),
+      account_id: '1234',
       windows: cwindow(nri, n),
       resources: [{
         resource_id: 'object-storage',
@@ -386,4 +387,3 @@ describe('abacus-perf-test', () => {
     submit(() => wait(done));
   });
 });
-


### PR DESCRIPTION
Included account_id as a part of the rated usage doc. https://github.com/cloudfoundry-incubator/cf-abacus/issues/175