### PR TITLE
New API in the account stub: returns pricing_plan_id and prices

### DIFF
--- a/lib/stubs/account/src/index.js
+++ b/lib/stubs/account/src/index.js
@@ -12,6 +12,9 @@ const oauth = require('abacus-oauth');
 const schemas = require('abacus-usage-schemas');
 
 const extend = _.extend;
+const pick = _.pick;
+const map = _.map;
+const filter = _.filter;
 
 /* jshint noyield: true */
 
@@ -110,6 +113,9 @@ routes.get(
     };
   });
 
+// Lookup the pricing_country of an organization
+const getCountry = (oid) => pick(fake, 'pricing_country').pricing_country;
+
 // Lookup the pricing_plan_id
 const pricingConfig = (oid, rid, rt, pid, time) => {
   // In this stub, the pricing_plan_id is obtained by a simple object mapping
@@ -133,10 +139,34 @@ routes.get(
       status: 404
     }
 
-  // Need further discussion on the price config schema.
+  const country = getCountry(req.params.organization_id);
+  const conf = config(req.params.resource_id, parseInt(req.params.time));
+
+  // Need further discussion on the price schema that will be attached to
+  // the usage document. Currently stub will returns:
+  // prices: [{
+  //   name: 'sample',
+  //   price: 0
+  // }]
+  let prices = 0;
+  if (conf) {
+    const plan = filter(conf.plans, (p) => p.plan_id === req.params.plan_id);
+    if (plan.length)
+      prices = map(plan[0].metrics, (m) => {
+        const cp = filter(m.prices, (p) => p.country === country);
+        return {
+          name: m.name,
+          price: cp.length ? cp[0].price : 0
+        }
+      });
+  }
+
   return {
     status: 200,
-    body: require('./pricing-configs/' + pid)
+    body: {
+      pricing_plan_id: pid,
+      prices: prices
+    }
   };
 });
 

--- a/lib/stubs/account/src/index.js
+++ b/lib/stubs/account/src/index.js
@@ -34,6 +34,25 @@ const fake = {
   pricing_country: 'USA'
 };
 
+const pricingPlans = {
+  analytics: {
+    basic: 'analytics-pricing-basic',
+    standard: 'analytics-pricing-standard'
+  },
+  'linux-container': {
+    basic: 'linux-pricing-basic',
+    standard: 'linux-pricing-standard'
+  },
+  'object-storage': {
+    basic: 'object-pricing-basic',
+    standard: 'object-pricing-standard'
+  },
+  'test-resource': {
+    basic: 'test-pricing-basic',
+    standard: 'test-pricing-standard'
+  }
+};
+
 // Retrieve and return an account
 routes.get('/v1/accounts/:account_id', function *(req) {
   debug('Retrieving account %s', req.params.account_id);
@@ -90,6 +109,36 @@ routes.get(
       body: require('./resources/' + req.params.resource_id)
     };
   });
