### PR TITLE
Account stub: introduce new API that returns rating config.

### DIFF
--- a/lib/config/schemas/src/index.js
+++ b/lib/config/schemas/src/index.js
@@ -10,6 +10,7 @@ const resourceConfig = require('./resource-config.js');
 const priceConfig = require('./price-config.js');
 const resourceUsage = require('./resource-usage.js');
 const organizationReport = require('./organization-report.js');
+const ratingConfig = require('./rating-config.js');
 
 // Compile a type into a JSON schema, GraphQL schema and validate function
 const compile = (type) => {
@@ -28,4 +29,4 @@ module.exports.resourceConfig = compile(resourceConfig());
 module.exports.priceConfig = compile(priceConfig());
 module.exports.resourceUsage = compile(resourceUsage());
 module.exports.organizationReport = compile(organizationReport());
-
+module.exports.ratingConfig = compile(ratingConfig());

--- a/lib/config/schemas/src/rating-config.js
+++ b/lib/config/schemas/src/rating-config.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// Rating config schema
+
+const schema = require('abacus-schema');
+
+const string = schema.string;
+const time = schema.time;
+const arrayOf = schema.arrayOf;
+const objectType = schema.objectType;
+const required = schema.required;
+
+/* eslint no-eval: 1 */
+/* jshint evil: true */
+
+// Metric schema
+const metric = () => objectType('metric', {
+  name: required(string()),
+  unit: required(string()),
+  rate: string(),
+  charge: string()
+});
+
+// Rating config schema
+const ratingConfig = () => objectType('resourceConfig', {
+  rating_plan_id: required(string()),
+  effective: required(time()),
+  metrics: required(arrayOf(metric()))
+});
+
+// Export our schema
+module.exports = ratingConfig;
+module.exports.metric = metric;

--- a/lib/config/schemas/src/rating-config.js
+++ b/lib/config/schemas/src/rating-config.js
@@ -16,7 +16,6 @@ const required = schema.required;
 // Metric schema
 const metric = () => objectType('metric', {
   name: required(string()),
-  unit: required(string()),
   rate: string(),
   charge: string()
 });

--- a/lib/config/schemas/src/test/test.js
+++ b/lib/config/schemas/src/test/test.js
@@ -194,5 +194,77 @@ describe('abacus-metering-schemas', () => {
       });
     });
   });
+
+  describe('validate schema for a rating configuration', () => {
+    it('validates a valid rating configuration', () => {
+      const def = {
+        rating_plan_id: 'test-rating-config',
+        effective: 1420070400000,
+        metrics: [{
+          name: 'storage',
+          unit: 'GIGABYTE'
+        }, {
+          name: 'thousand_light_api_calls',
+          unit: 'THOUSAND_CALLS'
+        }, {
+          name: 'heavy_api_calls',
+          unit: 'CALL',
+          rate: '(p, qty) => p ? p * qty : 0',
+          charge: '(t, cost) => cost'
+        }]
+      };
+      expect(schemas.ratingConfig.validate(def)).to.equal(def);
+    });
+
+    it('reports an invalid rating config', () => {
+      const def = {
+        id: 'test-rating-config',
+        effective: 1420070400000,
+        metrics: [{
+          name: 'storage',
+          unit: 'GIGABYTE'
+        }, {
+          unit: 'THOUSAND_CALLS'
+        }, {
+          name: 'heavy_api_calls',
+          meter: '(m) => m.heavy_api_calls'
+        }]
+      };
+
+      let result, error;
+      try {
+        result = schemas.ratingConfig.validate(def);
+      }
+      catch (e) {
+        error = e;
+      }
+
+      expect(result).to.equal(undefined);
+      expect(error).to.deep.equal({
+        statusCode: 400,
+        message: [{
+          field: 'data.rating_plan_id',
+          message: 'is required',
+          value: def
+        }, {
+          field: 'data',
+          message: 'has additional properties',
+          value: 'data.id'
+        }, {
+          field: 'data.metrics.1.name',
+          message: 'is required',
+          value: def.metrics[1]
+        }, {
+          field: 'data.metrics.2.unit',
+          message: 'is required',
+          value: def.metrics[2]
+        }, {
+          field: 'data.metrics.2',
+          message: 'has additional properties',
+          value: 'data.metrics[j].meter'
+        }]
+      })
+    });
+  });
 });
 

