### PR TITLE
Added getting rating config from db in account stub

### DIFF
--- a/lib/stubs/account/package.json
+++ b/lib/stubs/account/package.json
@@ -35,12 +35,21 @@
     "cfpush": "cfpush"
   },
   "dependencies": {
-    "abacus-oauth": "file:../../utils/oauth",
+    "abacus-batch": "file:../../utils/batch",
+    "abacus-breaker": "file:../../utils/breaker",
+    "abacus-dbclient": "file:../../utils/dbclient",
     "abacus-debug": "file:../../utils/debug",
     "abacus-launcher": "file:../../utils/launcher",
+    "abacus-lock": "file:../../utils/lock",
+    "abacus-lrucache": "file:../../utils/lrucache",
+    "abacus-oauth": "file:../../utils/oauth",
+    "abacus-partition": "file:../../utils/partition",
+    "abacus-retry": "file:../../utils/retry",
     "abacus-router": "file:../../utils/router",
+    "abacus-urienv": "file:../../utils/urienv",
     "abacus-usage-schemas": "file:../../config/schemas",
     "abacus-webapp": "file:../../utils/webapp",
+    "abacus-yieldable": "file:../../utils/yieldable",
     "babel-preset-es2015": "^6.1.4",
     "underscore": "^1.8.3"
   },

--- a/lib/stubs/account/src/index.js
+++ b/lib/stubs/account/src/index.js
@@ -10,8 +10,19 @@ const webapp = require('abacus-webapp');
 const router = require('abacus-router');
 const oauth = require('abacus-oauth');
 const schemas = require('abacus-usage-schemas');
+const dbclient = require('abacus-dbclient');
+const partition = require('abacus-partition');
+const lockcb = require('abacus-lock');
+const urienv = require('abacus-urienv');
+const retry = require('abacus-retry');
+const batch = require('abacus-batch');
+const breaker = require('abacus-breaker');
+const yieldable = require('abacus-yieldable');
+const lru = require('abacus-lrucache');
 
 const extend = _.extend;
+
+const lock = yieldable(lockcb);
 
 /* jshint noyield: true */
 
@@ -21,8 +32,43 @@ const debug = require('abacus-debug')('abacus-account-stub');
 // Secure the routes or not
 const secured = () => process.env.SECURED === 'true' ? true : false;
 
+const uris = urienv({
+  couchdb: 5984
+});
+
+// Configure rating config db
+const ratingdb = yieldable(retry(breaker(batch(
+  dbclient(partition.singleton,
+  dbclient.dburi(uris.couchdb, 'abacus-rating-config'))))));
+
 // Create an express router
 const routes = router();
+
+// Store a new rating config
+const newrConfig = function *(rpid, conf) {
+  schemas.ratingConfig.validate(conf);
+  debug('Storing new rating config with id %s effective from %s',
+    rpid, conf.effective);
+  const id = ['k', rpid].join('/');
+  yield ratingdb.put(extend({}, conf, {
+    _id: id
+  }));
+};
+
+// Maintain a cache of rating configs
+const rconfigs = lru({
+  max: 1000,
+  maxAge: 1000 * 60 * 20
+});
+
+// Cache a rating config
+const rcache = (k, rating) => {
+  rconfigs.set(k, rating);
+  return rating
+};
+
+// Return a rating config from the cache
+const rcached = (k) => rconfigs.get(k);
 
 // The fake test account returned by the stub
 const fake = {
@@ -112,19 +158,40 @@ routes.get(
   });
 
 // Lookup the rating_plan_id
