### PR TITLE
Enable cfpush of external artifacts (Eureka server)

### DIFF
--- a/bin/cfsetup
+++ b/bin/cfsetup
@@ -23,7 +23,7 @@ if [[ -z $CF_SPACE ]]; then
 fi
 
 # Point the CF CLI to your local Cloud Foundry deployment
-cf api --skip-ssl-validation https://api.10.244.0.34.xip.io
+cf api --skip-ssl-validation https://api.bosh-lite.com
 cf login -o $CF_ORG -s $CF_SPACE
 
 # Create a CF security group for the Abacus apps

--- a/tools/cfpush/src/index.js
+++ b/tools/cfpush/src/index.js
@@ -37,7 +37,7 @@ var remanifest = function(root, name, instances, conf, cb) {
         app.host = name;
         if(instances)
           app.instances = parseInt(instances);
-        app.path = '../.cfpack/app.zip';
+        app.path = '../' + app.path;
         if(conf) {
           if(!app.env) app.env = {};
           app.env.CONF = conf;


### PR DESCRIPTION
Pointing the manifest to external location now works correctly with `cfstage`, `cfpush` and `cfstart` targets