--- a/lib/config/schemas/src/test/test.js
+++ b/lib/config/schemas/src/test/test.js
@@ -201,14 +201,11 @@ describe('abacus-metering-schemas', () => {
         rating_plan_id: 'test-rating-config',
         effective: 1420070400000,
         metrics: [{
-          name: 'storage',
-          unit: 'GIGABYTE'
+          name: 'storage'
         }, {
-          name: 'thousand_light_api_calls',
-          unit: 'THOUSAND_CALLS'
+          name: 'thousand_light_api_calls'
         }, {
           name: 'heavy_api_calls',
-          unit: 'CALL',
           rate: '(p, qty) => p ? p * qty : 0',
           charge: '(t, cost) => cost'
         }]
@@ -221,8 +218,7 @@ describe('abacus-metering-schemas', () => {
         id: 'test-rating-config',
         effective: 1420070400000,
         metrics: [{
-          name: 'storage',
-          unit: 'GIGABYTE'
+          name: 'storage'
         }, {
           unit: 'THOUSAND_CALLS'
         }, {
@@ -231,39 +227,36 @@ describe('abacus-metering-schemas', () => {
         }]
       };
 
-      let result, error;
       try {
-        result = schemas.ratingConfig.validate(def);
+        schemas.ratingConfig.validate(def);
+        expect(schemas.ratingConfig.validate(def)).to.throw();
       }
       catch (e) {
-        error = e;
+        expect(e).to.deep.equal({
+          statusCode: 400,
+          message: [{
+            field: 'data.rating_plan_id',
+            message: 'is required',
+            value: def
+          }, {
+            field: 'data',
+            message: 'has additional properties',
+            value: 'data.id'
+          }, {
+            field: 'data.metrics.1.name',
+            message: 'is required',
+            value: def.metrics[1]
+          }, {
+            field: 'data.metrics.1',
+            message: 'has additional properties',
+            value: 'data.metrics[j].unit'
+          }, {
+            field: 'data.metrics.2',
+            message: 'has additional properties',
+            value: 'data.metrics[j].meter'
+          }]
+        })
       }
-
-      expect(result).to.equal(undefined);
-      expect(error).to.deep.equal({
-        statusCode: 400,
-        message: [{
-          field: 'data.rating_plan_id',
-          message: 'is required',
-          value: def
-        }, {
-          field: 'data',
-          message: 'has additional properties',
-          value: 'data.id'
-        }, {
-          field: 'data.metrics.1.name',
-          message: 'is required',
-          value: def.metrics[1]
-        }, {
-          field: 'data.metrics.2.unit',
-          message: 'is required',
-          value: def.metrics[2]
-        }, {
-          field: 'data.metrics.2',
-          message: 'has additional properties',
-          value: 'data.metrics[j].meter'
-        }]
-      })
     });
   });
 });

--- a/lib/stubs/account/src/index.js
+++ b/lib/stubs/account/src/index.js
@@ -34,6 +34,26 @@ const fake = {
   pricing_country: 'USA'
 };
 
+// Contains mapping of rating_plan_id. ratingPlans[resource_id][plan_id]
+const ratingPlans = {
+  analytics: {
+    basic: 'analytics-rating-plan',
+    standard: 'analytics-rating-plan'
+  },
+  'linux-container': {
+    basic: 'linux-rating-plan',
+    standard: 'linux-rating-plan'
+  },
+  'object-storage': {
+    basic: 'object-rating-plan',
+    standard: 'object-rating-plan'
+  },
+  'test-resource': {
+    basic: 'basic-test-rating-plan',
+    standard: 'standard-test-rating-plan'
+  }
+};
+
 // Retrieve and return an account
 routes.get('/v1/accounts/:account_id', function *(req) {
   debug('Retrieving account %s', req.params.account_id);
@@ -91,6 +111,37 @@ routes.get(
     };
   });
 