+
+// Lookup the pricing_plan_id
+const pricingConfig = (oid, rid, rt, pid, time) => {
+  // In this stub, the pricing_plan_id is obtained by a simple object mapping
+  return pricingPlans[rid] ? pricingPlans[rid][pid] : undefined;
+}
+
+// Validates the organization_id, resource_id, plan_id,
+// resource_type, and time. Returns the pricing_plan_id.
+routes.get(
+  '/v1/pricing/orgs/:organization_id/resources/:resource_id/types/' +
+  ':resource_type/plans/:plan_id/:time', function *(req) {
+  debug('Retrieving resource price config %s and the pricing plan id' +
+    'at time %d', req.params.resource_id, req.params.time);
+
+  // Get the pricing_plan_id. This is a stub so we just do a simple mapping
+  // to find the rating_plan_id
+  const pid = pricingConfig(req.params.organization_id, req.params.resource_id,
+    req.params.resource_type, req.params.plan_id, req.params.time);
+  if (!pid)
+    return {
+      status: 404
+    }
+
+  // Need further discussion on the price config schema.
+  return {
+    status: 200,
+    body: require('./pricing-configs/' + pid)
+  };
+});
 
 // Create an account info service app
 const accounts = () => {

--- a/lib/stubs/account/src/test/test.js
+++ b/lib/stubs/account/src/test/test.js
@@ -28,100 +28,100 @@ require.cache[require.resolve('abacus-oauth')].exports = oauthmock;
 const accountManagement = require('..');
 
 describe('abacus-account-stub', () => {
-  it('returns information about an account', (done) => {
-    process.env.SECURED = 'false';
-    oauthspy.reset();
+  // it('returns information about an account', (done) => {
+  //   process.env.SECURED = 'false';
+  //   oauthspy.reset();
 
-    // Create an account management stub application
-    const app = accountManagement();
+  //   // Create an account management stub application
+  //   const app = accountManagement();
 
-    // Listen on an ephemeral port
-    const server = app.listen(0);
+  //   // Listen on an ephemeral port
+  //   const server = app.listen(0);
 
-    // Get an account, expecting our stub test account
-    const account = {
-      account_id: '5678',
-      organizations: [
-        'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
-        'b3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
-        'c3d7fe4d-3cb1-4cc3-a831-ffe98e20cf29'],
-      pricing_country: 'USA'
-    };
-    request.get('http://localhost::p/v1/accounts/:account_id', {
-      p: server.address().port,
-      account_id: '5678'
-    }, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val.statusCode).to.equal(200);
-      expect(val.body).to.deep.equal(account);
+  //   // Get an account, expecting our stub test account
+  //   const account = {
+  //     account_id: '5678',
+  //     organizations: [
+  //       'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+  //       'b3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
+  //       'c3d7fe4d-3cb1-4cc3-a831-ffe98e20cf29'],
+  //     pricing_country: 'USA'
+  //   };
+  //   request.get('http://localhost::p/v1/accounts/:account_id', {
+  //     p: server.address().port,
+  //     account_id: '5678'
+  //   }, (err, val) => {
+  //     expect(err).to.equal(undefined);
+  //     expect(val.statusCode).to.equal(200);
+  //     expect(val.body).to.deep.equal(account);
 
-      // Check oauth validator spy
-      expect(oauthspy.callCount).to.equal(0);
+  //     // Check oauth validator spy
+  //     expect(oauthspy.callCount).to.equal(0);
 
-      done();
-    });
-  });
+  //     done();
+  //   });
+  // });
 
-  it('returns information about the account containing an org', (done) => {
-    process.env.SECURED = 'false';
-    oauthspy.reset();
+  // it('returns information about the account containing an org', (done) => {
+  //   process.env.SECURED = 'false';
+  //   oauthspy.reset();
 
-    // Create an account management stub application
-    const app = accountManagement();
+  //   // Create an account management stub application
+  //   const app = accountManagement();
 
-    // Listen on an ephemeral port
-    const server = app.listen(0);
+  //   // Listen on an ephemeral port
+  //   const server = app.listen(0);
 
-    // Get the account containing an org, expecting our stub test account
-    const account = {
-      account_id: '1234',
-      organizations: ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27'],
-      pricing_country: 'USA'
-    };
-    request.get('http://localhost::p/v1/orgs/:org_id/account/:time', {
-      p: server.address().port,
-      org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
-      time: 1420070400000
-    }, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val.statusCode).to.equal(200);
-      expect(val.body).to.deep.equal(account);
+  //   // Get the account containing an org, expecting our stub test account
+  //   const account = {
+  //     account_id: '1234',
+  //     organizations: ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27'],
+  //     pricing_country: 'USA'
+  //   };
+  //   request.get('http://localhost::p/v1/orgs/:org_id/account/:time', {
+  //     p: server.address().port,
+  //     org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+  //     time: 1420070400000
+  //   }, (err, val) => {
+  //     expect(err).to.equal(undefined);
+  //     expect(val.statusCode).to.equal(200);
+  //     expect(val.body).to.deep.equal(account);
 
-      // Check oauth validator spy
-      expect(oauthspy.callCount).to.equal(0);
+  //     // Check oauth validator spy
+  //     expect(oauthspy.callCount).to.equal(0);
 
-      done();
-    });
-  });
+  //     done();
+  //   });
+  // });
 
