### PR TITLE
Secure /healthcheck and /hystrix.stream with basic authentication.

### DIFF
--- a/lib/utils/eureka/package.json
+++ b/lib/utils/eureka/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "abacus-debug": "file:../debug",
+    "abacus-oauth": "file:../oauth",
     "abacus-perf": "file:../perf",
     "abacus-request": "file:../request",
     "abacus-urienv": "file:../urienv",
@@ -39,7 +40,8 @@
     "abacus-babel": "file:../../../tools/babel",
     "abacus-eslint": "file:../../../tools/eslint",
     "abacus-mocha": "file:../../../tools/mocha",
-    "abacus-publish": "file:../../../tools/publish"
+    "abacus-publish": "file:../../../tools/publish",
+    "underscore": "^1.8.3"
   },
   "engines": {
     "node": ">=0.12.0",

--- a/lib/utils/eureka/src/index.js
+++ b/lib/utils/eureka/src/index.js
@@ -5,32 +5,37 @@
 const request = require('abacus-request');
 const perf = require('abacus-perf');
 const urienv = require('abacus-urienv');
+const oauth = require('abacus-oauth');
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-eureka');
 
+// Return the Eureka v2 API URL. Can be configured with a EUREKA env variable
+// and default to http://localhost:8080.
+const uris = urienv({
+  eureka: 9990,
+  auth_server: 9882
+});
+
 // Return an Express middleware that responds to a health check request
 const health = () => {
   return function(req, res, next) {
-    if(req.path == '/healthcheck') {
-
-      // Get the health of the app computed from the perf stats
-      const h = perf.healthy();
-      debug('Returning app health %s', h);
-      res.status(h ? 200 : 500).send({
-        healthy: h
-      });
-    }
+    if(req.path == '/healthcheck')
+      oauth.basicAuth(uris.auth_server, req.headers &&
+        req.headers.authorization, (err, authenticated) => {
+          if (err)
+            throw err;
+          // Get the health of the app computed from the perf stats
+          const h = perf.healthy();
+          debug('Returning app health %s', h);
+          res.status(h ? 200 : 500).send({
+            healthy: h
+          });
+        });
     else
       next();
   };
 };
-
-// Return the Eureka v2 API URL. Can be configured with a EUREKA env variable
-// and default to http://localhost:8080.
-const uris = urienv({
-  eureka: 9990
-});
 
 const server = (host) => {
   const s = host ? host : process.env.EUREKA ? uris.eureka : undefined;

--- a/lib/utils/eureka/src/index.js
+++ b/lib/utils/eureka/src/index.js
@@ -7,6 +7,8 @@ const perf = require('abacus-perf');
 const urienv = require('abacus-urienv');
 const oauth = require('abacus-oauth');
 
+const secured = () => process.env.SECURED === 'true' ? true : false;
+
 // Setup debug log
 const debug = require('abacus-debug')('abacus-eureka');
 
@@ -17,21 +19,41 @@ const uris = urienv({
   auth_server: 9882
 });
 
+// Return Oauth system scopes needed to read system status
+const rscope = () => secured() ? {
+  system: ['abacus.system.read']
+} : undefined;
+
 // Return an Express middleware that responds to a health check request
 const health = () => {
   return function(req, res, next) {
-    if(req.path == '/healthcheck')
-      oauth.basicAuth(uris.auth_server, req.headers &&
-        req.headers.authorization, (err, authenticated) => {
-          if (err)
-            throw err;
-          // Get the health of the app computed from the perf stats
-          const h = perf.healthy();
-          debug('Returning app health %s', h);
-          res.status(h ? 200 : 500).send({
-            healthy: h
-          });
+    if(req.path == '/healthcheck') {
+      const healthStatus = () => {
+        // Get the health of the app computed from the perf stats
+        const h = perf.healthy();
+        debug('Returning app health %s', h);
+        res.status(h ? 200 : 500).send({
+          healthy: h
         });
+      };
+
+      if(secured()) {
+        // Get basic token
+        const auth = req.headers && req.headers.authorization;
+        // Extracts username and password
+        const user = oauth.decodeBasicToken(auth);
+        // Get bearer token from UAA to get the credentials
+        oauth.getBearerToken(uris.auth_server, user[0],
+          user[1], 'abacus.system.read', (err, token) => {
+            if(err)
+              throw err;
+            oauth.authorize(token, rscope());
+            healthStatus();
+          });
+      }
+      else
+        healthStatus();
+    }
     else
       next();
   };

--- a/lib/utils/eureka/src/test/test.js
+++ b/lib/utils/eureka/src/test/test.js
@@ -10,14 +10,21 @@ const extend = _.extend;
 
 process.env.SECURED = 'true';
 
-const basicAuthSpy = (authServer, auth, cb) => {
-  if(auth === 'Basic ZW5jb2RlOkhTMjU2')
-    cb(undefined, true)
+const getBearerToken = (authServer, username, password, scope, cb) => {
+  if(username === 'abacus')
+    cb(undefined, 'Bearer AAA')
   else
-    cb({ statusCode: 401 }, false);
+    cb({ statusCode: 401 }, undefined);
 };
+const authorize = (token, scope) => {
+  expect(scope).to.deep.equal({
+    system: ['abacus.system.read']
+  });
+  expect(token).to.equal('Bearer AAA')
+}
 const oauthmock = extend({}, oauth, {
-  basicAuth: (authServer, auth, cb) => basicAuthSpy(authServer, auth, cb)
+  getBearerToken: getBearerToken,
+  authorize: authorize
 });
 require.cache[require.resolve('abacus-oauth')].exports = oauthmock;
 
@@ -172,7 +179,9 @@ describe('abacus-eureka', () => {
     const middleware = eureka.health();
     const req = {
       path: '/healthcheck',
-      headers: {}
+      headers: {
+        authorization: 'Basic aW52YWxpZDpibGFibGE='
+      }
     }
     try {
       middleware(req, undefined, undefined);
@@ -187,7 +196,7 @@ describe('abacus-eureka', () => {
     const req = {
       path: '/healthcheck',
       headers: {
-        authorization: 'Basic ZW5jb2RlOkhTMjU2'
+        authorization: 'Basic YWJhY3VzOkhTMjU2'
       }
     };
     const res = {

--- a/lib/utils/eureka/src/test/test.js
+++ b/lib/utils/eureka/src/test/test.js
@@ -1,9 +1,25 @@
 'use strict';
 
 // A simple Netflix Eureka client.
-
+const oauth = require('abacus-oauth');
 const request = require('abacus-request');
+
 const http = require('http');
+const _ = require('underscore');
+const extend = _.extend;
+
+process.env.SECURED = 'true';
+
+const basicAuthSpy = (authServer, auth, cb) => {
+  if(auth === 'Basic ZW5jb2RlOkhTMjU2')
+    cb(undefined, true)
+  else
+    cb({ statusCode: 401 }, false);
+};
+const oauthmock = extend({}, oauth, {
+  basicAuth: (authServer, auth, cb) => basicAuthSpy(authServer, auth, cb)
+});
+require.cache[require.resolve('abacus-oauth')].exports = oauthmock;
 
 const eureka = require('..');
 
@@ -152,10 +168,27 @@ describe('abacus-eureka', () => {
     });
   });
 
+  it('denies access to unauthorized user', () => {
+    const middleware = eureka.health();
+    const req = {
+      path: '/healthcheck',
+      headers: {}
+    }
+    try {
+      middleware(req, undefined, undefined);
+    }
+    catch (e) {
+      expect(e).to.deep.equal({ statusCode: 401 });
+    }
+  }) 
+
   it('returns the health of the application', () => {
     const middleware = eureka.health();
     const req = {
-      path: '/healthcheck'
+      path: '/healthcheck',
+      headers: {
+        authorization: 'Basic ZW5jb2RlOkhTMjU2'
+      }
     };
     const res = {
       status: spy(() => res),

--- a/lib/utils/hystrix/package.json
+++ b/lib/utils/hystrix/package.json
@@ -31,6 +31,8 @@
   "dependencies": {
     "abacus-perf": "file:../perf",
     "abacus-debug": "file:../debug",
+    "abacus-oauth": "file:../oauth",
+    "abacus-urienv": "file:../urienv",
     "babel-preset-es2015": "^6.1.4",
     "underscore": "^1.8.3"
   },

--- a/lib/utils/hystrix/src/index.js
+++ b/lib/utils/hystrix/src/index.js
@@ -23,6 +23,9 @@ const uris = urienv({
   auth_server: 9882
 });
 
+// Secure the hystrix.stream or not
+const secured = () => process.env.SECURED === 'true' ? true : false;
+
 // Compute a percentile from a list of values using the ranking algorithm at
 // http://cnx.org/content/m10805/latest/,
 // see http://en.wikipedia.org/wiki/Percentile#Alternative_methods
@@ -156,45 +159,65 @@ const command = (s) => {
     });
 };
 
+// Return Oauth system scopes needed to read system status
+const rscope = () => secured() ? {
+  system: ['abacus.system.read']
+} : undefined;
+
 // Return an Express middleware that serves a Hystrix event stream
 const stream = () => {
   return (req, res, next) => {
-    if(req.path === '/hystrix.stream')
-      oauth.basicAuth(uris.auth_server, req.headers &&
-        req.headers.authorization, (err, authenticated) => {
-          if(err)
-            throw err;
-          // Keep the text/even-stream response open forever
-          req.socket.setTimeout(0);
-          res.writeHead(200, {
-            'Content-Type': 'text/event-stream; charset=utf-8',
-            'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate',
-            'Connection': 'keep-alive'
-          });
-    
-          // Write the latest Hystrix command stats right away, then
-          // periodically as specified in the client request or every 2000 ms
-          const write = () => {
-            const now = Date.now();
-            const all = values(perf.all(now));
-            if(all.length)
-              map(all, (s) => {
-                res.write('data: ' + JSON.stringify(command(s)) + '\n\n');
-                if(res.flush) res.flush();
-              });
-            else {
-              res.write('ping:\n\n');
-              if(res.flush) res.flush();
-            }
-          };
-          write();
-          const writer = setInterval(write, req.query.delay || 2000);
-    
-          // Stop when the request closes
-          req.on('close', () => {
-            clearInterval(writer);
-          });
+    if(req.path === '/hystrix.stream') {
+      const openStream = () => {
+        // Keep the text/even-stream response open forever
+        req.socket.setTimeout(0);
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream; charset=utf-8',
+          'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate',
+          'Connection': 'keep-alive'
         });
+    
+        // Write the latest Hystrix command stats right away, then
+        // periodically as specified in the client request or every 2000 ms
+        const write = () => {
+          const now = Date.now();
+          const all = values(perf.all(now));
+          if(all.length)
+            map(all, (s) => {
+              res.write('data: ' + JSON.stringify(command(s)) + '\n\n');
+              if(res.flush) res.flush();
+            });
+          else {
+            res.write('ping:\n\n');
+            if(res.flush) res.flush();
+          }
+        };
+        write();
+        const writer = setInterval(write, req.query.delay || 2000);
+    
+        // Stop when the request closes
+        req.on('close', () => {
+          clearInterval(writer);
+        });
+      };
+
+      if(secured()) {
+        // Get basic token
+        const auth = req.headers && req.headers.authorization;
+        // Extracts username and password
+        const user = oauth.decodeBasicToken(auth);
+        // Get bearer token from UAA to get the credentials
+        oauth.getBearerToken(uris.auth_server, user[0],
+          user[1], 'abacus.system.read', (err, token) => {
+            if(err)
+              throw err;
+            oauth.authorize(token, rscope());
+            openStream();
+          });
+      }
+      else
+        openStream();
+    }
     else next();
   };
 };

--- a/lib/utils/hystrix/src/index.js
+++ b/lib/utils/hystrix/src/index.js
@@ -3,7 +3,9 @@
 // Support for Netflix Hystrix, serves a stream of Hystrix command stats
 
 const _ = require('underscore');
+const oauth = require('abacus-oauth');
 const perf = require('abacus-perf');
+const urienv = require('abacus-urienv');
 
 const values = _.values;
 const map = _.map;
@@ -15,6 +17,11 @@ const sortBy = _.sortBy;
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-hystrix');
+
+// Resolve service URIs
+const uris = urienv({
+  auth_server: 9882
+});
 
 // Compute a percentile from a list of values using the ranking algorithm at
 // http://cnx.org/content/m10805/latest/,
@@ -152,38 +159,42 @@ const command = (s) => {
 // Return an Express middleware that serves a Hystrix event stream
 const stream = () => {
   return (req, res, next) => {
-    if(req.path === '/hystrix.stream') {
-      // Keep the text/even-stream response open forever
-      req.socket.setTimeout(0);
-      res.writeHead(200, {
-        'Content-Type': 'text/event-stream; charset=utf-8',
-        'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate',
-        'Connection': 'keep-alive'
-      });
-
-      // Write the latest Hystrix command stats right away, then
-      // periodically as specified in the client request or every 2000 ms
-      const write = () => {
-        const now = Date.now();
-        const all = values(perf.all(now));
-        if(all.length)
-          map(all, (s) => {
-            res.write('data: ' + JSON.stringify(command(s)) + '\n\n');
-            if(res.flush) res.flush();
+    if(req.path === '/hystrix.stream')
+      oauth.basicAuth(uris.auth_server, req.headers &&
+        req.headers.authorization, (err, authenticated) => {
+          if(err)
+            throw err;
+          // Keep the text/even-stream response open forever
+          req.socket.setTimeout(0);
+          res.writeHead(200, {
+            'Content-Type': 'text/event-stream; charset=utf-8',
+            'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate',
+            'Connection': 'keep-alive'
           });
-        else {
-          res.write('ping:\n\n');
-          if(res.flush) res.flush();
-        }
-      };
-      write();
-      const writer = setInterval(write, req.query.delay || 2000);
-
-      // Stop when the request closes
-      req.on('close', () => {
-        clearInterval(writer);
-      });
-    }
+    
+          // Write the latest Hystrix command stats right away, then
+          // periodically as specified in the client request or every 2000 ms
+          const write = () => {
+            const now = Date.now();
+            const all = values(perf.all(now));
+            if(all.length)
+              map(all, (s) => {
+                res.write('data: ' + JSON.stringify(command(s)) + '\n\n');
+                if(res.flush) res.flush();
+              });
+            else {
+              res.write('ping:\n\n');
+              if(res.flush) res.flush();
+            }
+          };
+          write();
+          const writer = setInterval(write, req.query.delay || 2000);
+    
+          // Stop when the request closes
+          req.on('close', () => {
+            clearInterval(writer);
+          });
+        });
     else next();
   };
 };

--- a/lib/utils/hystrix/src/test/test.js
+++ b/lib/utils/hystrix/src/test/test.js
@@ -8,14 +8,21 @@ const extend = _.extend;
 
 process.env.SECURED = 'true';
 
-const basicAuthSpy = (authServer, auth, cb) => {
-  if(auth === 'Basic ZW5jb2RlOkhTMjU2')
-    cb(undefined, true)
+const getBearerToken = (authServer, username, password, scope, cb) => {
+  if(username === 'abacus')
+    cb(undefined, 'Bearer AAA')
   else
-    cb({ statusCode: 401 }, false);
+    cb({ statusCode: 401 }, undefined);
 };
+const authorize = (token, scope) => {
+  expect(scope).to.deep.equal({
+    system: ['abacus.system.read']
+  });
+  expect(token).to.equal('Bearer AAA')
+}
 const oauthmock = extend({}, oauth, {
-  basicAuth: (authServer, auth, cb) => basicAuthSpy(authServer, auth, cb)
+  getBearerToken: getBearerToken,
+  authorize: authorize
 });
 require.cache[require.resolve('abacus-oauth')].exports = oauthmock;
 
@@ -55,7 +62,9 @@ describe('abacus-hystrix', () => {
         query: {
           delay: 1000
         },
-        headers: {},
+        headers: {
+          authorization: 'Basic aW52YWxpZDpibGFibGE='
+        },
         socket: socket,
         on: on
       }, res, next);
@@ -92,7 +101,7 @@ describe('abacus-hystrix', () => {
         delay: 1000
       },
       headers: {
-        authorization: 'Basic ZW5jb2RlOkhTMjU2'
+        authorization: 'Basic YWJhY3VzOkhTMjU2'
       },
       socket: socket,
       on: on

--- a/lib/utils/hystrix/src/test/test.js
+++ b/lib/utils/hystrix/src/test/test.js
@@ -2,7 +2,25 @@
 
 // Support for Netflix Hystrix, serves a stream of Hystrix command stats
 
+const oauth = require('abacus-oauth');
+const _ = require('underscore');
+const extend = _.extend;
+
+process.env.SECURED = 'true';
+
+const basicAuthSpy = (authServer, auth, cb) => {
+  if(auth === 'Basic ZW5jb2RlOkhTMjU2')
+    cb(undefined, true)
+  else
+    cb({ statusCode: 401 }, false);
+};
+const oauthmock = extend({}, oauth, {
+  basicAuth: (authServer, auth, cb) => basicAuthSpy(authServer, auth, cb)
+});
+require.cache[require.resolve('abacus-oauth')].exports = oauthmock;
+
 const hystrix = require('..');
+
 const perf = require('abacus-perf');
 
 describe('abacus-hystrix', () => {
@@ -15,6 +33,36 @@ describe('abacus-hystrix', () => {
   afterEach(() => {
     // Restore original timers
     clock.restore();
+  });
+
+  it('denies access to unauthorized user', () => {
+    // Get hystrix Express middleware
+    const stream = hystrix.stream();
+
+    const next = spy();
+    const res = {};
+    const socket = {
+      setTimeout: stub().returns(res)
+    };
+    res.writeHead = stub().returns(res);
+    res.write = stub().returns(res);
+    res.flush = stub().returns(res);
+    const on = spy();
+    
+    try {
+      stream({
+        path: '/hystrix.stream',
+        query: {
+          delay: 1000
+        },
+        headers: {},
+        socket: socket,
+        on: on
+      }, res, next);
+    }
+    catch (e) {
+      expect(e).to.deep.equal({ statusCode: 401 });
+    };
   });
 
   it('serves a stream of hystrix stats', () => {
@@ -42,6 +90,9 @@ describe('abacus-hystrix', () => {
       path: '/hystrix.stream',
       query: {
         delay: 1000
+      },
+      headers: {
+        authorization: 'Basic ZW5jb2RlOkhTMjU2'
       },
       socket: socket,
       on: on
@@ -165,5 +216,7 @@ describe('abacus-hystrix', () => {
     // Close the stream
     on.args[0][1]();
   });
+
+  
 });
 

--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -16,16 +16,11 @@ const isEmpty = _.isEmpty;
 const pick = _.pick;
 const intersection = _.intersection;
 const difference = _.difference;
-const contains = _.contains;
 
 const debug = require('abacus-debug')('abacus-oauth');
 const edebug = require('abacus-debug')('e-abacus-oauth');
 
 const get = retry(request.get);
-
-const username = process.env.USERNAME || 'abacus';
-const password = process.env.PASSWORD || 'HS256';
-const secured = () => process.env.SECURED === 'true' ? true : false;
 
 // Retrieve token endpoint from an authorization server
 const tokenEndpoint = (apiHostName, cb) => {
@@ -283,75 +278,45 @@ const cache = (authServer, id, secret, scopes) => {
   return wrapper;
 };
 
-// Decode basic token
-const decodeBasicToken = (auth) => new Buffer(auth.split(' ')[1], 'base64')
-  .toString().split(':');
+// Extract basic token to get username and password
+const decodeBasicToken = (auth) => {
+  try {
+    const user = new Buffer(auth.split(' ')[1], 'base64').toString().split(':');
+    if (!user[0] || !user[1])
+      throw new Error('Invalid token');
+    return user;
+  }
+  catch (e) {
+    throw {
+      statusCode: 401,
+      header: {
+        'WWW-Authenticate': 'Basic realm="cf", error="invalid_token",' +
+          ' error_description="malformed"'
+      }
+    };
+  }
+};
 
-// Get token from auth server, expect to have the required scope
-const basicAuth = (authServer, auth, cb) => {
-  if (!secured())
-    return cb(undefined, true);
+// Get OAuth bearer access token
+const getBearerToken = (authServer, id, secret, scopes, cb) => {
+  debug('Getting OAuth bearer access token');
+  // Get token endpoint from OAuth server
   tokenEndpoint(authServer, (err, endpoint) => {
     if (err) {
       edebug('Error getting OAuth bearer access token, %o', err);
       debug('Error getting OAuth bearer access token, %o', err);
-      return cb({
-        statusCode: 401,
-        header: {
-          'WWW-Authenticate': 'Basic realm="cf", error="invalid_token",' +
-            ' error_description="malformed ' + err + ' "'
-        }
-      }, false);
-    }
-    let decoded;
-    try {
-      decoded = decodeBasicToken(auth);
-    }
-    catch (exception) {
-      edebug('Exception when decoding basic token, %o', exception);
-      debug('Exception when decoding basic token, %o', exception);
-  
-      return cb({
-        statusCode: 401,
-        header: {
-          'WWW-Authenticate': 'Bearer realm="cf", error="invalid_token",' +
-            ' error_description="malformed"'
-        }
-      }, false);
-    }
-    const id = decoded[0];
-    const secret = decoded[1];
-    // Give access only to user with the right username and password
-    const scope = id === username && secret === password ?
-      'abacus' : ' ';
-    // Get token from OAuth endpoint with scope abacus.
-    newToken(endpoint, id, secret, scope, (err, t) => {
+      return cb(err, undefined);
+    };
+    // Get token endpoint from OAuth token endpoint
+    newToken(endpoint, id, secret, scopes, (err, t) => {
       if (err) {
         edebug('Error getting OAuth bearer access token, %o', err);
         debug('Error getting OAuth bearer access token, %o', err);
-        return cb({
-          statusCode: 401,
-          header: {
-            'WWW-Authenticate': 'Basic realm="cf", error="invalid_token",' +
-              ' error_description="malformed ' + err + ' "'
-          }
-        }, false);
-      }
+        return cb(err, undefined);
+      };
       debug('Got OAuth bearer access token');
-      const scopes = t.scope;
-      if(!contains(scopes, 'abacus')) {
-        // Request does not have expected scopes
-        edebug('Unauthorized request with scope, %o', scopes);
-        debug('Unauthorized request with scope, %o', scopes);
-        return cb({
-          statusCode: 403,
-          header: {
-            'WWW-Authenticate': 'Bearer realm="cf", error="insufficient_scope",'
-              + ' error_description="' + (scopes || '') + '"'
-          }
-        }, false);
-      }
-      return cb(undefined, true);
+      // Return the OAuth bearer access token
+      return cb(undefined, 'Bearer ' + t.access_token);
     });
   });
 };
@@ -361,4 +326,5 @@ module.exports.validate = validate;
 module.exports.validator = validator;
 module.exports.authorize = authorize;
 module.exports.getUserInfo = getUserInfo;
-module.exports.basicAuth = basicAuth;
+module.exports.decodeBasicToken = decodeBasicToken;
+module.exports.getBearerToken = getBearerToken;

--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -16,11 +16,16 @@ const isEmpty = _.isEmpty;
 const pick = _.pick;
 const intersection = _.intersection;
 const difference = _.difference;
+const contains = _.contains;
 
 const debug = require('abacus-debug')('abacus-oauth');
 const edebug = require('abacus-debug')('e-abacus-oauth');
 
 const get = retry(request.get);
+
+const username = process.env.USERNAME || 'abacus';
+const password = process.env.PASSWORD || 'HS256';
+const secured = () => process.env.SECURED === 'true' ? true : false;
 
 // Retrieve token endpoint from an authorization server
 const tokenEndpoint = (apiHostName, cb) => {
@@ -278,8 +283,82 @@ const cache = (authServer, id, secret, scopes) => {
   return wrapper;
 };
 
+// Decode basic token
+const decodeBasicToken = (auth) => new Buffer(auth.split(' ')[1], 'base64')
+  .toString().split(':');
+
+// Get token from auth server, expect to have the required scope
+const basicAuth = (authServer, auth, cb) => {
+  if (!secured())
+    return cb(undefined, true);
+  tokenEndpoint(authServer, (err, endpoint) => {
+    if (err) {
+      edebug('Error getting OAuth bearer access token, %o', err);
+      debug('Error getting OAuth bearer access token, %o', err);
+      return cb({
+        statusCode: 401,
+        header: {
+          'WWW-Authenticate': 'Basic realm="cf", error="invalid_token",' +
+            ' error_description="malformed ' + err + ' "'
+        }
+      }, false);
+    }
+    let decoded;
+    try {
+      decoded = decodeBasicToken(auth);
+    }
+    catch (exception) {
+      edebug('Exception when decoding basic token, %o', exception);
+      debug('Exception when decoding basic token, %o', exception);
+  
+      return cb({
+        statusCode: 401,
+        header: {
+          'WWW-Authenticate': 'Bearer realm="cf", error="invalid_token",' +
+            ' error_description="malformed"'
+        }
+      }, false);
+    }
+    const id = decoded[0];
+    const secret = decoded[1];
+    // Give access only to user with the right username and password
+    const scope = id === username && secret === password ?
+      'abacus' : ' ';
+    // Get token from OAuth endpoint with scope abacus.
+    newToken(endpoint, id, secret, scope, (err, t) => {
+      if (err) {
+        edebug('Error getting OAuth bearer access token, %o', err);
+        debug('Error getting OAuth bearer access token, %o', err);
+        return cb({
+          statusCode: 401,
+          header: {
+            'WWW-Authenticate': 'Basic realm="cf", error="invalid_token",' +
+              ' error_description="malformed ' + err + ' "'
+          }
+        }, false);
+      }
+      debug('Got OAuth bearer access token');
+      const scopes = t.scope;
+      if(!contains(scopes, 'abacus')) {
+        // Request does not have expected scopes
+        edebug('Unauthorized request with scope, %o', scopes);
+        debug('Unauthorized request with scope, %o', scopes);
+        return cb({
+          statusCode: 403,
+          header: {
+            'WWW-Authenticate': 'Bearer realm="cf", error="insufficient_scope",'
+              + ' error_description="' + (scopes || '') + '"'
+          }
+        }, false);
+      }
+      return cb(undefined, true);
+    });
+  });
+};
+
 module.exports.cache = cache;
 module.exports.validate = validate;
 module.exports.validator = validator;
 module.exports.authorize = authorize;
 module.exports.getUserInfo = getUserInfo;
+module.exports.basicAuth = basicAuth;

--- a/lib/utils/oauth/src/test/test.js
+++ b/lib/utils/oauth/src/test/test.js
@@ -298,6 +298,83 @@ describe('abacus-oauth', () => {
     }
   });
 
+  it('Authorize basic authentication', (done) => {
+
+    const verify = (secured, cb) => {
+      process.env.SECURED = secured;
+      let checks = 0;
+      const checkDone = () => {
+        if(++ checks === 4)
+          cb();
+      }
+      // Create a test Express application
+      const app = express();
+  
+      // Add auth server REST endpoints
+      app.get('/v2/info', (req, res) => {
+        res.send({
+          token_endpoint: [req.protocol, '://', req.headers.host].join('')
+        });
+      });
+  
+      app.get('/oauth/token', (req, res) => {
+        res.send({ access_token: 'AAA', token_type: 'bearer',
+          scope: req.query.scope.split(' ') });
+      });
+  
+      // Listen on an ephemeral port
+      const server = app.listen(0);
+  
+      oauth.basicAuth('http://localhost:' + server.address().port,
+        'Basic YWJhY3VzOkhTMjU2', (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val).to.equal(true);
+          checkDone();
+        });
+  
+      oauth.basicAuth('http://localhost:' + server.address().port,
+        'Basic YWJhY3VzOkhTAbU2', (err, val) => {
+          if (!secured) {
+            expect(err).to.equal(undefined);
+            expect(val).to.equal(true);
+          }
+          else {
+            expect(err.statusCode).to.equal(403);
+            expect(val).to.equal(false);
+          }
+          checkDone();
+        });
+  
+      oauth.basicAuth('http://localhost:' + server.address().port,
+        'YWJhY3VzOkhTMjU2', (err, val) => {
+          if (!secured) {
+            expect(err).to.equal(undefined);
+            expect(val).to.equal(true);
+          }
+          else {
+            expect(err.statusCode).to.equal(401);
+            expect(val).to.equal(false);
+          }
+          checkDone();
+        });
+  
+      oauth.basicAuth('http://localhost:' + server.address().port,
+        undefined, (err, val) => {
+          if (!secured) {
+            expect(err).to.equal(undefined);
+            expect(val).to.equal(true);
+          }
+          else {
+            expect(err.statusCode).to.equal(401);
+            expect(val).to.equal(false);
+          }
+          checkDone();
+        });
+    };
+
+    verify(false, () => verify('true', done));
+  })
+
   it('get OAuth bearer access token using cache', (done) => {
     // Create a test Express application
     const app = express();

--- a/lib/utils/oauth/src/test/test.js
+++ b/lib/utils/oauth/src/test/test.js
@@ -298,83 +298,6 @@ describe('abacus-oauth', () => {
     }
   });
 
-  it('Authorize basic authentication', (done) => {
-
-    const verify = (secured, cb) => {
-      process.env.SECURED = secured;
-      let checks = 0;
-      const checkDone = () => {
-        if(++ checks === 4)
-          cb();
-      }
-      // Create a test Express application
-      const app = express();
-  
-      // Add auth server REST endpoints
-      app.get('/v2/info', (req, res) => {
-        res.send({
-          token_endpoint: [req.protocol, '://', req.headers.host].join('')
-        });
-      });
-  
-      app.get('/oauth/token', (req, res) => {
-        res.send({ access_token: 'AAA', token_type: 'bearer',
-          scope: req.query.scope.split(' ') });
-      });
-  
-      // Listen on an ephemeral port
-      const server = app.listen(0);
-  
-      oauth.basicAuth('http://localhost:' + server.address().port,
-        'Basic YWJhY3VzOkhTMjU2', (err, val) => {
-          expect(err).to.equal(undefined);
-          expect(val).to.equal(true);
-          checkDone();
-        });
-  
-      oauth.basicAuth('http://localhost:' + server.address().port,
-        'Basic YWJhY3VzOkhTAbU2', (err, val) => {
-          if (!secured) {
-            expect(err).to.equal(undefined);
-            expect(val).to.equal(true);
-          }
-          else {
-            expect(err.statusCode).to.equal(403);
-            expect(val).to.equal(false);
-          }
-          checkDone();
-        });
-  
-      oauth.basicAuth('http://localhost:' + server.address().port,
-        'YWJhY3VzOkhTMjU2', (err, val) => {
-          if (!secured) {
-            expect(err).to.equal(undefined);
-            expect(val).to.equal(true);
-          }
-          else {
-            expect(err.statusCode).to.equal(401);
-            expect(val).to.equal(false);
-          }
-          checkDone();
-        });
-  
-      oauth.basicAuth('http://localhost:' + server.address().port,
-        undefined, (err, val) => {
-          if (!secured) {
-            expect(err).to.equal(undefined);
-            expect(val).to.equal(true);
-          }
-          else {
-            expect(err.statusCode).to.equal(401);
-            expect(val).to.equal(false);
-          }
-          checkDone();
-        });
-    };
-
-    verify(false, () => verify('true', done));
-  })
-
   it('get OAuth bearer access token using cache', (done) => {
     // Create a test Express application
     const app = express();
@@ -491,5 +414,51 @@ describe('abacus-oauth', () => {
     expect(client).to.deep.equal({
       client_id: 'runtimeext'
     });
+  });
+
+  it('Decode basic token', () => {
+    const user = oauth.decodeBasicToken('Basic YWJhY3VzOkhTMjU2');
+    expect(user).to.deep.equal(['abacus', 'HS256']);
+    try {
+      oauth.decodeBasicToken('Basic a');
+    }
+    catch(e) {
+      expect(e.statusCode).to.equal(401);
+    }
+  });
+
+  it('Get bearer access token', (done) => {
+    // Create a test Express application
+    const app = express();
+
+    // Add auth server REST endpoints
+    app.get('/v2/info', (req, res) => {
+      res.send({
+        token_endpoint: [req.protocol, '://', req.headers.host].join('')
+      });
+    });
+
+    app.get('/oauth/token', (req, res) => {
+      if (req.query.scope === 'invalid') return res.status(400).end();
+
+      res.send({ access_token: 'AAA', token_type: 'bearer', expires_in: 1 });
+    });
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    oauth.getBearerToken('http://localhost:' +
+      server.address().port, 'abacus', 'HS256', 'abacus.system.read',
+      (err, token) => {
+        expect(err).to.equal(undefined);
+        expect(token).to.equal('Bearer AAA');
+        oauth.getBearerToken('http://localhost:' +
+        server.address().port, 'abacus', 'HS256', 'invalid',
+        (err, token) => {
+          expect(err).to.deep.equal(new Error('Unable to get OAUTH token'));
+          expect(token).to.equal(undefined);
+          done();
+        });
+      });
   });
 });


### PR DESCRIPTION
Added basicAuth to healthcheck and hystrix.stream.

I would be happy to make changes on the basic authentication. Currently this is what the basic authentication is doing:

It takes in basic auth token and converts it to username and password. It then call UAA to get bearer token along with the scopes that the user has. It then checks whether the user has the scope 'abacus'.

What troubles me:
the UAA plugins that we have requires the caller to pass in the scope. The token that will be returned by the UAA plugins would have the scopes that was passed. This means that I cannot simulate unauthorized user and authorized user. Therefore I made it so that the only user that can pass basic auth would need to have
username: process.env.USERNAME || 'abacus'
password: process.env.PASSWORD || 'HS256'

Any feedback to solve this problem would be appreciated.

Thanks!