-const ratingConfig = (rid, pid) => {
+const ratingId = (rid, pid) => {
   // In this stub, the rating plan id is obtained by a simple object mapping
   return ratingPlans[rid] ? ratingPlans[rid][pid] : undefined;
 }
 
-// Load and return a rating config
-const rconfig = (rpid) => {
+// Load and return a rating config. Search in local directory first,
+// then in the rating config database.
+const rconfig = function *(rpid) {
+  const unlock = yield lock(rpid);
+  const id = ['k', rpid].join('/');
   try {
-    return schemas.ratingConfig.validate(
-      require('./rating-configs/' + rpid));
+    debug('Retrieving rating config for rating plan id %s', rpid);
+
+    // Look in cache
+    const cc = rcached(id);
+    if(cc) {
+      debug('Rating config %s found in cache', rpid);
+      return cc;
+    }
+    // Look in the local resource dir
+    try {
+      return schemas.ratingConfig.validate(
+        require('./rating-configs/' + rpid));
+    }
+    catch(e) {
+    }
+    debug('No rating config %s found in local resources', rpid);
+
+    // Look in the rating database
+    const doc = yield ratingdb.get(id);
+    return doc ? rcache(id, dbclient.undbify(doc)) : doc;
   }
-  catch(e) {
-    return undefined;
+  finally {
+    unlock();
   }
 };
 
@@ -139,15 +206,22 @@ routes.get(
 
   // Get the rating_plan_id. This is a stub so we just do a simple mapping
   // to find the rating_plan_id.
-  const rpid = ratingConfig(req.params.resource_id, req.params.plan_id);
+  const rpid = ratingId(req.params.resource_id, req.params.plan_id);
   if (!rpid)
     return {
       status: 404
     }
 
+  const conf = yield rconfig(rpid);
+
+  if(!conf)
+    return {
+      status: 404
+    };
+
   return {
     status: 200,
-    body: rconfig(rpid)
+    body: conf
   };
 });
 
@@ -158,7 +232,7 @@ routes.get(
 
     // This is a stub here so we just return our sample resource price
     // configs
-    const conf = rconfig(req.params.rating_plan_id);
+    const conf = yield rconfig(req.params.rating_plan_id);
     if(!conf)
       return {
         status: 404
@@ -168,6 +242,17 @@ routes.get(
     return {
       status: 200,
       body: conf
+    };
+  });
+
+// Store a new rating plan id to the database
+routes.post(
+  '/v1/rating/plans/:rating_plan_id/config', function *(req) {
+    debug('Storing rating config with rating plan id %s',
+      req.params.rating_plan_id);
+    yield newrConfig(req.params.rating_plan_id, req.body);
+    return {
+      status: 204
     };
   });
 

--- a/lib/stubs/account/src/test/test.js
+++ b/lib/stubs/account/src/test/test.js
@@ -12,6 +12,9 @@ const schemas = require('abacus-usage-schemas');
 const extend = _.extend;
 const map = _.map;
 
+// Configure test db URL prefix
+process.env.COUCHDB = process.env.COUCHDB || 'test';
+
 const brequest = batch(request);
 
 // Mock the cluster module
@@ -294,6 +297,86 @@ describe('abacus-account-stub', () => {
         const conf = require('../rating-configs/' + name);
         expect(schemas.ratingConfig.validate(conf)).to.deep.equal(conf);
         console.log('        validated', name, ' rating');
+      });
+  });
+
+  it('validates creation of new rating configurations', (done) => {
+    // Create a test provisioning app
+    const app = accountManagement();
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    // Validate a valid provisioned test resource config
+    const ratingConfig = {
+      rating_plan_id: 'test',
+      effective: 1420070400000,
+      metrics: [
+        {
+          name: 'classifier',
+          rate: ((price, qty) => new BigNumber(price || 0)
+            .mul(qty).toNumber()).toString()
+        }
+      ]
+    };
+
+    let expected = 4;
+    const checkDone = () => {
+      expected--;
+      if (expected === 0)
+        done();
+    };
+
+    const getFromCache = function(ratingConfig) {
+      request.get(
+        'http://localhost::p/v1/rating/plans/:rating_plan_id/config', {
+          p: server.address().port,
+          rating_plan_id: ratingConfig.rating_plan_id
+        }, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(200);
+          expect(val.body).to.deep.equal(ratingConfig);
+          checkDone();
+        });
+    }
+
+    const validGetRequest = function(ratingConfig) {
+      request.get(
+        'http://localhost::p/v1/rating/plans/:rating_plan_id/config', {
+          p: server.address().port,
+          rating_plan_id: ratingConfig.rating_plan_id
+        }, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(200);
+          expect(val.body).to.deep.equal(ratingConfig);
+          checkDone();
+          getFromCache(ratingConfig);
+        });
+    };
+
+    const postRequest = function(ratingConfig) {
+      request.post(
+        'http://localhost::p/v1/rating/plans/:rating_plan_id/config', {
+          p: server.address().port,
+          rating_plan_id: ratingConfig.rating_plan_id,
+          body: ratingConfig
+        }, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(204);
+          checkDone();
+          validGetRequest(ratingConfig);
+        });
+    };
+    postRequest(ratingConfig);
+    request.post(
+      'http://localhost::p/v1/rating/plans/:rating_plan_id/config', {
+        p: server.address().port,
+        rating_plan_id: 'test',
+        body: {}
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(400);
+        checkDone();
       });
   });
 });


### PR DESCRIPTION
One thing we should discuss is if we should add time to the key to get rating config. I am not using time as part of the key to get or to put to the database. 

I think time is irrelevant because any evolution of the rating should have a different rating_config_id, so we can accumulate them in separate bucket. Adding time will only be used as a validator, i.e: check if a rating config is effective at a given time(in the past for example).

Thoughts?