### PR TITLE
Changed the request module to allow customizaiton of defaults

### DIFF
--- a/lib/utils/request/src/index.js
+++ b/lib/utils/request/src/index.js
@@ -27,6 +27,16 @@ const omit = _.omit;
 const debug = require('abacus-debug')('abacus-request');
 const edebug = require('abacus-debug')('e-abacus-request');
 
+// The default request options
+let defopts = {
+  json: true,
+  rejectUnauthorized: false,
+  forever: true,
+  pool: {
+    maxSockets: 100
+  }
+};
+
 // Return the list of parameters found in a URI template
 const params = (template) => {
   return map(template.match(/:[a-z_][a-z0-9_]*/ig), (k) => k.substr(1));
@@ -42,15 +52,15 @@ const route = (template, parms) => {
   });
 };
 
+// Changes the request defaults abacus uses
+// Will override the same options or add the new one
+const setDefaults = (opts) => {
+  defopts = extend(defopts, opts);
+  return xrequest;
+};
+
 // Setup request default options
-const drequest = request.defaults({
-  json: true,
-  rejectUnauthorized: false,
-  forever: true,
-  pool: {
-    maxSockets: 100
-  }
-});
+const drequest = request.defaults(defopts);
 
 // Convert request params to a request target configuration, uri, options and
 // cb are all optional, but uri is expected to be given either as the uri
@@ -136,6 +146,7 @@ const httpexc = (res) => {
 //   JSON response
 // });
 const xrequest = (uri, opts, cb) => {
+
   // Convert the input parameters to a request target configuration
   const t = target(undefined, uri, opts, cb);
 
@@ -317,6 +328,7 @@ const batchOp = (m, opt) => {
 
 // Shorthand functions for the various HTTP methods
 extend(xrequest, {
+  defaults: setDefaults,
   get: singleOp('GET'),
   head: singleOp('HEAD'),
   patch: singleOp('PATCH'),


### PR DESCRIPTION
The request module will allow the user to change the defaults that the abacus-request module uses when it uses the request module. Tests still pass, but have not written any new tests for the new change.

Really submitted this pull request to see if this was the correct way to approach this problem.