### PR TITLE
Business responses are returned as an object.

### DIFF
--- a/lib/config/metering/src/index.js
+++ b/lib/config/metering/src/index.js
@@ -107,10 +107,9 @@ const cacheId = (k, id) => {
 const cachedId = (k) => ids.get(k);
 
 // Business response object
-const businessResponse = (error, response) => ({
-  error: error,
-  body: !error ? response : undefined,
-  reason: error ? response : undefined
+const businessError = (reason) => ({
+  error: true,
+  reason: reason
 });
 
 // Retrieve the metering plan id applicable to the specified organization,
@@ -121,7 +120,7 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
   if (!rtype) {
     debug('Undefined resource type');
     return cb(undefined,
-      businessResponse(true, 'Metering config - Undefined resource type'));
+      businessError('Metering config - Undefined resource type'));
   }
 
   // Round time to a 10 min boundary
@@ -132,13 +131,16 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
   const c = cachedId(k);
   if(c) {
     debug('Metering plan id for %s found in cache', k);
-    return cb(undefined, businessResponse(undefined, c));
+    return cb(undefined, {
+      metering_plan_id: c
+    });
   }
 
   // Lookup and cache test plans
   if(rtype === 'test-resource')
-    return cb(undefined, businessResponse(undefined, cacheId(k,
-      require('./test/test-metering-plan').plan_id)));
+    return cb(undefined, {
+      metering_plan_id: cacheId(k, require('./test/test-metering-plan').plan_id)
+    });
 
   // Forward authorization header field to provisioning plugin
   const o = auth ? { headers: { authorization: auth } } : {};
@@ -164,12 +166,14 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
           val.statusCode, val.body || '');
 
         // Response back with description of the error.
-        return cb(undefined, businessResponse(true,
+        return cb(undefined, businessError(
           'Metering config - Unable to retrieve metering plan id'));
       }
 
       // return the metering plan id
-      return cb(undefined, businessResponse(undefined, cacheId(k, val.body)));
+      return cb(undefined, {
+        metering_plan_id: cacheId(k, val.body)
+      });
     });
 };
 

--- a/lib/config/metering/src/index.js
+++ b/lib/config/metering/src/index.js
@@ -106,10 +106,23 @@ const cacheId = (k, id) => {
 // Return a metering plan from the cache
 const cachedId = (k) => ids.get(k);
 
+// Business response object
+const businessResponse = (error, response) => ({
+  error: error,
+  body: !error ? response : undefined,
+  reason: error ? response : undefined
+});
+
 // Retrieve the metering plan id applicable to the specified organization,
 // resource type, provisioning plan and time
 const id = (oid, rtype, ppid, time, auth, cb) => {
   debug('Retrieving metering plan_id');
+
+  if (!rtype) {
+    debug('Undefined resource type');
+    return cb(undefined,
+      businessResponse(true, 'Metering config - Undefined resource type'));
+  }
 
   // Round time to a 10 min boundary
   const t = Math.floor(time / 600000) * 600000;
@@ -119,13 +132,13 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
   const c = cachedId(k);
   if(c) {
     debug('Metering plan id for %s found in cache', k);
-    return cb(undefined, c);
+    return cb(undefined, businessResponse(undefined, c));
   }
 
   // Lookup and cache test plans
   if(rtype === 'test-resource')
-    return cb(undefined, cacheId(k,
-      require('./test/test-metering-plan').plan_id));
+    return cb(undefined, businessResponse(undefined, cacheId(k,
+      require('./test/test-metering-plan').plan_id)));
 
   // Forward authorization header field to provisioning plugin
   const o = auth ? { headers: { authorization: auth } } : {};
@@ -150,12 +163,13 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
         debug('Unable to retrieve metering plan id, %d - %o',
           val.statusCode, val.body || '');
 
-        // Throw response object as an exception to stop further processing.
-        throw val;
+        // Response back with description of the error.
+        return cb(undefined, businessResponse(true,
+          'Metering config - Unable to retrieve metering plan id'));
       }
 
       // return the metering plan id
-      return cb(undefined, cacheId(k, val.body));
+      return cb(undefined, businessResponse(undefined, cacheId(k, val.body)));
     });
 };
 

--- a/lib/config/metering/src/test/test.js
+++ b/lib/config/metering/src/test/test.js
@@ -148,10 +148,11 @@ describe('abacus-metering-config', () => {
       'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', undefined,
       'test-plan', 1420070400000, undefined, (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val.body).to.equal(undefined);
-        expect(val.error).to.equal(true);
-        expect(val.reason).to.equal(
-          'Metering config - Undefined resource type');
+        expect(val).to.deep.equal({
+          error: true,
+          body: undefined,
+          reason: 'Metering config - Undefined resource type'
+        });
         cb();
       });
  
@@ -160,10 +161,11 @@ describe('abacus-metering-config', () => {
       'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', 'InvalidResourceType',
       'test-plan', 1420070400000, undefined, (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val.body).to.equal(undefined);
-        expect(val.error).to.equal(true);
-        expect(val.reason).to.equal(
-          'Metering config - Unable to retrieve metering plan id');
+        expect(val).to.deep.equal({
+          error: true,
+          body: undefined,
+          reason: 'Metering config - Unable to retrieve metering plan id'
+        });
         cb();
       });
   });

