### PR TITLE
Clean up

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -225,7 +225,7 @@ const accumulate = function *(a, u) {
       const rfn = ratefn(rplan.metrics, mu.metric);
 
       // Find the price for the metric
-      const rp = price(u.pricing_metrics, mu.metric);
+      const rp = price(u.prices.metrics, mu.metric);
 
       const aw = accum(amerge.accumulated_usage, mu.metric);
 

--- a/lib/aggregation/accumulator/src/test/test.js
+++ b/lib/aggregation/accumulator/src/test/test.js
@@ -71,23 +71,26 @@ const usageTemplate = (u, s, e, p, mp, rp, pp, st, lapi, hapi, mem) => ({
   space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
   consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
   plan_id: p,
-  account_id: '1234',
-  rating_plan_id: rp,
-  metering_plan_id: mp,
-  pricing_plan_id: pp,
   resource_type: 'test',
+  account_id: '1234',
   pricing_country: 'USA',
+  metering_plan_id: mp,
+  rating_plan_id: rp,
+  pricing_plan_id: pp,
+  prices: {
+    metrics: [
+      { name: 'storage', price: selectprice(pp) ? 1 : 0.50 },
+      { name: 'thousand_light_api_calls',
+        price: selectprice(pp) ? 0.03 : 0.04 },
+      { name: 'heavy_api_calls', price: selectprice(pp) ? 0.15 : 0.18 },
+      { name: 'memory', price: selectprice(pp) ? 0.00014 : 0.00028 }
+    ]
+  },
   metered_usage: [
     { metric: 'storage', quantity: st },
     { metric: 'thousand_light_api_calls', quantity: lapi },
     { metric: 'heavy_api_calls', quantity: hapi },
     { metric: 'memory', quantity: { consuming: mem, since: s } }
-  ],
-  pricing_metrics: [
-    { name: 'storage', price: selectprice(pp) ? 1 : 0.50 },
-    { name: 'thousand_light_api_calls', price: selectprice(pp) ? 0.03 : 0.04 },
-    { name: 'heavy_api_calls', price: selectprice(pp) ? 0.15 : 0.18 },
-    { name: 'memory', price: selectprice(pp) ? 0.00014 : 0.00028 }
   ]
 });
 

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -331,7 +331,7 @@ const aggregate = function *(aggrs, u) {
     const rfn = ratefn(rplan.metrics, ua.metric);
 
     // Find the price for the metric
-    const rp = price(u.pricing_metrics, ua.metric);
+    const rp = price(u.prices.metrics, ua.metric);
 
     const aggr = (am, addCost, old) => {
       // We're mutating the input windows property here

--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -49,24 +49,27 @@ const aggregator = require('..');
 // Template for creating accumulated usage
 const accumulatedUsage = (rid, s, e, p, api, mem) => ({
   collected_usage_id: '555',
-  resource_id: 'test-resource',
-  resource_instance_id: rid,
   start: s,
   end: e,
   processed: p,
-  plan_id: 'basic',
-  rating_plan_id: 'basic-test-rating-plan',
-  pricing_plan_id: 'test-pricing-basic',
-  metering_plan_id: 'basic-test-metering-plan',
-  account_id: '1234',
-  pricing_metrics: [
-    { name: 'heavy_api_calls', price: 0.15 },
-    { name: 'memory', price: 0.00014 }
-  ],
-  resource_type: 'test-resource',
+  resource_id: 'test-resource',
+  resource_instance_id: rid,
   organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
   space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
   consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
+  plan_id: 'basic',
+  resource_type: 'test-resource',
+  account_id: '1234',
+  pricing_country: 'USA',
+  metering_plan_id: 'basic-test-metering-plan',
+  rating_plan_id: 'basic-test-rating-plan',
+  pricing_plan_id: 'test-pricing-basic',
+  prices: {
+    metrics: [
+      { name: 'heavy_api_calls', price: 0.15 },
+      { name: 'memory', price: 0.00014 }
+    ]
+  },
   accumulated_usage: [{
     metric: 'heavy_api_calls',
     windows: [

--- a/lib/config/metering/src/index.js
+++ b/lib/config/metering/src/index.js
@@ -122,9 +122,8 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
 
   // Lookup and cache test plans
   if(rtype === 'test-resource')
-    return cb(undefined, cacheId(k, {
-      metering_plan_id: require('./test/basic-test-metering-plan').plan_id
-    }));
+    return cb(undefined, cacheId(k,
+      require('./test/basic-test-metering-plan').plan_id));
 
   // Forward authorization header field to provisioning plugin
   const o = auth ? { headers: { authorization: auth } } : {};
@@ -142,7 +141,7 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
       if(err)
         return cb(err);
 
-      // Authorization failed. Unable to retrieve metering configuration
+      // Unable to retrieve metering configuration
       if (val.statusCode !== 200) {
         edebug('Unable to retrieve metering plan id, %d - %o',
           val.statusCode, val.body || '');
@@ -150,13 +149,11 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
           val.statusCode, val.body || '');
         
         // Throw response object as an exception to stop further processing.
-        throw res;
+        throw val;
       }
 
       // return the metering plan id
-      return cb(undefined, cacheId(k, {
-        metering_plan_id: val.body.plan_id
-      }));
+      return cb(undefined, cacheId(k, val.body));
     });
 };
 
@@ -185,7 +182,7 @@ const plan = (mpid, auth, cb) => {
 
     // Get the requested metering plan from the provisioning plugin
     return brequest.get(uris.provisioning +
-      '/v1/metering/plans/:metering_plan_id/config', extend(o, {
+      '/v1/metering/plans/:metering_plan_id', extend(o, {
         metering_plan_id: mpid
       }), (err, val) => {
         if(err)

--- a/lib/config/metering/src/test/test.js
+++ b/lib/config/metering/src/test/test.js
@@ -13,16 +13,12 @@ describe('abacus-metering-config', () => {
         if (++cbs === 2) done();
       };
 
-      const expected = {
-        metering_plan_id: 'basic-test-metering-plan'
-      };
-
       // Retrieve a metering plan id
       config.id(
         'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', 'test-resource',
         'basic-test-metering-plan', 1420070400000, undefined, (err, val) => {
           expect(err).to.equal(undefined);
-          expect(val).to.deep.equal(expected);
+          expect(val).to.equal('basic-test-metering-plan');
           cb();
         })
 
@@ -31,7 +27,7 @@ describe('abacus-metering-config', () => {
         'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', 'test-resource',
         'basic-test-metering-plan', 1420070400000, undefined, (err, val) => {
           expect(err).to.equal(undefined);
-          expect(val).to.deep.equal(expected);
+          expect(val).to.equal('basic-test-metering-plan');
           cb();
         })
     });

--- a/lib/config/pricing/src/index.js
+++ b/lib/config/pricing/src/index.js
@@ -42,8 +42,24 @@ const cached = (k) => {
   return plans.get(k);
 };
 
+// Return the prices from a pricing plan for the given country
+const countryPrices = (plan, country) => {
+  // find price for each specified metrics
+  return extend({}, {
+    metrics: map(plan.metrics, (m) => {
+      // Use the prices for the specified country, default to 0
+      const cp = filter(m.prices, (p) => p.country === country);
+      return {
+        name: m.name,
+        price: cp.length ? cp[0].price : 0
+      };
+    })
+  });
+};
+
+
 // Retrieve the specified pricing plan
-const plan = (ppid, auth, cb) => {
+const plan = (ppid, country, auth, cb) => {
   lock(ppid, (err, unlock) => {
     if(err)
       return unlock(cb(err));
@@ -53,27 +69,43 @@ const plan = (ppid, auth, cb) => {
     const c = cached(ppid);
     if(c) {
       debug('Pricing plan %s found in cache', ppid);
-      return unlock(cb(undefined, c));
+      return unlock(cb(undefined, countryPrices(c, country)));
     }
 
     // Lookup and cache test plans
     if(ppid === 'test-pricing-basic' || ppid === 'test-pricing-standard')
       return unlock(
-        cb(undefined, cache(ppid, require('./test/' + ppid))));
+        cb(undefined, countryPrices(cache(ppid, require('./test/' + ppid)),
+          country)));
 
     // Forward authorization header field to the account plugin
     const o = auth ? { headers: { authorization: auth } } : {};
 
     // Get the requested pricing plan from the account plugin
     return brequest.get(uris.account +
-      '/v1/pricing/plans/:pricing_plan_id/config', extend(o, {
+      '/v1/pricing/plans/:pricing_plan_id', extend(o, {
         pricing_plan_id: ppid
       }), (err, val) => {
         if(err)
-          return cb(err);
+          return unlock(cb(err));
+
+        // Unable to retrieve pricing plan
+        if (val.statusCode !== 200) {
+          edebug('Unable to retrieve pricing plan, %d - %o',
+            val.statusCode, val.body || '');
+          debug('Unable to retrieve pricing plan, %d - %o',
+            val.statusCode, val.body || '');
+
+          // Unlock and throw response object as an exception
+          // to stop further processing
+          return unlock(cb(extend({}, pick(val, ['statusCode', 'body']),
+            { headers: pick(val.headers, 'www-authenticate') })));
+        }
+
 
         // Return the pricing plan
-        return unlock(cb(undefined, cache(ppid, val.body)));
+        return unlock(cb(undefined, countryPrices(cache(ppid, val.body),
+          country)));
       });
   });
 };
@@ -93,42 +125,26 @@ const cacheId = (k, id) => {
 // Return a pricing plan id from the cache
 const cachedId = (k) => ids.get(k);
 
-// Return the prices from a pricing plan for the given country
-const prices = (plan, country) => {
-  // find price for each specified metrics
-  return extend({}, plan, {
-    pricing_metrics: map(plan.pricing_metrics, (m) => {
-      // Use the prices for the specified country, default to 0
-      const cp = filter(m.prices, (p) => p.country === country);
-      return {
-        name: m.name,
-        price: cp.length ? cp[0].price : 0
-      };
-    })
-  });
-};
-
 // Retrieve the pricing plan id applicable to the given org, resource type,
-// provisioning plan, country and time
-const id = (oid, rtype, ppid, country, time, auth, cb) => {
+// provisioning plan, and time
+const id = (oid, rtype, ppid, time, auth, cb) => {
   debug('Retrieving pricing plan id');
 
   // Round time to a 10 min boundary
   const t = Math.floor(time / 600000) * 600000;
-  const k = [oid, rtype, ppid, country, t].join('/');
+  const k = [oid, rtype, ppid, t].join('/');
 
   // Look in our cache first
   const c = cachedId(k);
   if(c) {
-    debug('Pricing plan id for %s found in cache',
-      k);
+    debug('Pricing plan id for %s found in cache', k);
     return cb(undefined, c);
   }
 
   // Lookup and cache test plans
   if(rtype === 'test-resource')
     return cb(undefined, cacheId(k,
-      prices(require('./test/test-pricing-basic'), country)));
+      require('./test/test-pricing-basic').plan_id));
 
   // Forward authorization header field to the account plugin
   const o = auth ? { headers: { authorization: auth } } : {};
@@ -136,13 +152,11 @@ const id = (oid, rtype, ppid, country, time, auth, cb) => {
   // Get pricing plan id from the account plugin
   return brequest.get(uris.account +
     '/v1/pricing/organizations/:organization_id/resource_types/' +
-    ':resource_type/plans/:plan_id/pricing_countries/' +
-    ':pricing_country/time/:time/pricing_plan/id',
+    ':resource_type/plans/:plan_id/time/:time/pricing_plan/id',
     extend({}, o, {
       organization_id: oid,
       resource_type: rtype,
       plan_id: ppid,
-      pricing_contry: country,
       time: time
     }), (err, val) => {
       if(err)
@@ -159,8 +173,8 @@ const id = (oid, rtype, ppid, country, time, auth, cb) => {
         throw res;
       }
 
-      // Return the pricing plan id and prices for the specified country
-      return cb(undefined, cacheId(k, prices(val.body, country)));
+      // Return the pricing plan id
+      return cb(undefined, cacheId(k, val.body));
     });
 };
 

--- a/lib/config/pricing/src/test/test-pricing-basic.js
+++ b/lib/config/pricing/src/test/test-pricing-basic.js
@@ -6,8 +6,8 @@
 /* istanbul ignore file */
 
 module.exports = {
-  pricing_plan_id: 'test-pricing-basic',
-  pricing_metrics: [
+  plan_id: 'test-pricing-basic',
+  metrics: [
     {
       name: 'storage',
       prices: [

--- a/lib/config/pricing/src/test/test-pricing-standard.js
+++ b/lib/config/pricing/src/test/test-pricing-standard.js
@@ -6,8 +6,8 @@
 /* istanbul ignore file */
 
 module.exports = {
-  pricing_plan_id: 'test-pricing-standard',
-  pricing_metrics: [
+  plan_id: 'test-pricing-standard',
+  metrics: [
     {
       name: 'storage',
       prices: [

--- a/lib/config/pricing/src/test/test.js
+++ b/lib/config/pricing/src/test/test.js
@@ -10,26 +10,8 @@ describe('abacus-pricing-config', () => {
     const cb = () => {
       if (++cbs === 2) done();
     };
-
-    // Retrieve a pricing plan
-    config.plan('test-pricing-basic', undefined, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val).to.deep.equal(require('./test-pricing-basic'));
-      cb();
-    })
-
-    // Retrieve it again, this time it should be returned from the cache
-    config.plan('test-pricing-basic', undefined, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val).to.deep.equal(require('./test-pricing-basic'));
-      cb();
-    })
-  });
-
-  it('returns a pricing_plan_id', (done) => {
     const expected = {
-      pricing_plan_id: 'test-pricing-basic',
-      pricing_metrics: [
+      metrics: [
         {
           name: 'storage',
           price: 1
@@ -49,24 +31,42 @@ describe('abacus-pricing-config', () => {
       ]
     };
 
+    // Retrieve a pricing plan
+    config.plan('test-pricing-basic', 'USA', undefined, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val).to.deep.equal(expected);
+      cb();
+    })
+
+    // Retrieve it again, this time it should be returned from the cache
+    config.plan('test-pricing-basic', 'USA', undefined, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val).to.deep.equal(expected);
+      cb();
+    })
+  });
+
+  it('returns a pricing_plan_id', (done) => {
     let cbs = 0;
     const cb = () => {
       if (++cbs === 2) done();
     };
 
     // Retrieve a pricing plan id
-    config.id('test-org', 'test-resource', 'test-plan', 'USA', 0, undefined,
+    config.id('a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+      'test-resource', 'test-plan', 1420070400000, undefined,
       (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val).to.deep.equal(expected);
+        expect(val).to.equal('test-pricing-basic');
         cb();
       });
 
     // Retrieve it again, this time it should be returned from the cache
-    config.id('test-org', 'test-resource', 'test-plan', 'USA', 0, undefined,
+    config.id('a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+      'test-resource', 'test-plan', 1420070400000, undefined,
       (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val).to.deep.equal(expected);
+        expect(val).to.equal('test-pricing-basic');
         cb();
       });
   });

--- a/lib/config/rating/src/index.js
+++ b/lib/config/rating/src/index.js
@@ -97,13 +97,13 @@ const plan = (rpid, auth, cb) => {
 
     // Get the requested rating plan from the account plugin
     return brequest.get(uris.account +
-      '/v1/rating/plans/:rating_plan_id/config', extend(o, {
+      '/v1/rating/plans/:rating_plan_id', extend(o, {
         rating_plan_id: rpid
       }), (err, val) => {
         if(err)
           return unlock(cb(err));
 
-        // Authorization failed. Unable to retrieve rating plan
+        // Unable to retrieve rating plan
         if (val.statusCode !== 200) {
           edebug('Unable to retrieve rating plan, %d - %o',
             val.statusCode, val.body || '');
@@ -157,7 +157,7 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
   // Lookup test plan ids
   if (rtype === 'test-resource')
     return cb(undefined, cacheId(k,
-      pick(require('./test/basic-test-rating-plan'), 'rating_plan_id')));
+      require('./test/basic-test-rating-plan').plan_id));
 
   // Forward authorization header field to account plugin
   const o = auth ? { headers: { authorization: auth } } : {};
@@ -175,7 +175,7 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
       if(err)
         return cb(err);
 
-      // Authorization failed. Unable to retrieve rating configuration
+      // Unable to retrieve rating configuration
       if (val.statusCode !== 200) {
         edebug('Unable to retrieve rating plan id, %d - %o',
           val.statusCode, val.body || '');
@@ -183,11 +183,11 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
           val.statusCode, val.body || '');
         
         // Throw response object as an exception to stop further processing.
-        throw res;
+        throw val;
       }
 
       // Return the rating plan id
-      return cb(undefined, cacheId(k, pick(val.body, 'rating_plan_id')));
+      return cb(undefined, cacheId(k, val.body));
     });
 };
 

--- a/lib/config/rating/src/test/basic-test-rating-plan.js
+++ b/lib/config/rating/src/test/basic-test-rating-plan.js
@@ -6,7 +6,7 @@
 /* istanbul ignore file */
 
 module.exports = {
-  rating_plan_id: 'basic-test-rating-plan',
+  plan_id: 'basic-test-rating-plan',
   metrics: [
     {
       name: 'storage',

--- a/lib/config/rating/src/test/standard-test-rating-plan.js
+++ b/lib/config/rating/src/test/standard-test-rating-plan.js
@@ -6,7 +6,7 @@
 /* istanbul ignore file */
 
 module.exports = {
-  rating_plan_id: 'standard-test-rating-plan',
+  plan_id: 'standard-test-rating-plan',
   metrics: [
     {
       name: 'storage',

--- a/lib/config/rating/src/test/test.js
+++ b/lib/config/rating/src/test/test.js
@@ -36,7 +36,7 @@ describe('abacus-rating-config', () => {
     config.id('test-org', 'test-resource', 'test-plan', 0, undefined,
       (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val).to.deep.equal({ rating_plan_id: 'basic-test-rating-plan' });
+        expect(val).to.equal('basic-test-rating-plan');
         cb();
       });
 
@@ -44,7 +44,7 @@ describe('abacus-rating-config', () => {
     config.id('test-org', 'test-resource', 'test-plan', 0, undefined,
       (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val).to.deep.equal({ rating_plan_id: 'basic-test-rating-plan' });
+        expect(val).to.equal('basic-test-rating-plan');
         cb();
       });
   });

--- a/lib/config/schemas/src/pricing-plan.js
+++ b/lib/config/schemas/src/pricing-plan.js
@@ -24,8 +24,8 @@ const pricingMetric = () => objectType('metric', {
 
 // Pricing plan schema
 const pricingPlan = () => objectType('pricingPlan', {
-  pricing_plan_id: required(string()),
-  pricing_metrics: required(arrayOf(pricingMetric()))
+  plan_id: required(string()),
+  metrics: required(arrayOf(pricingMetric()))
 });
 
 // Export our schema

--- a/lib/config/schemas/src/rating-plan.js
+++ b/lib/config/schemas/src/rating-plan.js
@@ -21,7 +21,7 @@ const metric = () => objectType('metric', {
 
 // Rating plan schema
 const ratingPlan = () => objectType('ratingPlan', {
-  rating_plan_id: required(string()),
+  plan_id: required(string()),
   metrics: required(arrayOf(metric()))
 });
 

--- a/lib/config/schemas/src/test/test.js
+++ b/lib/config/schemas/src/test/test.js
@@ -188,7 +188,7 @@ describe('abacus-metering-schemas', () => {
   describe('validate schema for a rating plan', () => {
     it('validates a valid rating plan', () => {
       const def = {
-        rating_plan_id: 'test-rating-plan',
+        plan_id: 'test-rating-plan',
         metrics: [{
           name: 'storage'
         }, {
@@ -223,7 +223,7 @@ describe('abacus-metering-schemas', () => {
         expect(e).to.deep.equal({
           statusCode: 400,
           message: [{
-            field: 'data.rating_plan_id',
+            field: 'data.plan_id',
             message: 'is required',
             value: def
           }, {
@@ -251,8 +251,8 @@ describe('abacus-metering-schemas', () => {
   describe('validate schema for a pricing plan', () => {
     it('validates a valid pricing plan', () => {
       const def = {
-        pricing_plan_id: 'test-pricing-plan',
-        pricing_metrics: [
+        plan_id: 'test-pricing-plan',
+        metrics: [
           {
             name: 'storage',
             prices: [
@@ -276,7 +276,7 @@ describe('abacus-metering-schemas', () => {
     it('reports an invalid pricing plan', () => {
       const def = {
         id: 'test-pricing-plan',
-        pricing_metrics: [{
+        metrics: [{
           name: 'storage'
         }, {
           prices: 'wrong type'
@@ -299,7 +299,7 @@ describe('abacus-metering-schemas', () => {
         expect(e).to.deep.equal({
           statusCode: 400,
           message: [{
-            field: 'data.pricing_plan_id',
+            field: 'data.plan_id',
             message: 'is required',
             value: def
           }, {
@@ -307,21 +307,21 @@ describe('abacus-metering-schemas', () => {
             message: 'has additional properties',
             value: 'data.id'
           }, {
-            field: 'data.pricing_metrics.0.prices',
+            field: 'data.metrics.0.prices',
             message: 'is required',
-            value: def.pricing_metrics[0]
+            value: def.metrics[0]
           }, {
-            field: 'data.pricing_metrics.1.name',
+            field: 'data.metrics.1.name',
             message: 'is required',
-            value: def.pricing_metrics[1]
+            value: def.metrics[1]
           }, {
-            field: 'data.pricing_metrics.1.prices',
+            field: 'data.metrics.1.prices',
             message: 'is the wrong type',
-            value: def.pricing_metrics[1].prices
+            value: def.metrics[1].prices
           }, {
-            field: 'data.pricing_metrics.2.prices.0.price',
+            field: 'data.metrics.2.prices.0.price',
             message: 'is required',
-            value: def.pricing_metrics[2].prices[0]
+            value: def.metrics[2].prices[0]
           }]
         })
       }

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -167,14 +167,17 @@ const getAccount = function *(oid, time, auth) {
     pick(res.body, 'account_id', 'pricing_country'));
 };
 
+// Return the metering_plan_id
+const meteringId = yieldable(mconfig.id);
+
 // Return the rating_plan_id
 const ratingId = yieldable(rconfig.id);
 
 // Return the prices and the pricing_plan_id
 const pricingId = yieldable(pconfig.id);
 
-// Return the metering_plan_id
-const meteringId = yieldable(mconfig.id);
+// Return the pricing plan
+const pricingPlan = yieldable(pconfig);
 
 // Map submitted resource usage doc to normalized usage docs
 const normalizeUsage = function *(udoc, auth) {
@@ -210,15 +213,27 @@ const normalizeUsage = function *(udoc, auth) {
       getAccount(u.organization_id, u.end, auth)
     ];
 
-    // Validates and enriches the individual usage with additional information
-    // used for metering and rating.
-    const [metering, rating, pricing] = yield [
-      meteringId(u.organization_id, rt.resource_type, u.plan_id, u.end, auth),
-      ratingId(u.organization_id, rt.resource_type, u.plan_id, u.end, auth),
-      pricingId(u.organization_id, rt.resource_type, u.plan_id,
-        account.pricing_country, u.end, auth)
+    // Validates and get account information & plan ids
+    const [mpid, rpid, ppid] = yield [
+      meteringId(u.organization_id, rt, u.plan_id, u.end, auth),
+      ratingId(u.organization_id, rt, u.plan_id, u.end, auth),
+      pricingId(u.organization_id, rt, u.plan_id, u.end, auth)
     ];
-    extend(u, rt, account, metering, rating, pricing);
+
+    // Attach pricing plan for the usage in the designated pricing country
+    const prices = yield pricingPlan(ppid, account.pricing_country, auth);
+    
+    // enriches the individual usage with additional information
+    // needed for metering and rating.
+    extend(u, {
+      resource_type: rt,
+      account_id: account.account_id,
+      pricing_country: account.pricing_country,
+      metering_plan_id: mpid,
+      rating_plan_id: rpid,
+      pricing_plan_id: ppid,
+      prices: prices
+    });
   });
 
   // Return the individual usage docs

--- a/lib/metering/collector/src/test/test.js
+++ b/lib/metering/collector/src/test/test.js
@@ -120,9 +120,7 @@ describe('abacus-usage-collector', () => {
             }));
             cb(undefined, [[undefined, {
               statusCode: 200,
-              body: {
-                resource_type: 'test-resource'
-              }
+              body: 'test-resource'
             }], [undefined, {
               statusCode: 200,
               body: {
@@ -136,9 +134,7 @@ describe('abacus-usage-collector', () => {
           else {
             cb(undefined, [[undefined, {
               statusCode: 200,
-              body: {
-                resource_type: 'test-resource'
-              }
+              body: 'test-resource'
             }]]);
 
             check();
@@ -159,24 +155,26 @@ describe('abacus-usage-collector', () => {
             metering_plan_id: 'basic-test-metering-plan',
             rating_plan_id: 'basic-test-rating-plan',
             pricing_plan_id: 'test-pricing-basic',
-            pricing_metrics: [
-              {
-                name: 'storage',
-                price: 1
-              },
-              {
-                name: 'thousand_light_api_calls',
-                price: 0.03
-              },
-              {
-                name: 'heavy_api_calls',
-                price: 0.15
-              },
-              {
-                name: 'memory',
-                price: 0.00014
-              }
-            ]
+            prices: {
+              metrics: [
+                {
+                  name: 'storage',
+                  price: 1
+                },
+                {
+                  name: 'thousand_light_api_calls',
+                  price: 0.03
+                },
+                {
+                  name: 'heavy_api_calls',
+                  price: 0.15
+                },
+                {
+                  name: 'memory',
+                  price: 0.00014
+                }
+              ]
+            }
           }));
 
         cb(undefined, [[undefined, {

--- a/lib/metering/meter/src/test/test.js
+++ b/lib/metering/meter/src/test/test.js
@@ -59,16 +59,18 @@ describe('abacus-usage-meter', () => {
         metering_plan_id: 'basic-test-metering-plan',
         rating_plan_id: 'basic-test-rating-plan',
         pricing_plan_id: 'test-pricing-basic',
-        pricing_metrics: [
-          { name: 'storage',
-            price: 1 },
-          { name: 'thousand_light_api_calls',
-            price: 0.03 },
-          { name: 'heavy_api_calls',
-            price: 0.15 },
-          { name: 'memory',
-            price: 0.00014 }
-        ],
+        prices: {
+          metrics: [
+            { name: 'storage',
+              price: 1 },
+            { name: 'thousand_light_api_calls',
+              price: 0.03 },
+            { name: 'heavy_api_calls',
+              price: 0.15 },
+            { name: 'memory',
+              price: 0.00014 }
+          ]
+        },
         measured_usage: [{
           measure: 'storage',
           quantity: 1073741824

--- a/lib/plugins/account/src/index.js
+++ b/lib/plugins/account/src/index.js
@@ -141,7 +141,7 @@ const samplePricings = {
 };
 
 // Map a resource type and provisioning plan id to a pricing plan id
-const pricingId = (rt, pid) => {
+const ppid = function *(rt, pid) {
   // Return our example pricing plan ids
   return samplePricings[rt] ? samplePricings[rt][pid] : undefined;
 }
@@ -167,7 +167,7 @@ const sampleRatings = {
 };
 
 // Map a resource type and provisioning plan id to a rating plan id
-const ratingId = (rt, pid) => {
+const rpid = function *(rt, pid) {
   return sampleRatings[rt] ? sampleRatings[rt][pid] : undefined;
 }
 
@@ -260,31 +260,40 @@ routes.get('/v1/organizations/:org_id/account/:time', function *(req) {
 // plan at the given time
 routes.get(
   '/v1/pricing/organizations/:organization_id/resource_types/' +
-  ':resource_type/plans/:plan_id/pricing_countries/' +
-  ':pricing_country/time/:time/pricing_plan/id', function *(req) {
+  ':resource_type/plans/:plan_id/time/:time/pricing_plan/id', function *(req) {
   debug('Retrieving pricing plan for resource type %s and plan %s at time %d',
     req.params.resource_type, req.params.plan_id, req.params.time);
 
   // Lookup the pricing plan id
-  const ppid = pricingId(req.params.resource_type, req.params.plan_id);
-  if (!ppid)
+  const id = yield ppid(req.params.resource_type, req.params.plan_id);
+  if (!id)
     return {
       status: 404
     };
 
-  // Return the pricing plan
-  const pp = yield pricing(ppid);
-  if(!pp)
-    return {
-      status: 404
-    };
   return {
     status: 200,
-    body: pp
+    body: id
   };
 });
 
-// Return the rating plan to use for the given resource type, provisioning
+// Return the specified pricing plan
+routes.get(
+  '/v1/pricing/plans/:pricing_plan_id', function *(req) {
+    debug('Retrieving pricing plan %s', req.params.pricing_plan_id);
+
+    const pp = yield pricing(req.params.pricing_plan_id);
+    if(!pp)
+      return {
+        status: 404
+      };
+    return {
+      status: 200,
+      body: pp
+    };
+  });
+
+// Return the rating plan id to use for the given resource type, provisioning
 // plan at the given time
 routes.get(
   '/v1/rating/organizations/:organization_id/resource_types/' +
@@ -293,27 +302,20 @@ routes.get(
     req.params.resource_type, req.params.plan_id, req.params.time);
 
   // Lookup the rating plan id
-  const rpid = ratingId(req.params.resource_type, req.params.plan_id);
-  if (!rpid)
+  const id = yield rpid(req.params.resource_type, req.params.plan_id);
+  if (!id)
     return {
       status: 404
     }
-
-  // Return the rating plan
-  const rp = yield rating(rpid);
-  if(!rp)
-    return {
-      status: 404
-    };
   return {
     status: 200,
-    body: rp
+    body: id
   };
 });
 
 // Return the specified rating plan
 routes.get(
-  '/v1/rating/plans/:rating_plan_id/config', function *(req) {
+  '/v1/rating/plans/:rating_plan_id', function *(req) {
     debug('Retrieving rating plan %s', req.params.rating_plan_id);
 
     const rp = yield rating(req.params.rating_plan_id);
@@ -329,7 +331,7 @@ routes.get(
 
 // Store a new rating plan
 routes.post(
-  '/v1/rating/plans/:rating_plan_id/config', function *(req) {
+  '/v1/rating/plans/:rating_plan_id', function *(req) {
     debug('Storing rating plan with rating plan id %s',
       req.params.rating_plan_id);
     yield newRating(req.params.rating_plan_id, req.body);
@@ -340,7 +342,7 @@ routes.post(
 
 // Store a new pricing plan
 routes.post(
-  '/v1/pricing/plans/:pricing_plan_id/config', function *(req) {
+  '/v1/pricing/plans/:pricing_plan_id', function *(req) {
     debug('Storing pricing plan %s',
       req.params.pricing_plan_id);
     yield newPricing(req.params.pricing_plan_id, req.body);

--- a/lib/plugins/account/src/index.js
+++ b/lib/plugins/account/src/index.js
@@ -359,7 +359,7 @@ const accounts = () => {
   // Secure accounts, orgs, pricing and batch routes using an OAuth
   // bearer access token
   if (secured())
-    app.use(/^\/v1\/(accounts|orgs|pricing|rating)|^\/batch$/,
+    app.use(/^\/v1\/(accounts|organizations|pricing|rating)|^\/batch$/,
       oauth.validator(process.env.JWTKEY, process.env.JWTALGO));
 
   app.use(routes);

--- a/lib/plugins/account/src/plans/pricing/linux-pricing-basic.js
+++ b/lib/plugins/account/src/plans/pricing/linux-pricing-basic.js
@@ -5,8 +5,8 @@
 /* istanbul ignore file */
 
 module.exports = {
-  pricing_plan_id: 'linux-pricing-basic',
-  pricing_metrics: [
+  plan_id: 'linux-pricing-basic',
+  metrics: [
     {
       name: 'memory',
       prices: [

--- a/lib/plugins/account/src/plans/pricing/linux-pricing-standard.js
+++ b/lib/plugins/account/src/plans/pricing/linux-pricing-standard.js
@@ -5,8 +5,8 @@
 /* istanbul ignore file */
 
 module.exports = {
-  pricing_plan_id: 'linux-pricing-standard',
-  pricing_metrics: [
+  plan_id: 'linux-pricing-standard',
+  metrics: [
     {
       name: 'memory',
       prices: [

--- a/lib/plugins/account/src/plans/pricing/object-pricing-basic.js
+++ b/lib/plugins/account/src/plans/pricing/object-pricing-basic.js
@@ -6,8 +6,8 @@
 /* istanbul ignore file */
 
 module.exports = {
-  pricing_plan_id: 'object-pricing-basic',
-  pricing_metrics: [
+  plan_id: 'object-pricing-basic',
+  metrics: [
     {
       name: 'storage',
       prices: [

--- a/lib/plugins/account/src/plans/pricing/object-pricing-standard.js
+++ b/lib/plugins/account/src/plans/pricing/object-pricing-standard.js
@@ -6,8 +6,8 @@
 /* istanbul ignore file */
 
 module.exports = {
-  pricing_plan_id: 'object-pricing-standard',
-  pricing_metrics: [
+  plan_id: 'object-pricing-standard',
+  metrics: [
     {
       name: 'storage',
       prices: [

--- a/lib/plugins/account/src/plans/pricing/test-pricing-basic.js
+++ b/lib/plugins/account/src/plans/pricing/test-pricing-basic.js
@@ -6,8 +6,8 @@
 /* istanbul ignore file */
 
 module.exports = {
-  pricing_plan_id: 'test-pricing-basic', 
-  pricing_metrics: [
+  plan_id: 'test-pricing-basic', 
+  metrics: [
     {
       name: 'storage',
       prices: [

--- a/lib/plugins/account/src/plans/pricing/test-pricing-standard.js
+++ b/lib/plugins/account/src/plans/pricing/test-pricing-standard.js
@@ -6,8 +6,8 @@
 /* istanbul ignore file */
 
 module.exports = {
-  pricing_plan_id: 'test-pricing-standard', 
-  pricing_metrics: [
+  plan_id: 'test-pricing-standard', 
+  metrics: [
     {
       name: 'storage',
       prices: [

--- a/lib/plugins/account/src/plans/rating/analytics-rating-plan.js
+++ b/lib/plugins/account/src/plans/rating/analytics-rating-plan.js
@@ -8,7 +8,7 @@
 /* istanbul ignore file */
 
 module.exports = {
-  rating_plan_id: 'analytics-rating-plan',
+  plan_id: 'analytics-rating-plan',
   metrics: [
     {
       name: 'classifier_instances'

--- a/lib/plugins/account/src/plans/rating/basic-test-rating-plan.js
+++ b/lib/plugins/account/src/plans/rating/basic-test-rating-plan.js
@@ -6,7 +6,7 @@
 /* istanbul ignore file */
 
 module.exports = {
-  rating_plan_id: 'basic-test-rating-plan',
+  plan_id: 'basic-test-rating-plan',
   metrics: [
     {
       name: 'storage',

--- a/lib/plugins/account/src/plans/rating/linux-rating-plan.js
+++ b/lib/plugins/account/src/plans/rating/linux-rating-plan.js
@@ -5,7 +5,7 @@
 /* istanbul ignore file */
 
 module.exports = {
-  rating_plan_id: 'linux-rating-plan',
+  plan_id: 'linux-rating-plan',
   metrics: [
     {
       name: 'memory',

--- a/lib/plugins/account/src/plans/rating/object-rating-plan.js
+++ b/lib/plugins/account/src/plans/rating/object-rating-plan.js
@@ -6,7 +6,7 @@
 /* istanbul ignore file */
 
 module.exports = {
-  rating_plan_id: 'object-rating-plan',
+  plan_id: 'object-rating-plan',
   metrics: [
     {
       name: 'storage',

--- a/lib/plugins/account/src/plans/rating/standard-test-rating-plan.js
+++ b/lib/plugins/account/src/plans/rating/standard-test-rating-plan.js
@@ -6,7 +6,7 @@
 /* istanbul ignore file */
 
 module.exports = {
-  rating_plan_id: 'standard-test-rating-plan',
+  plan_id: 'standard-test-rating-plan',
   metrics: [
     {
       name: 'storage',

--- a/lib/plugins/account/src/test/test.js
+++ b/lib/plugins/account/src/test/test.js
@@ -97,7 +97,7 @@ describe('abacus-account-plugin', () => {
     });
   });
 
-  it('returns a rating plan', (done) => {
+  it('returns a rating plan & rating plan id', (done) => {
     process.env.SECURED = 'false';
     oauthspy.reset();
 
@@ -117,7 +117,7 @@ describe('abacus-account-plugin', () => {
 
     request.get(
       'http://localhost::p/v1/rating/plans' +
-      '/:rating_plan_id/config/', {
+      '/:rating_plan_id', {
         p: server.address().port,
         rating_plan_id: 'object-rating-plan'
       }, (err, val) => {
@@ -144,8 +144,59 @@ describe('abacus-account-plugin', () => {
       }, (err, val) => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal(require(
-          '../plans/rating/object-rating-plan'));
+        expect(val.body).to.deep.equal('object-rating-plan');
+        done1();
+      });
+  });
+
+  it('returns a pricing plan & pricing plan id', (done) => {
+    process.env.SECURED = 'false';
+    oauthspy.reset();
+
+    // Create a test account management plugin app
+    const app = accountManagement();
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    let cbs = 0;
+    const done1 = () => {
+      if(++cbs === 2) {
+        expect(oauthspy.callCount).to.equal(0);
+        done();
+      }
+    }
+
+    request.get(
+      'http://localhost::p/v1/pricing/plans' +
+      '/:pricing_plan_id', {
+        p: server.address().port,
+        pricing_plan_id: 'object-pricing-basic'
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.body).to.deep.equal(
+          require('../plans/pricing/object-pricing-basic'));
+
+        // Check oauth validator spy
+        expect(oauthspy.callCount).to.equal(0);
+
+        done1();
+      });
+
+    request.get(
+      'http://localhost::p/v1/pricing/organizations/:organization_id' +
+      '/resource_types/:resource_type/plans/:plan_id' +
+      '/time/:time/pricing_plan/id', {
+        p: server.address().port,
+        organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+        resource_type: 'object-storage',
+        plan_id: 'basic',
+        time: 1420070400000
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.body).to.deep.equal('object-pricing-basic');
         done1();
       });
   });
@@ -162,9 +213,9 @@ describe('abacus-account-plugin', () => {
 
     let cbs = 0;
     const done1 = () => {
-      if(++cbs === 5) {
+      if(++cbs === 6) {
         // Check oauth validator spy
-        expect(oauthspy.callCount).to.equal(5);
+        expect(oauthspy.callCount).to.equal(6);
         done();
       }
     }
@@ -204,26 +255,24 @@ describe('abacus-account-plugin', () => {
       done1();
     });
 
-    // Get pricing information
+    // Get pricing plan id
     brequest.get(
       'http://localhost::p/v1/pricing/organizations/:organization_id/' +
       'resource_types/:resource_type/plans/:plan_id/' +
-      'pricing_countries/:pricing_country/time/:time/pricing_plan/id', {
+      'time/:time/pricing_plan/id', {
         p: server.address().port,
         organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
-        pricing_country: 'USA',
         resource_type: 'object-storage',
         plan_id: 'basic',
         time: 1420070400000
       }, (err, val) => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal(require(
-          '../plans/pricing/object-pricing-basic'));
+        expect(val.body).to.deep.equal('object-pricing-basic');
         done1();
       });
 
-    // Get rating plan for the given org, resource type, and plan id
+    // Get rating plan id for the given org, resource type, and plan id
     brequest.get(
       'http://localhost::p/v1/rating/organizations/:organization_id' +
       '/resource_types/:resource_type/plans/:plan_id/' +
@@ -236,14 +285,13 @@ describe('abacus-account-plugin', () => {
       }, (err, val) => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal(require(
-          '../plans/rating/object-rating-plan'));
+        expect(val.body).to.deep.equal('object-rating-plan');
         done1();
       });
 
     // Get rating plan with the given id
     brequest.get(
-      'http://localhost::p/v1/rating/plans/:rating_plan_id/config', {
+      'http://localhost::p/v1/rating/plans/:rating_plan_id', {
         p: server.address().port,
         rating_plan_id: 'object-rating-plan'
       }, (err, val) => {
@@ -251,6 +299,19 @@ describe('abacus-account-plugin', () => {
         expect(val.statusCode).to.equal(200);
         expect(val.body).to.deep.equal(require(
           '../plans/rating/object-rating-plan'));
+        done1();
+      });
+
+    // Get pricing plan with the given the id
+    brequest.get(
+      'http://localhost::p/v1/pricing/plans/:pricing_plan_id', {
+        p: server.address().port,
+        pricing_plan_id: 'object-pricing-basic'
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.body).to.deep.equal(require(
+          '../plans/pricing/object-pricing-basic'));
         done1();
       });
   });
@@ -287,7 +348,7 @@ describe('abacus-account-plugin', () => {
 
     // Validate a valid test rating plan
     const rating = {
-      rating_plan_id: 'test',
+      plan_id: 'test',
       metrics: [
         {
           name: 'classifier',
@@ -306,9 +367,9 @@ describe('abacus-account-plugin', () => {
 
     const getFromCache = function(rating) {
       request.get(
-        'http://localhost::p/v1/rating/plans/:rating_plan_id/config', {
+        'http://localhost::p/v1/rating/plans/:rating_plan_id', {
           p: server.address().port,
-          rating_plan_id: rating.rating_plan_id
+          rating_plan_id: rating.plan_id
         }, (err, val) => {
           expect(err).to.equal(undefined);
           expect(val.statusCode).to.equal(200);
@@ -319,9 +380,9 @@ describe('abacus-account-plugin', () => {
 
     const validGetRequest = function(rating) {
       request.get(
-        'http://localhost::p/v1/rating/plans/:rating_plan_id/config', {
+        'http://localhost::p/v1/rating/plans/:rating_plan_id', {
           p: server.address().port,
-          rating_plan_id: rating.rating_plan_id
+          rating_plan_id: rating.plan_id
         }, (err, val) => {
           expect(err).to.equal(undefined);
           expect(val.statusCode).to.equal(200);
@@ -333,9 +394,9 @@ describe('abacus-account-plugin', () => {
 
     const postRequest = function(rating) {
       request.post(
-        'http://localhost::p/v1/rating/plans/:rating_plan_id/config', {
+        'http://localhost::p/v1/rating/plans/:rating_plan_id', {
           p: server.address().port,
-          rating_plan_id: rating.rating_plan_id,
+          rating_plan_id: rating.plan_id,
           body: rating
         }, (err, val) => {
           expect(err).to.equal(undefined);
@@ -346,9 +407,9 @@ describe('abacus-account-plugin', () => {
     };
     postRequest(rating);
     request.post(
-      'http://localhost::p/v1/rating/plans/:rating_plan_id/config', {
+      'http://localhost::p/v1/rating/plans/:rating_plan_id', {
         p: server.address().port,
-        rating_plan_id: 'test',
+        rating_plan_id: rating.plan_id,
         body: {}
       }, (err, val) => {
         expect(err).to.equal(undefined);
@@ -366,8 +427,8 @@ describe('abacus-account-plugin', () => {
 
     // Validate a valid test pricing plan
     const pricing = {
-      pricing_plan_id: 'test-db-basic',
-      pricing_metrics: [
+      plan_id: 'test-db-basic',
+      metrics: [
         {
           name: 'classifier',
           prices: [
@@ -396,15 +457,9 @@ describe('abacus-account-plugin', () => {
 
     const getFromCache = function(pricing) {
       request.get(
-        'http://localhost::p/v1/pricing/organizations/:organization_id/' +
-        'resource_types/:resource_type/plans/:plan_id/' +
-        'pricing_countries/:pricing_country/time/:time/pricing_plan/id', {
+        'http://localhost::p/v1/pricing/plans/:pricing_plan_id', {
           p: server.address().port,
-          organization_id: 'testOrg',
-          resource_type: 'test-db',
-          pricing_country: 'USA',
-          plan_id: 'basic',
-          time: 1420070400000
+          pricing_plan_id: pricing.plan_id
         }, (err, val) => {
           expect(err).to.equal(undefined);
           expect(val.statusCode).to.equal(200);
@@ -415,15 +470,9 @@ describe('abacus-account-plugin', () => {
 
     const validGetRequest = function(pricing) {
       request.get(
-        'http://localhost::p/v1/pricing/organizations/:organization_id/' +
-        'resource_types/:resource_type/plans/:plan_id/' +
-        'pricing_countries/:pricing_country/time/:time/pricing_plan/id', {
+        'http://localhost::p/v1/pricing/plans/:pricing_plan_id', {
           p: server.address().port,
-          organization_id: 'testOrg',
-          resource_type: 'test-db',
-          plan_id: 'basic',
-          pricing_country: 'USA',
-          time: 1420070400000
+          pricing_plan_id: pricing.plan_id
         }, (err, val) => {
           expect(err).to.equal(undefined);
           expect(val.statusCode).to.equal(200);
@@ -435,9 +484,9 @@ describe('abacus-account-plugin', () => {
 
     const postRequest = function(pricing) {
       request.post(
-        'http://localhost::p/v1/pricing/plans/:pricing_plan_id/config', {
+        'http://localhost::p/v1/pricing/plans/:pricing_plan_id', {
           p: server.address().port,
-          pricing_plan_id: pricing.pricing_plan_id,
+          pricing_plan_id: pricing.plan_id,
           body: pricing
         }, (err, val) => {
           expect(err).to.equal(undefined);
@@ -448,9 +497,9 @@ describe('abacus-account-plugin', () => {
     };
     postRequest(pricing);
     request.post(
-      'http://localhost::p/v1/pricing/plans/:pricing_plan_id/config', {
+      'http://localhost::p/v1/pricing/plans/:pricing_plan_id', {
         p: server.address().port,
-        pricing_plan_id: 'test',
+        pricing_plan_id: pricing.plan_id,
         body: {}
       }, (err, val) => {
         expect(err).to.equal(undefined);

--- a/lib/plugins/account/src/test/test.js
+++ b/lib/plugins/account/src/test/test.js
@@ -144,7 +144,7 @@ describe('abacus-account-plugin', () => {
       }, (err, val) => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal('object-rating-plan');
+        expect(val.body).to.equal('object-rating-plan');
         done1();
       });
   });
@@ -196,7 +196,7 @@ describe('abacus-account-plugin', () => {
       }, (err, val) => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal('object-pricing-basic');
+        expect(val.body).to.equal('object-pricing-basic');
         done1();
       });
   });
@@ -268,7 +268,7 @@ describe('abacus-account-plugin', () => {
       }, (err, val) => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal('object-pricing-basic');
+        expect(val.body).to.equal('object-pricing-basic');
         done1();
       });
 
@@ -285,7 +285,7 @@ describe('abacus-account-plugin', () => {
       }, (err, val) => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal('object-rating-plan');
+        expect(val.body).to.equal('object-rating-plan');
         done1();
       });
 

--- a/lib/plugins/account/src/test/test.js
+++ b/lib/plugins/account/src/test/test.js
@@ -215,7 +215,7 @@ describe('abacus-account-plugin', () => {
     const done1 = () => {
       if(++cbs === 6) {
         // Check oauth validator spy
-        expect(oauthspy.callCount).to.equal(6);
+        expect(oauthspy.callCount).to.equal(7);
         done();
       }
     }

--- a/lib/plugins/provisioning/src/index.js
+++ b/lib/plugins/provisioning/src/index.js
@@ -182,7 +182,7 @@ routes.get(
 
 // Return the specified metering plan
 routes.get(
-  '/v1/metering/plans/:metering_plan_id/config', function *(req) {
+  '/v1/metering/plans/:metering_plan_id', function *(req) {
     debug('Retrieving metering plan %s', req.params.metering_plan_id);
 
     const mp = yield metering(req.params.metering_plan_id);
@@ -198,7 +198,7 @@ routes.get(
 
 // Create a new metering plan
 routes.post(
-  '/v1/metering/plans/:metering_plan_id/config', function *(req) {
+  '/v1/metering/plans/:metering_plan_id', function *(req) {
     debug('Creating metering plan %s', req.params.metering_plan_id);
     yield newMetering(req.params.metering_plan_id, req.body);
     return {
@@ -206,7 +206,7 @@ routes.post(
     };
   });
 
-// Return the metering plan to use for the given resource type, provisioning
+// Return the metering plan id to use for the given resource type, provisioning
 // plan at the given time
 routes.get(
   '/v1/metering/organizations/:organization_id/resource_types/' +
@@ -223,14 +223,9 @@ routes.get(
       status: 404
     }
 
-  const mp = yield metering(id);
-  if(!mp)
-    return {
-      status: 404
-    };
   return {
     status: 200,
-    body: mp
+    body: id
   };
 });
 
@@ -240,9 +235,7 @@ routes.get(
     debug('Identifying the resource type of %s', req.params.resource_id);
     return {
       status: 200,
-      body: {
-        resource_type: yield rtype(req.params.resource_id)
-      }
+      body: yield rtype(req.params.resource_id)
     };
   });
 

--- a/lib/plugins/provisioning/src/test/test.js
+++ b/lib/plugins/provisioning/src/test/test.js
@@ -119,7 +119,7 @@ describe('abacus-provisioning-plugin', () => {
 
     request.get(
       'http://localhost::p/v1/metering/plans' +
-      '/:metering_plan_id/config', {
+      '/:metering_plan_id', {
         p: server.address().port,
         metering_plan_id: 'basic-object-storage'
       }, (err, val) => {
@@ -142,8 +142,7 @@ describe('abacus-provisioning-plugin', () => {
       }, (err, val) => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal(require(
-          '../plans/metering/basic-object-storage'));
+        expect(val.body).to.deep.equal('basic-object-storage');
         done1();
       });
   });
@@ -163,9 +162,7 @@ describe('abacus-provisioning-plugin', () => {
       }, (err, val) => {
         expect(err).to.equal(undefined);
         expect(val.statusCode).to.equal(200);
-        expect(val.body).to.deep.equal({
-          resource_type: 'object-storage'
-        });
+        expect(val.body).to.equal('object-storage');
         done();
       });
   });
@@ -220,7 +217,7 @@ describe('abacus-provisioning-plugin', () => {
 
     const validGetRequest = function(mplan) {
       request.get(
-        'http://localhost::p/v1/metering/plans/:metering_plan_id/config', {
+        'http://localhost::p/v1/metering/plans/:metering_plan_id', {
           p: server.address().port,
           metering_plan_id: mplan.plan_id
         }, (err, val) => {
@@ -233,7 +230,7 @@ describe('abacus-provisioning-plugin', () => {
 
     const getFromCache = function(mplan) {
       request.get(
-        'http://localhost::p/v1/metering/plans/:metering_plan_id/config', {
+        'http://localhost::p/v1/metering/plans/:metering_plan_id', {
           p: server.address().port,
           metering_plan_id: mplan.plan_id
         }, (err, val) => {
@@ -246,7 +243,7 @@ describe('abacus-provisioning-plugin', () => {
 
     const postRequest = function(mplan) {
       request.post(
-        'http://localhost::p/v1/metering/plans/:metering_plan_id/config', {
+        'http://localhost::p/v1/metering/plans/:metering_plan_id', {
           p: server.address().port,
           metering_plan_id: mplan.plan_id,
           body: mplan
@@ -260,7 +257,7 @@ describe('abacus-provisioning-plugin', () => {
     };
     postRequest(mplan);
     request.post(
-      'http://localhost::p/v1/metering/plans/:metering_plan_id/config', {
+      'http://localhost::p/v1/metering/plans/:metering_plan_id', {
         p: server.address().port,
         metering_plan_id: 'test',
         body: {}

--- a/test/aggregation/accumulator/src/test/test.js
+++ b/test/aggregation/accumulator/src/test/test.js
@@ -224,16 +224,18 @@ describe('abacus-usage-accumulator-itest', () => {
       metering_plan_id: mpid(),
       rating_plan_id: rpid(),
       pricing_plan_id: ppid(),
-      pricing_metrics: [
-        { name: 'storage',
-          price: pid() === 'basic' ? 1 : 0.5 },
-        { name: 'thousand_light_api_calls',
-          price: pid() === 'basic' ? 0.03 : 0.04 },
-        { name: 'heavy_api_calls',
-          price: pid() === 'basic' ? 0.15 : 0.18 },
-        { name: 'memory',
-          price: pid() === 'basic' ? 0.00014 : 0.00028 }
-      ],
+      prices: {
+        metrics: [
+          { name: 'storage',
+            price: pid() === 'basic' ? 1 : 0.5 },
+          { name: 'thousand_light_api_calls',
+            price: pid() === 'basic' ? 0.03 : 0.04 },
+          { name: 'heavy_api_calls',
+            price: pid() === 'basic' ? 0.15 : 0.18 },
+          { name: 'memory',
+            price: pid() === 'basic' ? 0.00014 : 0.00028 }
+        ]
+      },
       metered_usage: [
         { metric: 'storage', quantity: 1 },
         { metric: 'thousand_light_api_calls', quantity: 1 },

--- a/test/aggregation/aggregator/src/test/test.js
+++ b/test/aggregation/aggregator/src/test/test.js
@@ -274,16 +274,18 @@ describe('abacus-usage-aggregator-itest', () => {
       metering_plan_id: mpid(ri),
       rating_plan_id: rpid(ri),
       pricing_plan_id: ppid(ri),
-      pricing_metrics: [
-        { name: 'storage',
-          price: pid(ri) === 'basic' ? 1 : 0.5 },
-        { name: 'thousand_light_api_calls',
-          price: pid(ri) === 'basic' ? 0.03 : 0.04 },
-        { name: 'heavy_api_calls',
-          price: pid(ri) === 'basic' ? 0.15 : 0.18 },
-        { name: 'memory',
-          price: pid(ri) === 'basic' ? 0.00014 : 0.00028 }
-      ],
+      prices: {
+        metrics: [
+          { name: 'storage',
+            price: pid(ri) === 'basic' ? 1 : 0.5 },
+          { name: 'thousand_light_api_calls',
+            price: pid(ri) === 'basic' ? 0.03 : 0.04 },
+          { name: 'heavy_api_calls',
+            price: pid(ri) === 'basic' ? 0.15 : 0.18 },
+          { name: 'memory',
+            price: pid(ri) === 'basic' ? 0.00014 : 0.00028 }
+        ]
+      },
       accumulated_usage: [
         {
           metric: 'storage',

--- a/test/metering/meter/src/test/test.js
+++ b/test/metering/meter/src/test/test.js
@@ -144,16 +144,18 @@ describe('abacus-usage-meter-itest', () => {
       metering_plan_id: mpid(),
       rating_plan_id: rpid(),
       pricing_plan_id: ppid(),
-      pricing_metrics: [
-        { name: 'storage',
-          price: pid() === 'basic' ? 1 : 0.5 },
-        { name: 'thousand_light_api_calls',
-          price: pid() === 'basic' ? 0.03 : 0.04 },
-        { name: 'heavy_api_calls',
-          price: pid() === 'basic' ? 0.15 : 0.18 },
-        { name: 'memory',
-          price: pid() === 'basic' ? 0.00014 : 0.00028 }
-      ],
+      prices: {
+        metrics: [
+          { name: 'storage',
+            price: pid() === 'basic' ? 1 : 0.5 },
+          { name: 'thousand_light_api_calls',
+            price: pid() === 'basic' ? 0.03 : 0.04 },
+          { name: 'heavy_api_calls',
+            price: pid() === 'basic' ? 0.15 : 0.18 },
+          { name: 'memory',
+            price: pid() === 'basic' ? 0.00014 : 0.00028 }
+        ]
+      },
       measured_usage: [
         { measure: 'storage', quantity: 1073741824 },
         { measure: 'light_api_calls', quantity: 1000 },


### PR DESCRIPTION
Made the plan configs consistent (metering, rating, pricing).
All:
endpoint /id now returns string.

rating:
- All plans now use plan_id instead of rating_plan_id

pricing: 
- All plans now use plan_id instead of pricing_plan_id
- structure changes from pricing_metrics: [] into prices: { metrics: [] }
- Get plan using pricing_plan_id now requires pricing country.

Collector:
- Updated so that it will extend the usage doc.

Accumulator & Aggregator:
- Updated get price for specific metric.

- Clean up tests and some bug fixes.