### PR TITLE
Resolve Org's Account Based on Time

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -106,7 +106,7 @@ const countries = lru({
 
 // Return the pricing country configured for an organization's account
 // using batch and group by organization
-const pricingCountry = function *(oid) {
+const pricingCountry = function *(oid, time) {
   // Get pricing country for a given organization
   debug('Retrieving pricing country for org %s', oid);
 
@@ -118,8 +118,9 @@ const pricingCountry = function *(oid) {
   const o = systemToken ?
     { headers: { authorization: systemToken() } } : {};
   const account = yield brequest.get(
-    uris.account + '/v1/orgs/:org_id/account', extend(o, {
-      org_id: oid
+    uris.account + '/v1/orgs/:org_id/account/:time', extend(o, {
+      org_id: oid,
+      time: time
     }));
 
   // Default to USA
@@ -260,7 +261,7 @@ const accumulate = function *(a, u) {
   const processed = a ? dateUTCNumbify(a.processed) : 0;
 
   // Retrieve the pricing country for the org's account
-  const country = yield pricingCountry(u.organization_id);
+  const country = yield pricingCountry(u.organization_id, u.end);
   debug('Pricing country %o', country);
 
   // Retrieve the configured metrics for the resource

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -230,7 +230,7 @@ const accounts = lru({
 
 // Return the account details configured for an organization's
 // using batch and group by organization
-const orgAccount = function *(oid) {
+const orgAccount = function *(oid, time) {
   // Get account details for a given organization
   debug('Retrieving account details for org %s', oid);
 
@@ -242,8 +242,9 @@ const orgAccount = function *(oid) {
   const o = systemToken ?
     { headers: { authorization: systemToken() } } : {};
   const account = yield brequest.get(
-    uris.account + '/v1/orgs/:org_id/account', extend(o, {
-      org_id: oid
+    uris.account + '/v1/orgs/:org_id/account/:time', extend(o, {
+      org_id: oid,
+      time: time
     }));
 
   if(!account.body) {
@@ -334,7 +335,7 @@ const aggregate = function *(a, u) {
   const oldend = a ? dateUTCNumbify(a.processed) : 0;
   const docend = dateUTCNumbify(u.end);
 
-  const account = yield orgAccount(u.organization_id);
+  const account = yield orgAccount(u.organization_id, u.end);
 
   // Deep clone and revive the org aggregated usage object behavior
   const newa = a ?

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -276,12 +276,15 @@ const summarizeUsage = function *(t, a, auth) {
 
 // Return the usage for an org in a given time period
 const orgUsage = function *(orgid, time, auth) {
+
+  const t = time || Date.now();
   // Forward authorization header field to account to authorize
   const o = auth ? { headers: { authorization: auth } } : {};
 
   const res = yield brequest.get(
-    uris.account + '/v1/orgs/:org_id/account', extend(o, {
-      org_id: orgid
+    uris.account + '/v1/orgs/:org_id/account/:time', extend(o, {
+      org_id: orgid,
+      time: t
     }));
 
   // Authorization failed. Unable to retrieve account information
@@ -295,7 +298,6 @@ const orgUsage = function *(orgid, time, auth) {
   }
 
   // Compute the query range
-  const t = time || Date.now();
   const d = new Date(t);
   const mt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
   const sid = dbclient.kturi(orgid, seqid.pad16(t)) + 'ZZZ';

--- a/lib/aggregation/reporting/src/test/test.js
+++ b/lib/aggregation/reporting/src/test/test.js
@@ -24,7 +24,7 @@ process.env.COUCHDB = process.env.COUCHDB || 'test';
 const getspy = (reqs, cb) => {
   // Expect a call to account
   expect(reqs[0][0]).to.equal(
-    'http://localhost:9881/v1/orgs/:org_id/account');
+    'http://localhost:9881/v1/orgs/:org_id/account/:time');
 
   cb(undefined, map(reqs, (req) => [undefined, {
     statusCode:

--- a/lib/stubs/account/src/index.js
+++ b/lib/stubs/account/src/index.js
@@ -45,9 +45,10 @@ routes.get('/v1/accounts/:account_id', function *(req) {
   };
 });
 
-// Retrieve and return the account containing the given org
-routes.get('/v1/orgs/:org_id/account', function *(req) {
-  debug('Retrieving account containing org %s', req.params.org_id);
+// Retrieve and return the account containing the given org and time
+routes.get('/v1/orgs/:org_id/account/:time', function *(req) {
+  debug('Retrieving account containing org %s at time %s',
+    req.params.org_id, req.params.time);
 
   // This is a stub here so we always succeed and return our fake account
   return {

--- a/lib/stubs/account/src/test/test.js
+++ b/lib/stubs/account/src/test/test.js
@@ -78,9 +78,10 @@ describe('abacus-account-stub', () => {
       organizations: ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27'],
       pricing_country: 'USA'
     };
-    request.get('http://localhost::p/v1/orgs/:org_id/account', {
+    request.get('http://localhost::p/v1/orgs/:org_id/account/:time', {
       p: server.address().port,
-      org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27'
+      org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+      time: Date.now()
     }, (err, val) => {
       expect(err).to.equal(undefined);
       expect(val.statusCode).to.equal(200);
@@ -161,9 +162,10 @@ describe('abacus-account-stub', () => {
     });
 
     // Get the account containing an org, expecting our stub test account
-    brequest.get('http://localhost::p/v1/orgs/:org_id/account', {
+    brequest.get('http://localhost::p/v1/orgs/:org_id/account/:time', {
       p: server.address().port,
-      org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27'
+      org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+      time: Date.now()
     }, (err, val) => {
       expect(err).to.equal(undefined);
       expect(val.statusCode).to.equal(200);


### PR DESCRIPTION
Since the organizations can be moved across accounts, the look up for an org's account should have a time parameter.