--- a/lib/config/metering/src/test/test.js
+++ b/lib/config/metering/src/test/test.js
@@ -56,7 +56,11 @@ describe('abacus-metering-config', () => {
         'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', 'test-resource',
         'test-metering-plan', 1420070400000, undefined, (err, val) => {
           expect(err).to.equal(undefined);
-          expect(val).to.equal('test-metering-plan');
+          expect(val).to.deep.equal({
+            error: undefined,
+            body: 'test-metering-plan',
+            reason: undefined
+          });
           cb();
         });
 
@@ -65,7 +69,11 @@ describe('abacus-metering-config', () => {
         'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', 'test-resource',
         'test-metering-plan', 1420070400000, undefined, (err, val) => {
           expect(err).to.equal(undefined);
-          expect(val).to.equal('test-metering-plan');
+          expect(val).to.deep.equal({
+            error: undefined,
+            body: 'test-metering-plan',
+            reason: undefined
+          });
           cb();
         });
 
@@ -74,7 +82,11 @@ describe('abacus-metering-config', () => {
         'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', 'test-id',
         'test-id', 1420070400000, undefined, (err, val) => {
           expect(err).to.equal(undefined);
-          expect(val).to.equal('test-id');
+          expect(val).to.deep.equal({
+            error: undefined,
+            body: 'test-id',
+            reason: undefined
+          });
           cb();
         });
     });
@@ -119,6 +131,41 @@ describe('abacus-metering-config', () => {
       expect(val.plan_id).to.equal('test-metering-plan');
       cb();
     });
+  });
+
+  it('returns with the appropriate error flag and reason', (done) => {
+    let cbs = 0;
+    const cb = () => {
+      if (++cbs === 2) done();
+    };
+
+    // Mock request to simulate business error
+    getspy = (reqs, cb) =>
+      cb(null, [[undefined, { statusCode: 404, body: 'Not found' }]]);
+
+    // When resource type is undefined
+    config.id(
+      'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', undefined,
+      'test-plan', 1420070400000, undefined, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.body).to.equal(undefined);
+        expect(val.error).to.equal(true);
+        expect(val.reason).to.equal(
+          'Metering config - Undefined resource type');
+        cb();
+      });
+ 
+    // When the plan id does not map to a plan
+    config.id(
+      'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', 'InvalidResourceType',
+      'test-plan', 1420070400000, undefined, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.body).to.equal(undefined);
+        expect(val.error).to.equal(true);
+        expect(val.reason).to.equal(
+          'Metering config - Unable to retrieve metering plan id');
+        cb();
+      });
   });
 
   describe('evaluate metering formulas', () => {

--- a/lib/config/metering/src/test/test.js
+++ b/lib/config/metering/src/test/test.js
@@ -57,9 +57,7 @@ describe('abacus-metering-config', () => {
         'test-metering-plan', 1420070400000, undefined, (err, val) => {
           expect(err).to.equal(undefined);
           expect(val).to.deep.equal({
-            error: undefined,
-            body: 'test-metering-plan',
-            reason: undefined
+            metering_plan_id: 'test-metering-plan'
           });
           cb();
         });
@@ -70,9 +68,7 @@ describe('abacus-metering-config', () => {
         'test-metering-plan', 1420070400000, undefined, (err, val) => {
           expect(err).to.equal(undefined);
           expect(val).to.deep.equal({
-            error: undefined,
-            body: 'test-metering-plan',
-            reason: undefined
+            metering_plan_id: 'test-metering-plan'
           });
           cb();
         });
@@ -83,9 +79,7 @@ describe('abacus-metering-config', () => {
         'test-id', 1420070400000, undefined, (err, val) => {
           expect(err).to.equal(undefined);
           expect(val).to.deep.equal({
-            error: undefined,
-            body: 'test-id',
-            reason: undefined
+            metering_plan_id: 'test-id'
           });
           cb();
         });
@@ -150,7 +144,6 @@ describe('abacus-metering-config', () => {
         expect(err).to.equal(undefined);
         expect(val).to.deep.equal({
           error: true,
-          body: undefined,
           reason: 'Metering config - Undefined resource type'
         });
         cb();
@@ -163,7 +156,6 @@ describe('abacus-metering-config', () => {
         expect(err).to.equal(undefined);
         expect(val).to.deep.equal({
           error: true,
-          body: undefined,
           reason: 'Metering config - Unable to retrieve metering plan id'
         });
         cb();

--- a/lib/config/pricing/src/index.js
+++ b/lib/config/pricing/src/index.js
@@ -14,7 +14,6 @@ const lru = require('abacus-lrucache');
 const extend = _.extend;
 const map = _.map;
 const filter = _.filter;
-const pick = _.pick;
 
 const brequest = retry(breaker(batch(request)));
 
@@ -60,26 +59,40 @@ const countryPrices = (plan, country) => {
   });
 };
 
+// Business response object
+const businessResponse = (error, response) => ({
+  error: error,
+  body: !error ? response : undefined,
+  reason: error ? response : undefined
+});
 
 // Retrieve the specified pricing plan
 const plan = (ppid, country, auth, cb) => {
-  lock(ppid, (err, unlock) => {
+  debug('Retrieving pricing plan %s', ppid);
+
+  if(!ppid || !country) {
+    debug('Undefined pricing plan id / country');
+    return cb(undefined, businessResponse(true,
+      'Pricing config - Undefined pricing plan id / country'));
+  }
+
+  return lock(ppid, (err, unlock) => {
     if(err)
       return unlock(cb(err));
-    debug('Retrieving pricing plan %s', ppid);
 
     // Look in our cache first
     const c = cached(ppid);
     if(c) {
       debug('Pricing plan %s found in cache', ppid);
-      return unlock(cb(undefined, countryPrices(c, country)));
+      return unlock(cb(undefined,
+        businessResponse(undefined, countryPrices(c, country))));
     }
 
     // Lookup and cache test plans
     if(ppid === 'test-pricing-basic' || ppid === 'test-pricing-standard')
       return unlock(
-        cb(undefined, countryPrices(cache(ppid, require('./test/' + ppid)),
-          country)));
+        cb(undefined, businessResponse(undefined, countryPrices(cache
+          (ppid, require('./test/' + ppid)), country))));
 
     // Forward authorization header field to the account plugin
     const o = auth ? { headers: { authorization: auth } } : {};
@@ -101,13 +114,14 @@ const plan = (ppid, country, auth, cb) => {
 
           // Unlock and throw response object as an exception
           // to stop further processing
-          return unlock(cb(extend({}, pick(val, ['statusCode', 'body']),
-            { headers: pick(val.headers, 'www-authenticate') })));
+          return unlock(cb(undefined, businessResponse(true,
+            'Pricing config - pricing plan for the given plan id is not found'
+            )));
         }
 
         // Return the pricing plan
-        return unlock(cb(undefined, countryPrices(cache(ppid, val.body),
-          country)));
+        return unlock(cb(undefined, businessResponse(undefined,
+          countryPrices(cache(ppid, val.body), country))));
       });
   });
 };
@@ -131,6 +145,11 @@ const cachedId = (k) => ids.get(k);
 // provisioning plan, and time
 const id = (oid, rtype, ppid, time, auth, cb) => {
   debug('Retrieving pricing plan id');
+  if(!rtype) {
+    debug('Undefined resource type');
+    return cb(undefined,
+      businessError(true, 'Pricing config - Undefined resource type'))
+  }
 
   // Round time to a 10 min boundary
   const t = Math.floor(time / 600000) * 600000;
@@ -140,13 +159,13 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
   const c = cachedId(k);
   if(c) {
     debug('Pricing plan id for %s found in cache', k);
-    return cb(undefined, c);
+    return cb(undefined, businessResponse(undefined, c));
   }
 
   // Lookup and cache test plans
   if(rtype === 'test-resource')
-    return cb(undefined, cacheId(k,
-      require('./test/test-pricing-basic').plan_id));
+    return cb(undefined, businessResponse(undefined, cacheId(k,
+      require('./test/test-pricing-basic').plan_id)));
 
   // Forward authorization header field to the account plugin
   const o = auth ? { headers: { authorization: auth } } : {};
@@ -172,11 +191,12 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
           val.statusCode, val.body || '');
 
         // Throw response object as an exception to stop further processing.
-        throw val;
+        return cb(undefined, businessResponse(true,
+          'Pricing config - Unable to retrieve pricing plan id'));
       }
 
       // Return the pricing plan id
-      return cb(undefined, cacheId(k, val.body));
+      return cb(undefined, businessResponse(undefined, cacheId(k, val.body)));
     });
 };
 

--- a/lib/config/pricing/src/index.js
+++ b/lib/config/pricing/src/index.js
@@ -60,10 +60,9 @@ const countryPrices = (plan, country) => {
 };
 
 // Business response object
-const businessResponse = (error, response) => ({
-  error: error,
-  body: !error ? response : undefined,
-  reason: error ? response : undefined
+const businessError = (reason) => ({
+  error: true,
+  reason: reason
 });
 
 // Retrieve the specified pricing plan
@@ -72,7 +71,7 @@ const plan = (ppid, country, auth, cb) => {
 
   if(!ppid || !country) {
     debug('Undefined pricing plan id / country');
-    return cb(undefined, businessResponse(true,
+    return cb(undefined, businessError(
       'Pricing config - Undefined pricing plan id / country'));
   }
 
@@ -84,15 +83,18 @@ const plan = (ppid, country, auth, cb) => {
     const c = cached(ppid);
     if(c) {
       debug('Pricing plan %s found in cache', ppid);
-      return unlock(cb(undefined,
-        businessResponse(undefined, countryPrices(c, country))));
+      return unlock(cb(undefined, {
+        pricing_plan: countryPrices(c, country)
+      }));
     }
 
     // Lookup and cache test plans
     if(ppid === 'test-pricing-basic' || ppid === 'test-pricing-standard')
       return unlock(
-        cb(undefined, businessResponse(undefined, countryPrices(cache
-          (ppid, require('./test/' + ppid)), country))));
+        cb(undefined, {
+          pricing_plan: countryPrices(cache (ppid, require('./test/' + ppid)),
+            country)
+        }));
 
     // Forward authorization header field to the account plugin
     const o = auth ? { headers: { authorization: auth } } : {};
@@ -114,14 +116,15 @@ const plan = (ppid, country, auth, cb) => {
 
           // Unlock and throw response object as an exception
           // to stop further processing
-          return unlock(cb(undefined, businessResponse(true,
+          return unlock(cb(undefined, businessError(
             'Pricing config - pricing plan for the given plan id is not found'
-            )));
+          )));
         }
 
         // Return the pricing plan
-        return unlock(cb(undefined, businessResponse(undefined,
-          countryPrices(cache(ppid, val.body), country))));
+        return unlock(cb(undefined, {
+          pricing_plan: countryPrices(cache(ppid, val.body), country)
+        }));
       });
   });
 };
@@ -148,7 +151,7 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
   if(!rtype) {
     debug('Undefined resource type');
     return cb(undefined,
-      businessError(true, 'Pricing config - Undefined resource type'))
+      businessError('Pricing config - Undefined resource type'))
   }
 
   // Round time to a 10 min boundary
@@ -159,13 +162,16 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
   const c = cachedId(k);
   if(c) {
     debug('Pricing plan id for %s found in cache', k);
-    return cb(undefined, businessResponse(undefined, c));
+    return cb(undefined, {
+      pricing_plan_id: c
+    });
   }
 
   // Lookup and cache test plans
   if(rtype === 'test-resource')
-    return cb(undefined, businessResponse(undefined, cacheId(k,
-      require('./test/test-pricing-basic').plan_id)));
+    return cb(undefined, {
+      pricing_plan_id: cacheId(k,require('./test/test-pricing-basic').plan_id)
+    });
 
   // Forward authorization header field to the account plugin
   const o = auth ? { headers: { authorization: auth } } : {};
@@ -191,12 +197,14 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
           val.statusCode, val.body || '');
 
         // Throw response object as an exception to stop further processing.