-  it('returns a resource price config', (done) => {
-    process.env.SECURED = 'false';
-    oauthspy.reset();
+  // it('returns a resource price config', (done) => {
+  //   process.env.SECURED = 'false';
+  //   oauthspy.reset();
 
-    // Create a test account management stub app
-    const app = accountManagement();
+  //   // Create a test account management stub app
+  //   const app = accountManagement();
 
-    // Listen on an ephemeral port
-    const server = app.listen(0);
+  //   // Listen on an ephemeral port
+  //   const server = app.listen(0);
 
-    request.get(
-      'http://localhost::p/v1/pricing/resources' +
-      '/:resource_id/config/:time', {
-        p: server.address().port,
-        resource_id: 'object-storage',
-        time: 1420070400000
-      }, (err, val) => {
-        expect(err).to.equal(undefined);
-        expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal(
-          require('../resources/object-storage'));
+  //   request.get(
+  //     'http://localhost::p/v1/pricing/resources' +
+  //     '/:resource_id/config/:time', {
+  //       p: server.address().port,
+  //       resource_id: 'object-storage',
+  //       time: 1420070400000
+  //     }, (err, val) => {
+  //       expect(err).to.equal(undefined);
+  //       expect(val.statusCode).to.equal(200);
+  //       expect(val.body).to.deep.equal(
+  //         require('../resources/object-storage'));
 
-        // Check oauth validator spy
-        expect(oauthspy.callCount).to.equal(0);
+  //       // Check oauth validator spy
+  //       expect(oauthspy.callCount).to.equal(0);
 
-        done();
-      });
-  });
+  //       done();
+  //     });
+  // });
 
   it('Run a secured account management stub', (done) => {
     process.env.SECURED = 'true';
@@ -135,9 +135,9 @@ describe('abacus-account-stub', () => {
 
     let cbs = 0;
     const done1 = () => {
-      if(++cbs === 3) {
+      if(++cbs === 4) {
         // Check oauth validator spy
-        expect(oauthspy.callCount).to.equal(4);
+        expect(oauthspy.callCount).to.equal(5);
         done();
       }
     }
@@ -189,6 +189,35 @@ describe('abacus-account-stub', () => {
         expect(val.statusCode).to.equal(200);
         expect(val.body).to.deep.equal(
           require('../resources/object-storage'));
+        done1();
+      });
+
+    // Get pricing information
+    brequest.get(
+      'http://localhost::p/v1/pricing/orgs/:organization_id/resources/' +
+      ':resource_id/types/:resource_type/plans/:plan_id/:time', {
+        p: server.address().port,
+        organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+        resource_id: 'object-storage',
+        resource_type: 'object-storage',
+        plan_id: 'basic',
+        time: 1420070400000
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.body).to.deep.equal({
+          pricing_plan_id: 'object-pricing-basic',
+          prices: [{
+            name: 'storage',
+            price: 1.00
+          }, {
+            name: 'thousand_light_api_calls',
+            price: 0.03
+          }, {
+            name: 'heavy_api_calls',
+            price: 0.15
+          }]
+        });
         done1();
       });
   });

--- a/lib/stubs/account/src/test/test.js
+++ b/lib/stubs/account/src/test/test.js
@@ -28,100 +28,100 @@ require.cache[require.resolve('abacus-oauth')].exports = oauthmock;
 const accountManagement = require('..');
 
 describe('abacus-account-stub', () => {
-  // it('returns information about an account', (done) => {
-  //   process.env.SECURED = 'false';
-  //   oauthspy.reset();
+  it('returns information about an account', (done) => {
+    process.env.SECURED = 'false';
+    oauthspy.reset();
 
-  //   // Create an account management stub application
-  //   const app = accountManagement();
+    // Create an account management stub application
+    const app = accountManagement();
 
-  //   // Listen on an ephemeral port
-  //   const server = app.listen(0);
+    // Listen on an ephemeral port
+    const server = app.listen(0);
 
-  //   // Get an account, expecting our stub test account
-  //   const account = {
-  //     account_id: '5678',
-  //     organizations: [
-  //       'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
-  //       'b3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
-  //       'c3d7fe4d-3cb1-4cc3-a831-ffe98e20cf29'],
-  //     pricing_country: 'USA'
-  //   };
-  //   request.get('http://localhost::p/v1/accounts/:account_id', {
-  //     p: server.address().port,
-  //     account_id: '5678'
-  //   }, (err, val) => {
-  //     expect(err).to.equal(undefined);
-  //     expect(val.statusCode).to.equal(200);
-  //     expect(val.body).to.deep.equal(account);
+    // Get an account, expecting our stub test account
+    const account = {
+      account_id: '5678',
+      organizations: [
+        'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+        'b3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
+        'c3d7fe4d-3cb1-4cc3-a831-ffe98e20cf29'],
+      pricing_country: 'USA'
+    };
+    request.get('http://localhost::p/v1/accounts/:account_id', {
+      p: server.address().port,
+      account_id: '5678'
+    }, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val.statusCode).to.equal(200);
+      expect(val.body).to.deep.equal(account);
 
-  //     // Check oauth validator spy
-  //     expect(oauthspy.callCount).to.equal(0);
+      // Check oauth validator spy
+      expect(oauthspy.callCount).to.equal(0);
 
-  //     done();
-  //   });
-  // });
+      done();
+    });
+  });
 
-  // it('returns information about the account containing an org', (done) => {
-  //   process.env.SECURED = 'false';
-  //   oauthspy.reset();
+  it('returns information about the account containing an org', (done) => {
+    process.env.SECURED = 'false';
+    oauthspy.reset();
 
-  //   // Create an account management stub application
-  //   const app = accountManagement();
+    // Create an account management stub application
+    const app = accountManagement();
 
-  //   // Listen on an ephemeral port
-  //   const server = app.listen(0);
+    // Listen on an ephemeral port
+    const server = app.listen(0);
 
-  //   // Get the account containing an org, expecting our stub test account
-  //   const account = {
-  //     account_id: '1234',
-  //     organizations: ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27'],
-  //     pricing_country: 'USA'
-  //   };
-  //   request.get('http://localhost::p/v1/orgs/:org_id/account/:time', {
-  //     p: server.address().port,
-  //     org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
-  //     time: 1420070400000
-  //   }, (err, val) => {
-  //     expect(err).to.equal(undefined);
-  //     expect(val.statusCode).to.equal(200);
-  //     expect(val.body).to.deep.equal(account);
+    // Get the account containing an org, expecting our stub test account
+    const account = {
+      account_id: '1234',
+      organizations: ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27'],
+      pricing_country: 'USA'
+    };
+    request.get('http://localhost::p/v1/orgs/:org_id/account/:time', {
+      p: server.address().port,
+      org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+      time: 1420070400000
+    }, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val.statusCode).to.equal(200);
+      expect(val.body).to.deep.equal(account);
 
-  //     // Check oauth validator spy
-  //     expect(oauthspy.callCount).to.equal(0);
+      // Check oauth validator spy
+      expect(oauthspy.callCount).to.equal(0);
 
-  //     done();
-  //   });
-  // });
+      done();
+    });
+  });
 
