### PR TITLE
Added fail event management to dataflow's mapper.

### DIFF
--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -280,11 +280,17 @@ const postError = (oid, res) => {
 // Build a list of output docs
 const buildOutputs = (itype, idoc, otype, odocs, okeys, otimes, now) => {
   return map(odocs, (odoc, i, l) => {
-    return extend({},
+    // Return doc or error doc
+    return !odoc.error ? extend({},
       odoc,
       idoc.id ? object([[idname(itype), idoc.id]]) : {}, {
         id: dbclient.kturi(okeys[i], otimes[i]),
         processed_id: seqid.pad16(seqid()),
+        processed: now
+      }) : extend({},
+      odoc,
+      idoc.id ? object([[idname(itype), idoc.id]]) : {}, {
+        id: [idoc.id, i].join('/'),
         processed: now
       });
   });
@@ -323,9 +329,18 @@ const postOutput = function *(odoc,
 const postOutputs = function *(odocs,
   shost, spartition, spost, authentication) {
   yield tmap(odocs, function *(odoc, i, l) {
-    return yield postOutput(odoc, shost, spartition, spost, authentication);
+    // Only post docs with no error.
+    if(!odoc.error)
+      yield postOutput(odoc, shost, spartition, spost, authentication);
   });
 };
+
+// Log an error doc
+const logError = function *(edoc, edb) {
+  debug('Logging error doc %s', edoc.id);
+  yield edb.put(edoc);
+  debug('Logged error doc %o', edoc);
+}
 
 // Log an output doc
 const logOutput = function *(odoc, odb) {
@@ -335,10 +350,13 @@ const logOutput = function *(odoc, odb) {
 };
 
 // Log a list of output docs
-const logOutputs = function *(odocs, odb) {
+const logOutputs = function *(odocs, odb, edb) {
   yield tmap(odocs.concat([]).reverse(), function *(odoc, i, l) {
     // Log each doc into the output database
-    yield logOutput(odoc, odb);
+    if(odoc.error && edb)
+      yield logError(odoc, edb);
+    else if(!odoc.error)
+      yield logOutput(odoc, odb);
   });
 };
 
@@ -360,12 +378,24 @@ const db = (dbname, dbh) => !dbname ? undefined :
   yieldable(throttle(retry(breaker(batch(
     (dbh || dbhandle)(uris().db, dbname), 20, 100, dbcsize)))));
 
+// Return error db
+const errordb = (config) => !config ? undefined :
+  db(config.dbname, config.dbhandle);
+
+// Return the current month
+const currentMonth = (t) => {
+  const d = new Date(parseInt(t));
+  const m = (d.getUTCFullYear() - 1970) * 12 + d.getUTCMonth();
+  return Date.UTC(1970 + Math.floor(m / 12), m % 12, 1) + 1;
+};
+
 // Return an Express router that provides a REST API to a dataflow map
 // transform service
 const mapper = (mapfn, opt) => {
   // Configure dbs for input and output docs
   const idb = db(opt.input.dbname, opt.input.dbhandle);
   const odb = db(opt.output.dbname, opt.output.dbhandle);
+  const edb = errordb(opt.error);
 
   // Create a duplicate doc filter
   const ddup =
@@ -380,7 +410,7 @@ const mapper = (mapfn, opt) => {
 
   // Map an input doc to an output doc, store both the input and output and
   // pass the output to the configured sink service
-  /* eslint complexity: [1, 6] */
+  /* eslint complexity: [1, 9] */
   const play = function *(req, idoc) {
     debug('Mapping input doc %o', idoc);
 
@@ -446,7 +476,7 @@ const mapper = (mapfn, opt) => {
 
       // Log the output docs
       if(odb)
-        yield logOutputs(podocs, odb);
+        yield logOutputs(podocs, odb, edb);
 
       // Add leaf output doc id to duplicate filter
       if(ddup)
@@ -468,7 +498,6 @@ const mapper = (mapfn, opt) => {
   // Handle an input doc post, map it to an output doc, store both the
   // input and output and pass the output to the configured sink service
   routes.post(opt.input.post, throttle(function *(req) {
-
     // Process the input doc
     return yield play(req, req.body);
   }));
@@ -520,6 +549,29 @@ const mapper = (mapfn, opt) => {
 
       return {
         body: dbclient.undbify(doc)
+      };
+    }));
+
+  // Retrieve error docs
+  if(opt.error && opt.error.get)
+    routes.get(opt.error.get, throttle(function *(req) {
+      const ts = map(filter(
+        pairs(req.params), (p) => /^t/.test(p[0])), (p) => p[1]).join('/');
+
+      debug('Retrieving error docs from beginning of the month to %s', ts);
+
+      // Get all error from beginning of month in descending order
+      const docs = yield edb.allDocs({
+        startkey: dbclient.tkuri('', ts + 'Z'),
+        endkey: dbclient.tkuri('', currentMonth(ts)),
+        descending: true,
+        include_docs: true
+      });
+
+      return {
+        body: map(docs.rows, (row) => {
+          return dbclient.undbify(row.doc)
+        })
       };
     }));
 
@@ -629,7 +681,7 @@ const reducer = (reducefn, opt) => {
 
   // Reduce an input doc to an output doc, store both the input and output
   // and pass the output to the configured sink service
-  /* eslint complexity: [1, 6] */
+  /* eslint complexity: [1, 7] */
   const play = function *(req, idoc) {
     debug('Reducing input doc %o', idoc);
 

--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -568,6 +568,11 @@ const mapper = (mapfn, opt) => {
         include_docs: true
       });
 
+      // Authorize using error read access
+      if (opt.error.rscope)
+        oauth.authorize(req.headers && req.headers.authorization,
+          opt.error.rscope(docs));
+
       return {
         body: map(docs.rows, (row) => {
           return dbclient.undbify(row.doc)

--- a/lib/utils/dataflow/src/test/test.js
+++ b/lib/utils/dataflow/src/test/test.js
@@ -51,13 +51,15 @@ describe('abacus-dataflow', () => {
 
     // Define a test map transform that computes the sum of a pair of
     // numbers
-    const sum = function *(doc, auth) {
+    const sumBelowEight = function *(doc, auth) {
       const res = {
         t: doc.t,
         x: doc.x,
         y: doc.y,
         val: doc.x + doc.y
       };
+      extend(res, res.val > 8 ? { error: true, reasons: ['x + y is > 8'] } :
+        {});
       return [res];
     };
 
@@ -72,7 +74,7 @@ describe('abacus-dataflow', () => {
     const otimes = (doc) => [doc.t];
 
     // Add a dataflow mapper middleware to our test app
-    const mapper = dataflow.mapper(sum, {
+    const mapper = dataflow.mapper(sumBelowEight, {
       input: {
         type: 'pair',
         schema: Pair,
@@ -91,6 +93,10 @@ describe('abacus-dataflow', () => {
         rscope: orscope,
         keys: okeys,
         times: otimes
+      },
+      error: {
+        get: '/v1/pairs/t/:t/k/:kx/:ky/error',
+        dbname: 'pairerror'
       },
       sink: {
         host: 'http://localhost:9081',
@@ -113,7 +119,7 @@ describe('abacus-dataflow', () => {
       // Handle callback checks
       let checks = 0;
       const check = () => {
-        if(++checks == 6) done();
+        if(++checks == 4) done();
       };
 
       // Expect output docs to be posted to the sink service
@@ -168,7 +174,10 @@ describe('abacus-dataflow', () => {
           auth: {
             bearer: 'test'
           },
-          body: idoc
+          body: i === 4 || i === 5 ? extend({}, idoc, {
+            error: true,
+            reasons: ['i is equal to 4 / 5']
+          }) : idoc
 
         }, (err, pval) => {
 
@@ -181,21 +190,40 @@ describe('abacus-dataflow', () => {
             return;
           }
 
-          // Expect a 201 result
-          expect(pval.statusCode).to.equal(201);
+          // Post to error db instead of output and sink
+          if(i === 4 || i === 5)
+            request.get(pval.headers.location + '/error', (err, val) => {
+              expect(err).to.equal(undefined);
+              expect(val.statusCode).to.equal(200);
 
-          // Get the input doc
-          request.get(pval.headers.location, {}, (err, val) => {
-            expect(err).to.equal(undefined);
-            expect(val.statusCode).to.equal(200);
-
-            expect(omit(val.body,
-              'id', 'processed', 'processed_id')).to.deep.equal(idoc);
-            expect(val.body.id).to.match(new RegExp(
-              't/00014.*-0-0-0/k/' + idoc.x + '/' + idoc.y));
-
-            cb();
-          });
+              expect(omit(val.body[0], 'id', 'processed', 'pair_id',
+                'processed_id')).to.deep.equal(extend({}, idoc, {
+                  val: idoc.x + idoc.y,
+                  reasons: ['x + y is > 8'],
+                  error: true
+                }));
+              expect(val.body[0].id).to.match(new RegExp(
+                't/00014.*-0-0-0/k/' + idoc.x + '/' + idoc.y));
+              expect(val.body.length).to.equal(i - 3);
+              return cb();
+            });
+          else {
+            // Expect a 201 result
+            expect(pval.statusCode).to.equal(201);
+  
+            // Get the input doc
+            request.get(pval.headers.location, {}, (err, val) => {
+              expect(err).to.equal(undefined);
+              expect(val.statusCode).to.equal(200);
+  
+              expect(omit(val.body,
+                'id', 'processed', 'processed_id')).to.deep.equal(idoc);
+              expect(val.body.id).to.match(new RegExp(
+                't/00014.*-0-0-0/k/' + idoc.x + '/' + idoc.y));
+  
+              return cb();
+            });
+          };
         });
       }, undefined, (err, res) => {
         expect(err).to.equal(undefined);

--- a/lib/utils/dataflow/src/test/test.js
+++ b/lib/utils/dataflow/src/test/test.js
@@ -70,6 +70,7 @@ describe('abacus-dataflow', () => {
     const ikey = (doc) => '' + doc.x + '/' + doc.y;
     const itime = (doc) => seqid();
     const orscope = (doc) => undefined;
+    const erscope = (doc) => undefined;
     const okeys = (doc) => ['' + doc.x + '/' + doc.y];
     const otimes = (doc) => [doc.t];
 
@@ -96,7 +97,8 @@ describe('abacus-dataflow', () => {
       },
       error: {
         get: '/v1/pairs/t/:t/k/:kx/:ky/error',
-        dbname: 'pairerror'
+        dbname: 'pairerror',
+        rscope: erscope
       },
       sink: {
         host: 'http://localhost:9081',


### PR DESCRIPTION
The dataflow's mapper will now redirects docs with 
``` javascript
{
  error: true
}
```
to the error db instead of to the sink and output db.

For discussion:

Identifying errors. Currently the way to identify business error is to make the map / reduce function attach error field.

The configuration of the dataflow mapper becomes: [test](https://github.com/cloudfoundry-incubator/cf-abacus/blob/76d6c7fa19249ab037cc9a52213942da1220e693/lib/utils/dataflow/src/test/test.js#L77-L106). 

The error doc's id is set to [idoc id/doc order](https://github.com/cloudfoundry-incubator/cf-abacus/blob/76d6c7fa19249ab037cc9a52213942da1220e693/lib/utils/dataflow/src/index.js#L290-L295). I'm not too sure how to get the error doc. I am currently setting it to the input doc id.

The error doc's get endpoint is getting [all error docs from beginning of the month to current time](https://github.com/cloudfoundry-incubator/cf-abacus/blob/76d6c7fa19249ab037cc9a52213942da1220e693/lib/utils/dataflow/src/index.js#L556-L576) in descending order. As an operator I want to see list of errors, which is why I decided to grab all errors.

Enhancement:
1. Add more endpoints that will allow operator to do more operations: example delete a doc after the operator fixes the issue, resubmit, or delete all.
2. Add fail event management to dataflow's groupReduce. I'm hesitant to add the error redirecting in reduce because let's say that a usage passed accumulator and fails at aggregator we will lose accuracy.

Any feedback would be appreciated. Thanks.