-        return cb(undefined, businessResponse(true,
+        return cb(undefined, businessError(
           'Pricing config - Unable to retrieve pricing plan id'));
       }
 
       // Return the pricing plan id
-      return cb(undefined, businessResponse(undefined, cacheId(k, val.body)));
+      return cb(undefined, {
+        pricing_plan_id: cacheId(k, val.body)
+      });
     });
 };
 

--- a/lib/config/pricing/src/test/test.js
+++ b/lib/config/pricing/src/test/test.js
@@ -72,9 +72,7 @@ describe('abacus-pricing-config', () => {
     config.plan('test-pricing-basic', 'USA', undefined, (err, val) => {
       expect(err).to.equal(undefined);
       expect(val).to.deep.equal({
-        error: undefined,
-        body: expected,
-        reason: undefined
+        pricing_plan: expected
       });
       cb();
     });
@@ -83,9 +81,7 @@ describe('abacus-pricing-config', () => {
     config.plan('test-pricing-basic', 'USA', undefined, (err, val) => {
       expect(err).to.equal(undefined);
       expect(val).to.deep.equal({
-        error: undefined,
-        body: expected,
-        reason: undefined
+        pricing_plan: expected
       });
       cb();
     });
@@ -95,7 +91,6 @@ describe('abacus-pricing-config', () => {
       expect(err).to.equal(undefined);
       expect(val).to.deep.equal({
         error: true,
-        body: undefined,
         reason: 'Pricing config - pricing plan ' +
           'for the given plan id is not found'
       });
@@ -106,9 +101,7 @@ describe('abacus-pricing-config', () => {
     config.plan('test-get-plan', 'USA', undefined, (err, val) => {
       expect(err).to.equal(undefined);
       expect(val).to.deep.equal({
-        error: undefined,
-        body: expected,
-        reason: undefined
+        pricing_plan: expected
       });
       cb();
     });
@@ -126,9 +119,7 @@ describe('abacus-pricing-config', () => {
       (err, val) => {
         expect(err).to.equal(undefined);
         expect(val).to.deep.equal({
-          error: undefined,
-          body: 'test-pricing-basic',
-          reason: undefined
+          pricing_plan_id: 'test-pricing-basic'
         });
         cb();
       });
@@ -139,9 +130,7 @@ describe('abacus-pricing-config', () => {
       (err, val) => {
         expect(err).to.equal(undefined);
         expect(val).to.deep.equal({
-          error: undefined,
-          body: 'test-pricing-basic',
-          reason: undefined
+          pricing_plan_id: 'test-pricing-basic'
         });
         cb();
       });
@@ -152,9 +141,7 @@ describe('abacus-pricing-config', () => {
       'test-id', 1420070400000, undefined, (err, val) => {
         expect(err).to.equal(undefined);
         expect(val).to.deep.equal({
-          error: undefined,
-          body: 'test-id',
-          reason: undefined
+          pricing_plan_id: 'test-id'
         });
         cb();
       });

--- a/lib/config/pricing/src/test/test.js
+++ b/lib/config/pricing/src/test/test.js
@@ -71,27 +71,34 @@ describe('abacus-pricing-config', () => {
     // Retrieve a pricing plan
     config.plan('test-pricing-basic', 'USA', undefined, (err, val) => {
       expect(err).to.equal(undefined);
-      expect(val).to.deep.equal(expected);
+      expect(val).to.deep.equal({
+        error: undefined,
+        body: expected,
+        reason: undefined
+      });
       cb();
     });
 
     // Retrieve it again, this time it should be returned from the cache
     config.plan('test-pricing-basic', 'USA', undefined, (err, val) => {
       expect(err).to.equal(undefined);
-      expect(val).to.deep.equal(expected);
+      expect(val).to.deep.equal({
+        error: undefined,
+        body: expected,
+        reason: undefined
+      });
       cb();
     });
 
     // Config not found
     config.plan('notFound', 'USA', undefined, (err, val) => {
-      expect(err).to.deep.equal({
-        statusCode: 404,
-        body: 'not found',
-        headers: {
-          'www-authenticate': 'test'
-        }
+      expect(err).to.equal(undefined);
+      expect(val).to.deep.equal({
+        error: true,
+        body: undefined,
+        reason: 'Pricing config - pricing plan ' +
+          'for the given plan id is not found'
       });
-      expect(val).to.equal(undefined);
       cb();
     });
 
@@ -99,12 +106,9 @@ describe('abacus-pricing-config', () => {
     config.plan('test-get-plan', 'USA', undefined, (err, val) => {
       expect(err).to.equal(undefined);
       expect(val).to.deep.equal({
-        metrics: [
-          { name: 'storage', price: 1 },
-          { name: 'thousand_light_api_calls', price: 0.03 },
-          { name: 'heavy_api_calls', price: 0.15 },
-          { name: 'memory', price: 0.00014 }
-        ]
+        error: undefined,
+        body: expected,
+        reason: undefined
       });
       cb();
     });
@@ -121,7 +125,11 @@ describe('abacus-pricing-config', () => {
       'test-resource', 'test-plan', 1420070400000, undefined,
       (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val).to.equal('test-pricing-basic');
+        expect(val).to.deep.equal({
+          error: undefined,
+          body: 'test-pricing-basic',
+          reason: undefined
+        });
         cb();
       });
 
@@ -130,7 +138,11 @@ describe('abacus-pricing-config', () => {
       'test-resource', 'test-plan', 1420070400000, undefined,
       (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val).to.equal('test-pricing-basic');
+        expect(val).to.deep.equal({
+          error: undefined,
+          body: 'test-pricing-basic',
+          reason: undefined
+        });
         cb();
       });
 
@@ -139,7 +151,11 @@ describe('abacus-pricing-config', () => {
       'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', 'test-id',
       'test-id', 1420070400000, undefined, (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val).to.equal('test-id');
+        expect(val).to.deep.equal({
+          error: undefined,
+          body: 'test-id',
+          reason: undefined
+        });
         cb();
       });
   });

--- a/lib/config/rating/src/index.js
+++ b/lib/config/rating/src/index.js
@@ -74,10 +74,9 @@ const cache = (k, p) => {
 const cached = (k) => plans.get(k);
 
 // Business response object
-const businessResponse = (error, response) => ({
-  error: error,
-  body: !error ? response : undefined,
-  reason: error ? response : undefined
+const businessError = (reason) => ({
+  error: true,
+  reason: reason
 })
 
 // Retrieve the specified rating plan
@@ -152,7 +151,7 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
   if(!rtype) {
     debug('Undefined resource type');
     return cb(undefined,
-      businessResponse(true, 'Rating config - Undefined resource type'));
+      businessError('Rating config - Undefined resource type'));
   }
 
   // Round time to a 10 min boundary
@@ -163,13 +162,16 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
   const c = cachedId(k);
   if(c) {
     debug('Rating plan id for %s found in cache', k);
-    return cb(undefined, businessResponse(undefined, c));
+    return cb(undefined, {
+      rating_plan_id: c
+    });
   }
 
   // Lookup test plan ids
   if (rtype === 'test-resource')
-    return cb(undefined, businessResponse(undefined, cacheId(k,
-      require('./test/test-rating-plan').plan_id)));
+    return cb(undefined, {
+      rating_plan_id: cacheId(k, require('./test/test-rating-plan').plan_id)
+    });
 
   // Forward authorization header field to account plugin
   const o = auth ? { headers: { authorization: auth } } : {};
@@ -195,12 +197,14 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
           val.statusCode, val.body || '');
 
         // Throw response object as an exception to stop further processing.
-        return cb(undefined, businessResponse(true,
+        return cb(undefined, businessError(
           'Rating config - Unable to retrieve rating plan id'));;
       }
 
       // Return the rating plan id
-      return cb(undefined, businessResponse(undefined, cacheId(k, val.body)));
+      return cb(undefined, {
+        rating_plan_id: cacheId(k, val.body)
+      });
     });
 };
 

--- a/lib/config/rating/src/index.js
+++ b/lib/config/rating/src/index.js
@@ -73,6 +73,13 @@ const cache = (k, p) => {
 // Return a rating plan from the cache
 const cached = (k) => plans.get(k);
 
+// Business response object
+const businessResponse = (error, response) => ({
+  error: error,
+  body: !error ? response : undefined,
+  reason: error ? response : undefined
+})
+
 // Retrieve the specified rating plan
 const plan = (rpid, auth, cb) => {
   lock(rpid, (err, unlock) => {
@@ -142,6 +149,11 @@ const cachedId = (k) => ids.get(k);
 // resource type, provisioning plan and time
 const id = (oid, rtype, ppid, time, auth, cb) => {
   debug('Retrieving rating plan id');
+  if(!rtype) {
+    debug('Undefined resource type');
+    return cb(undefined,
+      businessResponse(true, 'Rating config - Undefined resource type'));
+  }
 
   // Round time to a 10 min boundary
   const t = Math.floor(time / 600000) * 600000;
@@ -151,13 +163,13 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
   const c = cachedId(k);
   if(c) {
     debug('Rating plan id for %s found in cache', k);
-    return cb(undefined, c);
+    return cb(undefined, businessResponse(undefined, c));
   }
 
   // Lookup test plan ids
   if (rtype === 'test-resource')
-    return cb(undefined, cacheId(k,
-      require('./test/test-rating-plan').plan_id));
+    return cb(undefined, businessResponse(undefined, cacheId(k,
+      require('./test/test-rating-plan').plan_id)));
 
   // Forward authorization header field to account plugin
   const o = auth ? { headers: { authorization: auth } } : {};
@@ -183,11 +195,12 @@ const id = (oid, rtype, ppid, time, auth, cb) => {
           val.statusCode, val.body || '');
 
         // Throw response object as an exception to stop further processing.
-        throw val;
+        return cb(undefined, businessResponse(true,
+          'Rating config - Unable to retrieve rating plan id'));;
       }
 
       // Return the rating plan id
-      return cb(undefined, cacheId(k, val.body));
+      return cb(undefined, businessResponse(undefined, cacheId(k, val.body)));
     });
 };
 

--- a/lib/config/rating/src/test/test.js
+++ b/lib/config/rating/src/test/test.js
@@ -92,7 +92,11 @@ describe('abacus-rating-config', () => {
     config.id('test-org', 'test-resource', 'test-plan', 0, undefined,
       (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val).to.equal('test-rating-plan');
+        expect(val).to.deep.equal({
+          error: undefined,
+          body: 'test-rating-plan',
+          reason: undefined
+        });
         cb();
       });
 
@@ -100,7 +104,11 @@ describe('abacus-rating-config', () => {
     config.id('test-org', 'test-resource', 'test-plan', 0, undefined,
       (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val).to.equal('test-rating-plan');
+        expect(val).to.deep.equal({
+          error: undefined,
+          body: 'test-rating-plan',
+          reason: undefined
+        });
         cb();
       });
 
@@ -108,7 +116,48 @@ describe('abacus-rating-config', () => {
     config.id('test-org', 'test-id', 'test-id', 0, undefined,
       (err, val) => {
         expect(err).to.equal(undefined);
-        expect(val).to.equal('test-id');
+        expect(val).to.deep.equal({
+          error: undefined,
+          body: 'test-id',
+          reason: undefined
+        });
+        cb();
+      });
+  });
+
+  it('returns with the appropriate error flag and reason', (done) => {
+    let cbs = 0;
+    const cb = () => {
+      if (++cbs === 2) done();
+    };
+
+    // Mock request to simulate business error
+    getspy = (reqs, cb) =>
+      cb(null, [[undefined, { statusCode: 404, body: 'Not found' }]]);
+
+    // When resource type is undefined
+    config.id(
+      'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', undefined,
+      'test-plan', 1420070400000, undefined, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val).to.deep.equal({
+          error: true,
+          body: undefined,
+          reason: 'Rating config - Undefined resource type'
+        });
+        cb();
+      });
+ 
+    // When the plan id does not map to a plan
+    config.id(
+      'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', 'InvalidResourceType',
+      'test-plan', 1420070400000, undefined, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val).to.deep.equal({
+          error: true,
+          body: undefined,
+          reason: 'Rating config - Unable to retrieve rating plan id'
+        });
         cb();
       });
   });

--- a/lib/config/rating/src/test/test.js
+++ b/lib/config/rating/src/test/test.js
@@ -93,9 +93,7 @@ describe('abacus-rating-config', () => {
       (err, val) => {
         expect(err).to.equal(undefined);
         expect(val).to.deep.equal({
-          error: undefined,
-          body: 'test-rating-plan',
-          reason: undefined
+          rating_plan_id: 'test-rating-plan'
         });
         cb();
       });
@@ -105,9 +103,7 @@ describe('abacus-rating-config', () => {
       (err, val) => {
         expect(err).to.equal(undefined);
         expect(val).to.deep.equal({
-          error: undefined,
-          body: 'test-rating-plan',
-          reason: undefined
+          rating_plan_id: 'test-rating-plan'
         });
         cb();
       });
@@ -117,9 +113,7 @@ describe('abacus-rating-config', () => {
       (err, val) => {
         expect(err).to.equal(undefined);
         expect(val).to.deep.equal({
-          error: undefined,
-          body: 'test-id',
-          reason: undefined
+          rating_plan_id: 'test-id'
         });
         cb();
       });
@@ -142,7 +136,6 @@ describe('abacus-rating-config', () => {
         expect(err).to.equal(undefined);
         expect(val).to.deep.equal({
           error: true,
-          body: undefined,
           reason: 'Rating config - Undefined resource type'
         });
         cb();
@@ -155,7 +148,6 @@ describe('abacus-rating-config', () => {
         expect(err).to.equal(undefined);
         expect(val).to.deep.equal({
           error: true,
-          body: undefined,
           reason: 'Rating config - Unable to retrieve rating plan id'
         });
         cb();

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -85,10 +85,9 @@ const otimes = (udoc, itime) =>
   [map([udoc.end, udoc.start], seqid.pad16).concat([itime]).join('/')];
 
 // Business response object
-const businessResponse = (error, response) => ({
-  error: error,
-  body: !error ? response : undefined,
-  reason: error ? response : undefined
+const businessError = (reason) => ({
+  error: true,
+  reason: reason
 });
 
 // Retrieve resource type given the resource id, and attach it to u
@@ -110,12 +109,13 @@ const getResourceType = function *(rid, auth) {
     debug('Unable to retrieve resource type, %o', res);
 
     // Return with the reason of the error
-    return businessResponse(true,
-      'Collector - Unable to retrieve resource type');
+    return businessError('Collector - Unable to retrieve resource type');
   }
 
   // Return the resource_type
-  return businessResponse(undefined, res.body);
+  return {
+    resource_type: res.body
+  };
 };
 
 // Maintain a cache of accounts
@@ -143,7 +143,9 @@ const getAccount = function *(oid, time, auth) {
   const ac = cachedAccount(k);
   if (ac) {
     debug('Accont information found in the cache');
-    return businessResponse(undefined, ac);
+    return {
+      account: ac
+    };
   }
 
   const o = auth ? { headers: { authorization: auth } } : {};
@@ -162,13 +164,13 @@ const getAccount = function *(oid, time, auth) {
     debug('Unable to retrieve account information, %o', res);
 
     // Return with the reason of the error
-    return businessResponse(true,
-      'Collector - Unable to retrieve account info');
+    return businessError('Collector - Unable to retrieve account info');
   }
 
   // cache and returns Return the account_id and the pricing_country
-  return businessResponse(undefined, cacheAccount(k,
-    pick(res.body, 'account_id', 'pricing_country')));
+  return {
+    account: cacheAccount(k, pick(res.body, 'account_id', 'pricing_country'))
+  };
 };
 
 // Return the metering_plan_id
@@ -202,13 +204,13 @@ const normalizeDoc = (u, info) => {
       return reason;
     })
   } : {
-    resource_type: info[0].body,
-    account_id: info[1].body.account_id,
-    pricing_country: info[1].body.pricing_country,
-    metering_plan_id: info[2].body,
-    rating_plan_id: info[3].body,
-    pricing_plan_id: info[4].body,
-    prices: info[5].body
+    resource_type: info[0].resource_type,
+    account_id: info[1].account.account_id,
+    pricing_country: info[1].account.pricing_country,
+    metering_plan_id: info[2].metering_plan_id,
+    rating_plan_id: info[3].rating_plan_id,
+    pricing_plan_id: info[4].pricing_plan_id,
+    prices: info[5].pricing_plan
   });
 };
 
@@ -247,15 +249,18 @@ const normalizeUsage = function *(udoc, auth) {
 
   // Get account information and plan ids
   const [mpid, rpid, ppid] = yield [
-    meteringId(udoc.organization_id, rt.body, udoc.plan_id, udoc.end, auth),
-    ratingId(udoc.organization_id, rt.body, udoc.plan_id, udoc.end, auth),
-    pricingId(udoc.organization_id, rt.body, udoc.plan_id, udoc.end, auth)
+    meteringId(udoc.organization_id, rt.resource_type, udoc.plan_id,
+      udoc.end, auth),
+    ratingId(udoc.organization_id, rt.resource_type, udoc.plan_id,
+      udoc.end, auth),
+    pricingId(udoc.organization_id, rt.resource_type, udoc.plan_id,
+      udoc.end, auth)
   ];
 
   // Get the usage prices in the account's pricing country
-  const prices = yield pricingPlan(ppid.body,
-    !account.error && account.body.pricing_country, auth);
-  
+  const prices = yield pricingPlan(ppid.pricing_plan_id,
+    !account.error && account.account.pricing_country, auth);
+
   // Extend the submitted usage with the additional information we've
   // collected
   const nudoc = normalizeDoc(udoc, [rt, account, mpid, rpid, ppid, prices]);

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -24,6 +24,7 @@ const seqid = require('abacus-seqid');
 const map = _.map;
 const extend = _.extend;
 const pick = _.pick;
+const filter = _.filter;
 
 const brequest = yieldable(retry(breaker(batch(request))));
 
@@ -81,7 +82,14 @@ const okeys = (udoc, ikey) =>
     udoc.consumer_id || 'UNKNOWN', udoc.plan_id].join('/')];
 
 const otimes = (udoc, itime) =>
-    [map([udoc.end, udoc.start], seqid.pad16).concat([itime]).join('/')];
+  [map([udoc.end, udoc.start], seqid.pad16).concat([itime]).join('/')];
+
+// Business response object
+const businessResponse = (error, response) => ({
+  error: error,
+  body: !error ? response : undefined,
+  reason: error ? response : undefined
+});
 
 // Retrieve resource type given the resource id, and attach it to u
 const getResourceType = function *(rid, auth) {
@@ -101,12 +109,13 @@ const getResourceType = function *(rid, auth) {
     edebug('Unable to retrieve resource type, %o', res);
     debug('Unable to retrieve resource type, %o', res);
 
-    // Throw response object as an exception to stop further processing
-    throw res;
+    // Return with the reason of the error
+    return businessResponse(true,
+      'Collector - Unable to retrieve resource type');
   }
 
   // Return the resource_type
-  return res.body;
+  return businessResponse(undefined, res.body);
 };
 
 // Maintain a cache of accounts
@@ -132,8 +141,10 @@ const getAccount = function *(oid, time, auth) {
 
   // Look in our cache first
   const ac = cachedAccount(k);
-  if (ac)
-    return ac;
+  if (ac) {
+    debug('Accont information found in the cache');
+    return businessResponse(undefined, ac);
+  }
 
   const o = auth ? { headers: { authorization: auth } } : {};
 
@@ -150,13 +161,14 @@ const getAccount = function *(oid, time, auth) {
     edebug('Unable to retrieve account information, %o', res);
     debug('Unable to retrieve account information, %o', res);
 
-    // Throw response object as an exception to stop further processing
-    throw res;
+    // Return with the reason of the error
+    return businessResponse(true,
+      'Collector - Unable to retrieve account info');
   }
 
   // cache and returns Return the account_id and the pricing_country
-  return cacheAccount(k,
-    pick(res.body, 'account_id', 'pricing_country'));
+  return businessResponse(undefined, cacheAccount(k,
+    pick(res.body, 'account_id', 'pricing_country')));
 };
 
 // Return the metering_plan_id
@@ -190,9 +202,9 @@ const normalizeDoc = (u, info) => {
       return reason;
     })
   } : {
-    resource_type: info[0],
-    account_id: info[1].account_id,
-    pricing_country: info[1].pricing_country,
+    resource_type: info[0].body,
+    account_id: info[1].body.account_id,
+    pricing_country: info[1].body.pricing_country,
     metering_plan_id: info[2].body,
     rating_plan_id: info[3].body,
     pricing_plan_id: info[4].body,
@@ -235,14 +247,14 @@ const normalizeUsage = function *(udoc, auth) {
 
   // Get account information and plan ids
   const [mpid, rpid, ppid] = yield [
-    meteringId(udoc.organization_id, rt, udoc.plan_id, udoc.end, auth),
-    ratingId(udoc.organization_id, rt, udoc.plan_id, udoc.end, auth),
-    pricingId(udoc.organization_id, rt, udoc.plan_id, udoc.end, auth)
+    meteringId(udoc.organization_id, rt.body, udoc.plan_id, udoc.end, auth),
+    ratingId(udoc.organization_id, rt.body, udoc.plan_id, udoc.end, auth),
+    pricingId(udoc.organization_id, rt.body, udoc.plan_id, udoc.end, auth)
   ];
 
   // Get the usage prices in the account's pricing country
   const prices = yield pricingPlan(ppid.body,
-    account.pricing_country, auth);
+    !account.error && account.body.pricing_country, auth);
   
   // Extend the submitted usage with the additional information we've
   // collected
@@ -320,4 +332,6 @@ const runCLI = () => {
 
 // Export our public functions
 module.exports = collector;
+module.exports.account = getAccount;
+module.exports.resourceType = getResourceType;
 module.exports.runCLI = runCLI;

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -171,6 +171,35 @@ const pricingId = yieldable(pconfig.id);
 // Return the pricing plan
 const pricingPlan = yieldable(pconfig);
 
+// Extend the submitted usage with the additional information we've
+// collected or flag usage doc with error and reasons to redirect 
+// usage to error db and stop processing it to the next pipeline.
+const normalizeDoc = (u, info) => {
+  let e;
+
+  // Go through each information and create list of error reasons
+  const reasons = map(info, (i) => {
+    e = e || i.error;
+    return i.reason;
+  });
+
+  // Attachees error flag and list of reasons
+  return extend({}, u, e ? {
+    error: true,
+    reason: filter(reasons, (reason) => {
+      return reason;
+    })
+  } : {
+    resource_type: info[0],
+    account_id: info[1].account_id,
+    pricing_country: info[1].pricing_country,
+    metering_plan_id: info[2].body,
+    rating_plan_id: info[3],
+    pricing_plan_id: info[4],
+    prices: info[5]
+  });
+};
+
 // Map submitted usage doc to normalized usage doc
 const normalizeUsage = function *(udoc, auth) {
   debug('Normalizing usage %o', udoc);
@@ -216,15 +245,7 @@ const normalizeUsage = function *(udoc, auth) {
   
   // Extend the submitted usage with the additional information we've
   // collected
-  const nudoc = extend({}, udoc, {
-    resource_type: rt,
-    account_id: account.account_id,
-    pricing_country: account.pricing_country,
-    metering_plan_id: mpid,
-    rating_plan_id: rpid,
-    pricing_plan_id: ppid,
-    prices: prices
-  });
+  const nudoc = normalizeDoc(udoc, [rt, account, mpid, rpid, ppid, prices]);
 
   // Return the normalized usage doc
   return [nudoc];

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -195,8 +195,8 @@ const normalizeDoc = (u, info) => {
     pricing_country: info[1].pricing_country,
     metering_plan_id: info[2].body,
     rating_plan_id: info[3].body,
-    pricing_plan_id: info[4],
-    prices: info[5]
+    pricing_plan_id: info[4].body,
+    prices: info[5].body
   });
 };
 
@@ -241,7 +241,8 @@ const normalizeUsage = function *(udoc, auth) {
   ];
 
   // Get the usage prices in the account's pricing country
-  const prices = yield pricingPlan(ppid, account.pricing_country, auth);
+  const prices = yield pricingPlan(ppid.body,
+    account.pricing_country, auth);
   
   // Extend the submitted usage with the additional information we've
   // collected

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -194,7 +194,7 @@ const normalizeDoc = (u, info) => {
     account_id: info[1].account_id,
     pricing_country: info[1].pricing_country,
     metering_plan_id: info[2].body,
-    rating_plan_id: info[3],
+    rating_plan_id: info[3].body,
     pricing_plan_id: info[4],
     prices: info[5]
   });

--- a/lib/metering/collector/src/test/test.js
+++ b/lib/metering/collector/src/test/test.js
@@ -7,6 +7,7 @@ const request = require('abacus-request');
 const batch = require('abacus-batch');
 const cluster = require('abacus-cluster');
 const oauth = require('abacus-oauth');
+const yieldable = require('abacus-yieldable');
 
 const omit = _.omit;
 const extend = _.extend;
@@ -225,5 +226,247 @@ describe('abacus-usage-collector', () => {
 
     // Verify without and with security
     verify(false, () => verify(true, done));
+  });
+
+  it('reports reason of business errors', (done) => {
+    const usage = {
+      start: 1420243200000,
+      end: 1420245000000,
+      organization_id: 'invalidOrg',
+      space_id: 'invalidSpace',
+      consumer_id: 'invalidConsumer',
+      resource_id: 'test-resource',
+      plan_id: 'invalidPlan',
+      resource_instance_id: 'invalidResourceInstance',
+      measured_usage: [{
+        measure: 'light_api_calls',
+        quantity: 12
+      }]
+    };
+
+    // Create a test collector app
+    const app = collector();
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    // Handle callback checks
+    let checks = 0;
+    const check = () => {
+      if(++checks == 4) done();
+    };
+
+    getspy = (reqs, cb) => {
+      // Expect a call to the provisioning service's validate
+      // Returns 200 so we can get into failure management
+      if(reqs[0][0] === 
+        'http://localhost:9880/v1/provisioning/organizations/' +
+        ':organization_id/spaces/:space_id/consumers/:consumer_id/' +
+        'resources/:resource_id/plans/:plan_id/instances/' +
+        ':resource_instance_id/:time') {
+        expect(omit(reqs[0][1],
+          'id', 'processed', 'processed_id')).to.deep.equal(
+          extend({}, usage, {
+            time: usage.end
+          }));
+        cb(undefined, [[undefined, {
+          statusCode: 200
+        }]]);
+        check();
+      }
+      // Expect a call to the provisioning service's get resource type
+      if(reqs[0][0] === 'http://localhost:9880/v1/provisioning/' +
+        'resources/:resource_id/type') {
+        expect(reqs[0][1]).to.deep.equal({
+          resource_id: usage.resource_id,
+          cache: true
+        });
+        // The second call to account is cached
+        expect(reqs[1][0]).to.equal('http://localhost:9881/v1/' +
+          'organizations/:org_id/account/:time');
+        expect(reqs[1][1]).to.deep.equal(extend({}, {
+          org_id: usage.organization_id,
+          time: usage.end
+        }));
+        cb(undefined, [[undefined, {
+          statusCode: 200,
+          body: 'test-resource'
+        }], [undefined, {
+          statusCode: 404
+        }]]);
+        check();
+      }
+    };
+
+    postspy = (reqs, cb) => {
+      // Expect usage to be posted to the meter service
+      expect(reqs[0][0]).to.equal(
+        'http://localhost:9100/v1/metering/normalized/usage');
+      // Error due to no account info and no pricing country.
+      expect(omit(reqs[0][1].body,
+        'id', 'processed', 'processed_id', 'collected_usage_id'))
+        .to.deep.equal(extend({}, usage, {
+          error: true,
+          reason: [
+            'Collector - Unable to retrieve account info',
+            'Pricing config - Undefined pricing plan id / country'
+          ]
+        }));
+      cb(undefined, [[undefined, {
+        statusCode: 201
+      }]]);
+      check();
+    };
+
+    // Post usage for a resource, expecting a 201 response
+    request.post('http://localhost::p/v1/metering/collected/usage', {
+      p: server.address().port,
+      body: usage
+    }, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val.statusCode).to.equal(201);
+
+      // Get usage, expecting what we posted
+      brequest.get(val.headers.location, {}, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(omit(val.body, 'id', 'processed', 'processed_id'))
+        .to.deep.equal(usage);
+
+        check();
+      });
+    });
+  });
+
+  it('calls account plugin to get account information', (done) => {
+    let cbs = 0;
+    const cb = () => {
+      if (++cbs === 1) done();
+    };
+
+    const sampleAccount = {
+      account_id: '1234',
+      organizations: ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27'],
+      pricing_country: 'USA'
+    };
+    getspy = (reqs, cb) => {
+      expect(reqs[cbs][0]).to.equal(
+        'http://localhost:9881/v1/organizations/:org_id/account/:time');
+      expect(reqs[cbs][1]).to.deep.equal({
+        org_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+        time: 1420070400000
+      })
+      cb(undefined, [[null, { statusCode: 200, body: sampleAccount }]])
+    }
+
+    const getAccount = yieldable.functioncb(collector.account);
+    
+    // Retrieve account information
+    getAccount('a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', 1420070400000, undefined,
+      (err, val) => {
+        expect(err).to.equal(null);
+        expect(val).to.deep.equal({
+          error: undefined,
+          body: {
+            account_id: '1234',
+            pricing_country: 'USA'
+          },
+          reason: undefined
+        });
+        cb();
+      });
+
+    // Retrieve it again, this time it should be returned from the cache
+    getAccount('a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', 1420070400000, undefined,
+      (err, val) => {
+        expect(err).to.equal(null);
+        expect(val).to.deep.equal({
+          error: undefined,
+          body: {
+            account_id: '1234',
+            pricing_country: 'USA'
+          },
+          reason: undefined
+        });
+        cb();
+      });
+  });
+
+  it('responses with the appropriate account error flag and reason', (done) => {
+    getspy = (reqs, cb) => {
+      expect(reqs[0][0]).to.equal(
+        'http://localhost:9881/v1/organizations/:org_id/account/:time');
+      expect(reqs[0][1]).to.deep.equal({
+        org_id: 'invalidOrg',
+        time: 1420070400000
+      })
+      cb(undefined, [[null, { statusCode: 404, body: 'Not found' }]])
+    }
+
+    const getAccount = yieldable.functioncb(collector.account);
+    
+    // Retrieve account information
+    getAccount('invalidOrg', 1420070400000, undefined,
+      (err, val) => {
+        expect(err).to.equal(null);
+        expect(val).to.deep.equal({
+          error: true,
+          body: undefined,
+          reason: 'Collector - Unable to retrieve account info'
+        });
+        done();
+      });
+  });
+
+  it('calls provision plugin to get resource type', (done) => {
+    getspy = (reqs, cb) => {
+      expect(reqs[0][0]).to.equal(
+        'http://localhost:9880/v1/provisioning/resources/:resource_id/type');
+      expect(reqs[0][1]).to.deep.equal({
+        cache: true,
+        resource_id: 'test-resourceId'
+      })
+      cb(undefined, [[null, { statusCode: 200, body: 'test-resourceType' }]])
+    }
+
+    const getResType = yieldable.functioncb(collector.resourceType);
+    
+    // Retrieve account information
+    getResType('test-resourceId', undefined,
+      (err, val) => {
+        expect(err).to.equal(null);
+        expect(val).to.deep.equal({
+          error: undefined,
+          body: 'test-resourceType',
+          reason: undefined
+        });
+        done();
+      });
+  });
+
+  it('responses with resource type error flag and reason', (done) => {
+    getspy = (reqs, cb) => {
+      expect(reqs[0][0]).to.equal(
+        'http://localhost:9880/v1/provisioning/resources/:resource_id/type');
+      expect(reqs[0][1]).to.deep.equal({
+        cache: true,
+        resource_id: 'invalidId'
+      })
+      cb(undefined, [[null, { statusCode: 404, body: 'Not found' }]])
+    }
+
+    const getResType = yieldable.functioncb(collector.resourceType);
+    
+    // Retrieve account information
+    getResType('invalidId', undefined,
+      (err, val) => {
+        expect(err).to.equal(null);
+        expect(val).to.deep.equal({
+          error: true,
+          body: undefined,
+          reason: 'Collector - Unable to retrieve resource type'
+        });
+        done();
+      });
   });
 });

--- a/lib/metering/collector/src/test/test.js
+++ b/lib/metering/collector/src/test/test.js
@@ -366,12 +366,10 @@ describe('abacus-usage-collector', () => {
       (err, val) => {
         expect(err).to.equal(null);
         expect(val).to.deep.equal({
-          error: undefined,
-          body: {
+          account: {
             account_id: '1234',
             pricing_country: 'USA'
-          },
-          reason: undefined
+          }
         });
         cb();
       });
@@ -381,12 +379,10 @@ describe('abacus-usage-collector', () => {
       (err, val) => {
         expect(err).to.equal(null);
         expect(val).to.deep.equal({
-          error: undefined,
-          body: {
+          account: {
             account_id: '1234',
             pricing_country: 'USA'
-          },
-          reason: undefined
+          }
         });
         cb();
       });
@@ -411,7 +407,6 @@ describe('abacus-usage-collector', () => {
         expect(err).to.equal(null);
         expect(val).to.deep.equal({
           error: true,
-          body: undefined,
           reason: 'Collector - Unable to retrieve account info'
         });
         done();
@@ -436,9 +431,7 @@ describe('abacus-usage-collector', () => {
       (err, val) => {
         expect(err).to.equal(null);
         expect(val).to.deep.equal({
-          error: undefined,
-          body: 'test-resourceType',
-          reason: undefined
+          resource_type: 'test-resourceType'
         });
         done();
       });
@@ -463,7 +456,6 @@ describe('abacus-usage-collector', () => {
         expect(err).to.equal(null);
         expect(val).to.deep.equal({
           error: true,
-          body: undefined,
           reason: 'Collector - Unable to retrieve resource type'
         });
         done();


### PR DESCRIPTION
This changes include changes to collector, metering, rating, and pricing configs.
The summary of the changes is that instead of returning a value, we're returning a business response object.

For example:
Getting metering plan id: Instead of returning 'sample_plan_id' we are returning 
```javascript
{
  error: undefined,
  body: 'sample_plan_id',
  reason: undefined
}
```

In the case that there is an error, instead of throwing an error, we are returning:
```javascript
{
  error: true,
  body: undefined,
  reason: 'metering plan id not found'
}
```

Collector will go through each business responses and make sure that there is no error. When there are error(s), collector will add two fields to the usage doc:
```javascript
{
  error: true,
  reasons: ['account not found', 'metering plan id not found']
}
```

The reason for adding the two fields is so that dataflow would be able to handle the business errors that happen (example: redirect docs with error to an error db). The changes to dataflow is not yet there, but I want to get feedback before making the changes to the dataflow, hence the pull request.

Any feedback would be appreciated. Thanks!
