### PR TITLE
Removed duplicate key "babel-preset-es2015" in "dependencies"

### DIFF
--- a/lib/utils/router/package.json
+++ b/lib/utils/router/package.json
@@ -33,7 +33,6 @@
     "abacus-debug": "file:../debug",
     "abacus-transform": "file:../transform",
     "abacus-yieldable": "file:../yieldable",
-    "babel-preset-es2015": "^6.1.4",
     "express": "^4.9.4",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
The duplicate key causes "npm run lint" to fail.