### PR TITLE
Update webhook module to allow publication

### DIFF
--- a/lib/utils/webhook/README.md
+++ b/lib/utils/webhook/README.md
@@ -3,3 +3,38 @@ abacus-webhook
 
 Wrapper around the request module providing an easy way to implement a Webhook.
 
+Make an http post request to a list of subscriptions.  This module behaves
+similarly to [request](https://github.com/request/request) except that it
+takes an array of endpoints as input and its default request type is post
+instead of get.
+
+Usage
+---
+
+Post a message to a list of subscribers
+
+```javascript
+  const webhook = require('abacus-webhook');
+
+  const endpoints = ['https://foo.com/bar', 'https://bar.com/foo'];
+
+  const body = {
+    event: 'account_region_move',
+    account_id: '5d32efa8-8572-4388-b026-aebddc7e42c7',
+    old_pricing_country: 'USA',
+    new_pricing_country: 'CAD'
+  };
+
+  const options = {
+    json: body,
+    // Send messages one at a time.
+    concurrency: 1
+  };
+
+  webhook(endpoints, options, (error, responses) => {
+    if(!error)
+      responses.map((response) => {
+        // Do more stuff
+      });
+  });
+```

--- a/lib/utils/webhook/package.json
+++ b/lib/utils/webhook/package.json
@@ -30,15 +30,16 @@
   },
   "dependencies": {
     "abacus-debug": "file:../debug",
-    "abacus-request": "file:../request",
+    "abacus-throttle": "file:../throttle",
     "abacus-transform": "file:../transform",
     "babel-preset-es2015": "^6.6.0",
+    "request": "^2.69.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
     "abacus-babel": "file:../../../tools/babel",
-    "abacus-batch": "file:../batch",
     "abacus-eslint": "file:../../../tools/eslint",
+    "abacus-express": "file:../express",
     "abacus-mocha": "file:../../../tools/mocha",
     "abacus-publish": "file:../../../tools/publish"
   },

--- a/lib/utils/webhook/src/index.js
+++ b/lib/utils/webhook/src/index.js
@@ -3,27 +3,61 @@
 // Wrapper around the request module providing an easy way to implement a
 // Webhook.
 
-// const _ = require('underscore');
-// const request = require('abacus-request');
-// const transform = require('abacus-transform');
-// const url = require('url');
-
-// const map = _.map;
-// const groupBy = _.groupBy;
+const request = require('request').defaults({ method: 'post' });
+const throttle = require('abacus-throttle');
+const tmap = require('abacus-transform').map;
 
 /* jshint undef: false */
 /* jshint unused: false */
+/* eslint complexity: [2, 10] */
 
 // Setup debug log
-// const debug = require('abacus-debug')('abacus-webhook');
+const debug = require('abacus-debug')('abacus-webhook');
 // const edebug = require('abacus-debug')('e-abacus-webhook');
 
-// Simple wrapper around the request module function providing an easy way
-// to call a list of Webhook URIs
+/**
+ * Create a webhook with the given uris.
+ * @param  {String[]} uris - a list of uris to post to.
+ * @param  {Object} opts - configuration options object.
+ * @param  {number} opts.concurrency - the maximum number of posts to be
+ * performed concurrently.
+ * @return {function} a function that makes requests to each url.
+ */
 const webhook = (uris, opts, cb) => {
-  // TODO Implement this
+  // Handle undefined options
+  const options = opts || {};
+
+  // Handle uris list inside options
+  const urls = uris || options.uris || options.urls || [];
+
+  debug('Send a request to each of %o', urls)
+
+  // Specify the maximum number of concurrent calls
+  const trequest = throttle(request, options.concurrency || 5);
+
+  // Inject options object into each request.
+  const otrequest = (uri, it, list, next) => trequest(uri, options, next);
+
+  return tmap(urls, otrequest, (err, res) => cb(err, res));
+};
+
+
+// Export a public webhook function that handles
+// the input parameters in the proper order.
+const pwebhook = (uris, opts, cb) => {
+  // Only two arguments were input
+  if (typeof opts === 'function') {
+
+    // webhook(opts, cb)
+    if(!Array.isArray(uris))
+      return webhook(uris.uris || uris.urls, uris, opts);
+
+    // webhook(uris, cb)
+    return webhook(uris, undefined, opts);
+  }
+
+  return webhook(uris, opts, cb);
 };
 
 // Export our public functions
-module.exports = webhook;
-
+module.exports = pwebhook;

--- a/lib/utils/webhook/src/test/test.js
+++ b/lib/utils/webhook/src/test/test.js
@@ -3,17 +3,82 @@
 // Wrapper around the request module providing an easy way to implement a
 // Webhook.
 
-// const _ = require('underscore');
-// const http = require('http');
+/* eslint no-unused-expressions: 1 */
 
-// const map = _.map;
-
+const express = require('abacus-express');
+const _ = require('underscore');
+const map = _.map;
+const range = _.range;
 const webhook = require('..');
 
 describe('abacus-webhook', () => {
-  it('sends HTTP requests', () => {
-    // TODO Implement the tests
-    expect(webhook).to.not.equal(undefined);
+  // Create ten subscriptions.
+  const uris = map(range(10), () => {
+
+    const handler = (req, res) => res.status(204).send();
+
+    // Create an express server and listen on an ephemeral port.
+    const server = express().post('/', handler).listen(0);
+
+    // Export their subscription information
+    return 'http://localhost:' + server.address().port + '/';
+  });
+
+  it('sends HTTP requests', (done) => {
+
+    const json = {
+      event_type: 'space_create',
+      organization: '1c6e9105-a290-44b7-b51d-e78a6cf73539',
+      space: '9833520b-24f4-4ef4-aa15-4b6c774d4e10'
+    };
+
+    const options = { json };
+
+    const callback = (error, responses) => {
+      expect(error).to.eql(undefined);
+      map(responses, (response) => {
+        expect(response).to.be.an('object');
+        expect(response.statusCode).to.equal(204);
+      });
+
+      return done();
+    };
+
+    return webhook(uris, options, callback);
+
+  });
+
+  describe('handles each type of param list', () => {
+    const callback = (error, responses, cb) => {
+      expect(error).to.eql(undefined);
+      map(responses, (response, index) => {
+        expect(response).to.be.an('object');
+        expect(response.statusCode).to.equal(204);
+      });
+      return cb();
+    };
+
+    const opts = { uris };
+
+    it('webhook(uris, callback)', (done) => {
+      return webhook(uris, (err, res) => callback(err, res, done));
+    });
+
+    it('webhook(options, callback)', (done) => {
+      return webhook(opts, (err, res) => callback(err, res, done));
+    });
+
+    it('webhook(uris, undefined, callback)', (done) => {
+      return webhook(uris, undefined, (err, res) => callback(err, res, done));
+    });
+
+    it('webhook(undefined, options, callback)', (done) => {
+      return webhook(undefined, opts, (err, res) => callback(err, res, done));
+    });
+
+    it('webhook(uris, options, callback)', (done) => {
+      return webhook(uris, {}, (err, res) => callback(err, res, done));
+    });
   });
 
 });


### PR DESCRIPTION
Publishers can create webhooks and supply HMAC authentication to their subscribers.