-  // it('returns a resource price config', (done) => {
-  //   process.env.SECURED = 'false';
-  //   oauthspy.reset();
+  it('returns a resource price config', (done) => {
+    process.env.SECURED = 'false';
+    oauthspy.reset();
 
-  //   // Create a test account management stub app
-  //   const app = accountManagement();
+    // Create a test account management stub app
+    const app = accountManagement();
 
-  //   // Listen on an ephemeral port
-  //   const server = app.listen(0);
+    // Listen on an ephemeral port
+    const server = app.listen(0);
 
-  //   request.get(
-  //     'http://localhost::p/v1/pricing/resources' +
-  //     '/:resource_id/config/:time', {
-  //       p: server.address().port,
-  //       resource_id: 'object-storage',
-  //       time: 1420070400000
-  //     }, (err, val) => {
-  //       expect(err).to.equal(undefined);
-  //       expect(val.statusCode).to.equal(200);
-  //       expect(val.body).to.deep.equal(
-  //         require('../resources/object-storage'));
+    request.get(
+      'http://localhost::p/v1/pricing/resources' +
+      '/:resource_id/config/:time', {
+        p: server.address().port,
+        resource_id: 'object-storage',
+        time: 1420070400000
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.body).to.deep.equal(
+          require('../resources/object-storage'));
 
-  //       // Check oauth validator spy
-  //       expect(oauthspy.callCount).to.equal(0);
+        // Check oauth validator spy
+        expect(oauthspy.callCount).to.equal(0);
 
-  //       done();
-  //     });
-  // });
+        done();
+      });
+  });
 
   it('Run a secured account management stub', (done) => {
     process.env.SECURED = 'true';


### PR DESCRIPTION
The intent of this API is for the collector to:
- attach prices to the usage document to avoid multiple price lookup
- attach pricing plan id to the usage document to allow accumulation to pricing_plan_id

This is the draft of the API. If this schema is good, I'll go ahead and add pricing schema, caching, and all the necessary adjustment.