+// Lookup the rating_plan_id
+const ratingConfig = (rid, rt, pid, time) => {
+  // In this stub, the rating plan id is obtained by a simple object mapping
+  return ratingPlans[rid] ? ratingPlans[rid][pid] : undefined;
+}
+
+// Validate the rating configuration given the organization_id,
+// resource_id, plan_id, resource_type, and time. Returns the
+// rating_plan_id. 
+routes.get(
+  '/v1/rating/orgs/:organization_id/resources/:resource_id/types/' +
+  ':resource_type/plans/:plan_id/:time', function *(req) {
+  debug('Retrieving rating config %s at time %d',
+    req.params.resource_id, req.params.time);
+
+  // Get the rating_plan_id. This is a stub so we just do a simple mapping
+  // to find the rating_plan_id.
+  const rpid = ratingConfig(req.params.resource_id, req.params.resource_type,
+    req.params.plan_id, req.params.time);
+  if (!rpid)
+    return {
+      status: 404
+    }
+
+  // Need further discussion on rating_config schema.
+  return {
+    status: 200,
+    body: require('./rating-configs/' + rpid)
+  };
+});
+
 // Create an account info service app
 const accounts = () => {
   // Create the Webapp
@@ -99,7 +150,7 @@ const accounts = () => {
   // Secure accounts, orgs, pricing and batch routes using an OAuth
   // bearer access token
   if (secured())
-    app.use(/^\/v1\/(accounts|orgs|pricing)|^\/batch$/,
+    app.use(/^\/v1\/(accounts|orgs|pricing|rating)|^\/batch$/,
       oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
 
   app.use(routes);

--- a/lib/stubs/account/src/index.js
+++ b/lib/stubs/account/src/index.js
@@ -112,7 +112,7 @@ routes.get(
   });
 
 // Lookup the rating_plan_id
-const ratingConfig = (rid, rt, pid, time) => {
+const ratingConfig = (oid, rid, rt, pid, time) => {
   // In this stub, the rating plan id is obtained by a simple object mapping
   return ratingPlans[rid] ? ratingPlans[rid][pid] : undefined;
 }
@@ -128,8 +128,8 @@ routes.get(
 
   // Get the rating_plan_id. This is a stub so we just do a simple mapping
   // to find the rating_plan_id.
-  const rpid = ratingConfig(req.params.resource_id, req.params.resource_type,
-    req.params.plan_id, req.params.time);
+  const rpid = ratingConfig(req.params.organization_id, req.params.resource_id,
+    req.params.resource_type, req.params.plan_id, req.params.time);
   if (!rpid)
     return {
       status: 404

--- a/lib/stubs/account/src/index.js
+++ b/lib/stubs/account/src/index.js
@@ -112,10 +112,21 @@ routes.get(
   });
 
 // Lookup the rating_plan_id
-const ratingConfig = (oid, rid, rt, pid, time) => {
+const ratingConfig = (rid, pid) => {
   // In this stub, the rating plan id is obtained by a simple object mapping
   return ratingPlans[rid] ? ratingPlans[rid][pid] : undefined;
 }
+
+// Load and return a rating config
+const rconfig = (rpid) => {
+  try {
+    return schemas.ratingConfig.validate(
+      require('./rating-configs/' + rpid));
+  }
+  catch(e) {
+    return undefined;
+  }
+};
 
 // Validate the rating configuration given the organization_id,
 // resource_id, plan_id, resource_type, and time. Returns the
@@ -128,19 +139,37 @@ routes.get(
 
   // Get the rating_plan_id. This is a stub so we just do a simple mapping
   // to find the rating_plan_id.
-  const rpid = ratingConfig(req.params.organization_id, req.params.resource_id,
-    req.params.resource_type, req.params.plan_id, req.params.time);
+  const rpid = ratingConfig(req.params.resource_id, req.params.plan_id);
   if (!rpid)
     return {
       status: 404
     }
 
-  // Need further discussion on rating_config schema.
   return {
     status: 200,
-    body: require('./rating-configs/' + rpid)
+    body: rconfig(rpid)
   };
 });
+
+// Return the rating configuration for a particular rating_plan_id
+routes.get(
+  '/v1/rating/plans/:rating_plan_id/config', function *(req) {
+    debug('Retrieving rating config %s', req.params.rating_plan_id);
+
+    // This is a stub here so we just return our sample resource price
+    // configs
+    const conf = rconfig(req.params.rating_plan_id);
+    if(!conf)
+      return {
+        status: 404
+      };
+
+    // Return the rating config
+    return {
+      status: 200,
+      body: conf
+    };
+  });
 
 // Create an account info service app
 const accounts = () => {

--- a/lib/stubs/account/src/rating-configs/analytics-rating-plan.js
+++ b/lib/stubs/account/src/rating-configs/analytics-rating-plan.js
@@ -12,16 +12,13 @@ module.exports = {
   effective: 1420070400000,
   metrics: [
     {
-      name: 'classifier_instances',
-      unit: 'INSTANCE'
+      name: 'classifier_instances'
     },
     {
-      name: 'classifier_api_calls',
-      unit: 'CALL'
+      name: 'classifier_api_calls'
     },
     {
-      name: 'training_event_api_calls',
-      unit: 'CALL'
+      name: 'training_event_api_calls'
     }
   ]
 };

--- a/lib/stubs/account/src/rating-configs/analytics-rating-plan.js
+++ b/lib/stubs/account/src/rating-configs/analytics-rating-plan.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// A sample analytics service
+
+// Formulas are deprecated, we're now using meter, accumulate, aggregate
+// and rate Javascript functions instead
+
+/* istanbul ignore file */
+
+module.exports = {
+  rating_plan_id: 'analytics-rating-plan',
+  effective: 1420070400000,
+  metrics: [
+    {
+      name: 'classifier_instances',
+      unit: 'INSTANCE'
+    },
+    {
+      name: 'classifier_api_calls',
+      unit: 'CALL'
+    },
+    {
+      name: 'training_event_api_calls',
+      unit: 'CALL'
+    }
+  ]
+};

--- a/lib/stubs/account/src/rating-configs/basic-test-rating-plan.js
+++ b/lib/stubs/account/src/rating-configs/basic-test-rating-plan.js
@@ -1,0 +1,42 @@
+'use strict';
+
+// A test resource metered by max storage, API calls, and memory consumption
+// over time
+
+/* istanbul ignore file */
+
+module.exports = {
+  rating_plan_id: 'basic-test-rating-plan',
+  effective: 1420070400000,
+  metrics: [
+    {
+      name: 'storage',
+      unit: 'GIGABYTE',
+      rate: ((price, qty) => new BigNumber(price || 0)
+        .mul(qty).toNumber()).toString()
+    },
+    {
+      name: 'thousand_light_api_calls',
+      unit: 'THOUSAND_CALLS',
+      charge: ((t, cost) => cost ? cost : 0).toString()
+    },
+    {
+      name: 'heavy_api_calls',
+      unit: 'CALL',
+      rate: ((price, qty) => new BigNumber(qty)
+        .mul(price || 0).toNumber()).toString()
+    },
+    {
+      name: 'memory',
+      unit: 'GIGABYTE',
+      rate: ((price, qty) => ({
+        burned: new BigNumber(qty.consumed).mul(price || 0).toNumber(),
+        burning: new BigNumber(qty.consuming).mul(price || 0).toNumber(),
+        since: qty.since
+      })).toString(),
+      charge: ((t, cost, from, to) => cost ? new BigNumber(cost.burning)
+        .mul(Math.max(0, Math.min(t, to) - cost.since)).div(1000)
+        .add(cost.burned).toNumber() : 0).toString()
+    }
+  ]
+};

--- a/lib/stubs/account/src/rating-configs/basic-test-rating-plan.js
+++ b/lib/stubs/account/src/rating-configs/basic-test-rating-plan.js
@@ -11,24 +11,20 @@ module.exports = {
   metrics: [
     {
       name: 'storage',
-      unit: 'GIGABYTE',
       rate: ((price, qty) => new BigNumber(price || 0)
         .mul(qty).toNumber()).toString()
     },
     {
       name: 'thousand_light_api_calls',
-      unit: 'THOUSAND_CALLS',
       charge: ((t, cost) => cost ? cost : 0).toString()
     },
     {
       name: 'heavy_api_calls',
-      unit: 'CALL',
       rate: ((price, qty) => new BigNumber(qty)
         .mul(price || 0).toNumber()).toString()
     },
     {
       name: 'memory',
-      unit: 'GIGABYTE',
       rate: ((price, qty) => ({
         burned: new BigNumber(qty.consumed).mul(price || 0).toNumber(),
         burning: new BigNumber(qty.consuming).mul(price || 0).toNumber(),

--- a/lib/stubs/account/src/rating-configs/linux-rating-plan.js
+++ b/lib/stubs/account/src/rating-configs/linux-rating-plan.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// A sample container service rated by memory consumption over time
+
+/* istanbul ignore file */
+
+module.exports = {
+  rating_plan_id: 'linux-rating-plan',
+  effective: 1420070400000,
+  metrics: [
+    {
+      name: 'memory',
+      unit: 'GIGABYTE',
+
+      rate: ((price, qty) => ({
+        burned: new BigNumber(qty.consumed).mul(price || 0).toNumber(),
+        burning: new BigNumber(qty.consuming).mul(price || 0).toNumber(),
+        since: qty.since
+      })).toString(),
+
+      charge: ((t, cost, from, to) => cost ? new BigNumber(cost.burning)
+        .mul(Math.max(0, Math.min(t, to) - cost.since)).add(cost.burned)
+        .div(3600000).toNumber() : 0).toString()
+    }
+  ]
+};

--- a/lib/stubs/account/src/rating-configs/linux-rating-plan.js
+++ b/lib/stubs/account/src/rating-configs/linux-rating-plan.js
@@ -10,7 +10,6 @@ module.exports = {
   metrics: [
     {
       name: 'memory',
-      unit: 'GIGABYTE',
 
       rate: ((price, qty) => ({
         burned: new BigNumber(qty.consumed).mul(price || 0).toNumber(),

--- a/lib/stubs/account/src/rating-configs/object-rating-plan.js
+++ b/lib/stubs/account/src/rating-configs/object-rating-plan.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// A sample storage service, rating gigabytes of storage, thousand
+// light API calls and heavy API calls.
+
+/* istanbul ignore file */
+
+module.exports = {
+  rating_plan_id: 'object-rating-plan',
+  effective: 1420070400000,
+  metrics: [
+    {
+      name: 'storage',
+      unit: 'GIGABYTE',
+      rate: ((price, qty) => new BigNumber(price || 0)
+        .mul(qty).toNumber()).toString()
+    },
+    {
+      name: 'thousand_light_api_calls',
+      unit: 'THOUSAND_CALLS',
+      charge: ((t, cost, from, to) => cost ? cost : 0).toString()
+    },
+    {
+      name: 'heavy_api_calls',
+      unit: 'CALL',
+      rate: ((price, qty) => new BigNumber(qty)
+        .mul(price || 0).toNumber()).toString()
+    }
+  ]
+};

--- a/lib/stubs/account/src/rating-configs/object-rating-plan.js
+++ b/lib/stubs/account/src/rating-configs/object-rating-plan.js
@@ -11,18 +11,15 @@ module.exports = {
   metrics: [
     {
       name: 'storage',
-      unit: 'GIGABYTE',
       rate: ((price, qty) => new BigNumber(price || 0)
         .mul(qty).toNumber()).toString()
     },
     {
       name: 'thousand_light_api_calls',
-      unit: 'THOUSAND_CALLS',
       charge: ((t, cost, from, to) => cost ? cost : 0).toString()
     },
     {
       name: 'heavy_api_calls',
-      unit: 'CALL',
       rate: ((price, qty) => new BigNumber(qty)
         .mul(price || 0).toNumber()).toString()
     }

--- a/lib/stubs/account/src/rating-configs/standard-test-rating-plan.js
+++ b/lib/stubs/account/src/rating-configs/standard-test-rating-plan.js
@@ -1,0 +1,42 @@
+'use strict';
+
+// A test resource metered by max storage, API calls, and memory consumption
+// over time
+
+/* istanbul ignore file */
+
+module.exports = {
+  rating_plan_id: 'standard-test-rating-plan',
+  effective: 1420070400000,
+  metrics: [
+    {
+      name: 'storage',
+      unit: 'GIGABYTE',
+      rate: ((price, qty) => new BigNumber(price || 0)
+        .mul(qty).toNumber()).toString()
+    },
+    {
+      name: 'thousand_light_api_calls',
+      unit: 'THOUSAND_CALLS',
+      charge: ((t, cost) => cost ? cost : 0).toString()
+    },
+    {
+      name: 'heavy_api_calls',
+      unit: 'CALL',
+      rate: ((price, qty) => new BigNumber(qty)
+        .mul(price || 0).toNumber()).toString()
+    },
+    {
+      name: 'memory',
+      unit: 'GIGABYTE',
+      rate: ((price, qty) => ({
+        burned: new BigNumber(qty.consumed).mul(price || 0).toNumber(),
+        burning: new BigNumber(qty.consuming).mul(price || 0).toNumber(),
+        since: qty.since
+      })).toString(),
+      charge: ((t, cost, from, to) => cost ? new BigNumber(cost.burning)
+        .mul(Math.max(0, Math.min(t, to) - cost.since)).div(1000)
+        .add(cost.burned).toNumber() : 0).toString()
+    }
+  ]
+};

--- a/lib/stubs/account/src/rating-configs/standard-test-rating-plan.js
+++ b/lib/stubs/account/src/rating-configs/standard-test-rating-plan.js
@@ -11,24 +11,20 @@ module.exports = {
   metrics: [
     {
       name: 'storage',
-      unit: 'GIGABYTE',
       rate: ((price, qty) => new BigNumber(price || 0)
         .mul(qty).toNumber()).toString()
     },
     {
       name: 'thousand_light_api_calls',
-      unit: 'THOUSAND_CALLS',
       charge: ((t, cost) => cost ? cost : 0).toString()
     },
     {
       name: 'heavy_api_calls',
-      unit: 'CALL',
       rate: ((price, qty) => new BigNumber(qty)
         .mul(price || 0).toNumber()).toString()
     },
     {
       name: 'memory',
-      unit: 'GIGABYTE',
       rate: ((price, qty) => ({
         burned: new BigNumber(qty.consumed).mul(price || 0).toNumber(),
         burning: new BigNumber(qty.consuming).mul(price || 0).toNumber(),

--- a/lib/stubs/account/src/test/test.js
+++ b/lib/stubs/account/src/test/test.js
@@ -135,9 +135,9 @@ describe('abacus-account-stub', () => {
 
     let cbs = 0;
     const done1 = () => {
-      if(++cbs === 3) {
+      if(++cbs === 4) {
         // Check oauth validator spy
-        expect(oauthspy.callCount).to.equal(4);
+        expect(oauthspy.callCount).to.equal(5);
         done();
       }
     }
@@ -191,6 +191,24 @@ describe('abacus-account-stub', () => {
           require('../resources/object-storage'));
         done1();
       });
+
+    // Get rating configuration
+    brequest.get(
+      'http://localhost::p/v1/rating/orgs/:organization_id/resources/' +
+      ':resource_id/types/:resource_type/plans/:plan_id/:time', {
+        p: server.address().port,
+        organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+        resource_id: 'object-storage',
+        resource_type: 'object-storage',
+        plan_id: 'basic',
+        time: 1420070400000
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.body).to.deep.equal(require(
+          '../rating-configs/object-rating-plan'));
+        done1();
+      });
   });
 
   it('validates sample price configurations', () => {
@@ -200,5 +218,16 @@ describe('abacus-account-stub', () => {
       expect(schemas.priceConfig.validate(conf)).to.deep.equal(conf);
       console.log('        validated', name, ' pricing');
     });
+  });
+
+  it('validates sample rating configurations', () => {
+    map(['analytics-rating-plan', 'basic-test-rating-plan',
+      'linux-rating-plan', 'object-rating-plan', 'standard-test-rating-plan'],
+      (name) => {
+        console.log('    validating', name, ' rating');
+        const conf = require('../rating-configs/' + name);
+        expect(schemas.ratingConfig.validate(conf)).to.deep.equal(conf);
+        console.log('        validated', name, ' rating');
+      });
   });
 });

--- a/lib/stubs/account/src/test/test.js
+++ b/lib/stubs/account/src/test/test.js
@@ -123,6 +123,59 @@ describe('abacus-account-stub', () => {
       });
   });
 
+  it('returns a rating config', (done) => {
+    process.env.SECURED = 'false';
+    oauthspy.reset();
+
+    // Create a test account management stub app
+    const app = accountManagement();
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    let cbs = 0;
+    const done1 = () => {
+      if(++cbs === 2) {
+        expect(oauthspy.callCount).to.equal(0);
+        done();
+      }
+    }
+
+    request.get(
+      'http://localhost::p/v1/rating/plans' +
+      '/:rating_plan_id/config/', {
+        p: server.address().port,
+        rating_plan_id: 'object-rating-plan'
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.body).to.deep.equal(
+          require('../rating-configs/object-rating-plan'));
+
+        // Check oauth validator spy
+        expect(oauthspy.callCount).to.equal(0);
+
+        done1();
+      });
+
+    request.get(
+      'http://localhost::p/v1/rating/orgs/:organization_id/resources/' +
+      ':resource_id/types/:resource_type/plans/:plan_id/:time', {
+        p: server.address().port,
+        organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+        resource_id: 'object-storage',
+        resource_type: 'object-storage',
+        plan_id: 'basic',
+        time: 1420070400000
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.body).to.deep.equal(require(
+          '../rating-configs/object-rating-plan'));
+        done1();
+      });
+  });
+
   it('Run a secured account management stub', (done) => {
     process.env.SECURED = 'true';
     oauthspy.reset();
@@ -135,9 +188,9 @@ describe('abacus-account-stub', () => {
 
     let cbs = 0;
     const done1 = () => {
-      if(++cbs === 4) {
+      if(++cbs === 5) {
         // Check oauth validator spy
-        expect(oauthspy.callCount).to.equal(5);
+        expect(oauthspy.callCount).to.equal(6);
         done();
       }
     }
@@ -202,6 +255,19 @@ describe('abacus-account-stub', () => {
         resource_type: 'object-storage',
         plan_id: 'basic',
         time: 1420070400000
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.body).to.deep.equal(require(
+          '../rating-configs/object-rating-plan'));
+        done1();
+      });
+
+    // Get rating configuration using rating_plan_id
+    brequest.get(
+      'http://localhost::p/v1/rating/plans/:rating_plan_id/config', {
+        p: server.address().port,
+        rating_plan_id: 'object-rating-plan'
       }, (err, val) => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(200);


### PR DESCRIPTION
The schema for rating_config is up for discussion.

The collector would call this API to 'validate', get the rating_plan_id, and attach the rating_plan_id to the usage document. 

Currently this API returns the whole rating_configuration, and collector would _.pick the rating_plan_id. 

I think we should have another API that would returns the rating config given a rating_plan_id and time because it seems unnatural for accumulator, aggregator, and reporting to get rating config by passing org_id, resource_id, resource_type, plan_id, and time when we already have the rating_plan_id from the collector. If we are to implements this another API, then the validate API should just returns the rating_plan_id.