### PR TITLE
Change abacus-timewindow to use moment.js for its manipulations

### DIFF
--- a/lib/utils/timewindow/README.md
+++ b/lib/utils/timewindow/README.md
@@ -23,24 +23,24 @@ in 4.
 
 ```javascript
 // Results in 4
-timewindow.monthWindowDiff(new Date(Date.UTC(2015, 8)),
-  new Date(Date.UTC(2016, 0)));
+timewindow.diff(new Date(Date.UTC(2015, 8)),
+  new Date(Date.UTC(2016, 0)), 'M');
 
 // Results in 6
-timewindow.dateWindowDiff(new Date(Date.UTC(2016, 0, 1)),
-  new Date(Date.UTC(2016, 0, 7)));
+timewindow.diff(new Date(Date.UTC(2016, 0, 1)),
+  new Date(Date.UTC(2016, 0, 7)), 'D');
 
 // Results in 13
-timewindow.hoursWindowDiff(new Date(Date.UTC(2016, 0, 1, 10)),
-  new Date(Date.UTC(2016, 0, 1, 23)));
+timewindow.diff(new Date(Date.UTC(2016, 0, 1, 10)),
+  new Date(Date.UTC(2016, 0, 1, 23)), 'h');
 
 // Results in 23
-timewindow.minutesWindowDiff(new Date(Date.UTC(2016, 0, 1, 0, 23)),
-  new Date(Date.UTC(2016, 0, 1, 0, 46)));
+timewindow.diff(new Date(Date.UTC(2016, 0, 1, 0, 23)),
+  new Date(Date.UTC(2016, 0, 1, 0, 46)), 'm');
 
 // Results in 35
-timewindow.secondsWindowDiff(new Date(Date.UTC(2016, 0, 1, 0, 0, 20)),
-  new Date(Date.UTC(2016, 0, 1, 0, 0, 55)));
+timewindow.diff(new Date(Date.UTC(2016, 0, 1, 0, 0, 20)),
+  new Date(Date.UTC(2016, 0, 1, 0, 0, 55)), 's');
 ```
 
 "Flattening" a date

--- a/lib/utils/timewindow/package.json
+++ b/lib/utils/timewindow/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "version": "0.0.5-rc.1",
   "private": true,
-  "homepage": "https://github.com/cloudfoundry-incubator/cf-abacus/lib/utils/clone",
+  "homepage": "https://github.com/cloudfoundry-incubator/cf-abacus/lib/utils/timewindow",
   "bugs": {
     "url": "https://github.com/cloudfoundry-incubator/cf-abacus/issues"
   },
@@ -31,6 +31,7 @@
   "dependencies": {
     "abacus-debug": "file:../debug",
     "babel-preset-es2015": "^6.6.0",
+    "moment": "^2.12.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/lib/utils/timewindow/src/index.js
+++ b/lib/utils/timewindow/src/index.js
@@ -1,95 +1,42 @@
 'use strict';
 
 // Utilities for time
+const moment = require('moment');
 const _ = require('underscore');
-
 const map = _.map;
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-timewindow');
 
-// Millisecond representation of higher time dimensions up to a day
-const dateInMilliseconds = 86400000;
-const hoursInMilliseconds = 3600000;
-const minutesInMilliseconds = 60000;
-const secondsInMilliseconds = 1000;
+// Mapping from time window shortcuts to moment.js shortcuts
+const shortcut = {
+  Y: 'y',
+  M: 'M',
+  D: 'd',
+  h: 'h',
+  m: 'm',
+  s: 's'
+};
 
-
-// Takes a Date object and returns an equivalent with all lower dimensions
-// of time specified zeroed out
+// Takes a Date or moment.js object and returns a Javascript Date equivalent
+// with all dimensions lower than the given one set to 0
 const zeroLowerTimeDimensions = (date, dim) => {
   debug('Zeroing out dimensions lower than %s on %s', dim, date);
-  const dims = {
-    M: 5,
-    D: 4,
-    h: 3,
-    m: 2,
-    s: 1
-  };
-  return new Date(Date.UTC.apply(null, [
-    date.getUTCFullYear(),
-    date.getUTCMonth(),
-    date.getUTCDate(),
-    date.getUTCHours(),
-    date.getUTCMinutes(),
-    date.getUTCSeconds(),
-    date.getUTCMilliseconds()
-  ].slice(0, 7 - (dims[dim] ? dims[dim] : 0))));
+  return moment.utc(date).startOf(shortcut[dim]).toDate();
 };
 
-// Returns the difference in months between the two times while ignoring
-// any lower dimension of time
-const monthWindowDiff = (date1, date2) => {
-  debug('Calculating month window diff between %s and %s', date1, date2);
-  return (date2.getUTCFullYear() - date1.getUTCFullYear()) * 12
-    - date1.getUTCMonth() + date2.getUTCMonth();
-};
-
-// Returns the difference in dates between the two times while ignoring
-// any lower dimension of time
-const dateWindowDiff = (date1, date2) => {
-  debug('Calculating date window diff between %s and %s', date1, date2);
-  return (zeroLowerTimeDimensions(date2, 'D')
-    - zeroLowerTimeDimensions(date1, 'D')) / dateInMilliseconds;
-};
-
-// Returns the difference in dates between the two times while ignoring
-// any lower dimension of time
-const hoursWindowDiff = (date1, date2) => {
-  debug('Calculating hours window diff between %s and %s', date1, date2);
-  return (zeroLowerTimeDimensions(date2, 'h')
-    - zeroLowerTimeDimensions(date1, 'h')) / hoursInMilliseconds;
-};
-
-// Returns the difference in dates between the two times while ignoring
-// any lower dimension of time
-const minutesWindowDiff = (date1, date2) => {
-  debug('Calculating minutes window diff between %s and %s', date1, date2);
-  return (zeroLowerTimeDimensions(date2, 'm')
-    - zeroLowerTimeDimensions(date1, 'm')) / minutesInMilliseconds;
-};
-
-// Returns the difference in dates between the two times while ignoring
-// any lower dimension of time
-const secondsWindowDiff = (date1, date2) => {
-  debug('Calculating seconds window diff between %s and %s', date1, date2);
-  return (zeroLowerTimeDimensions(date2, 's')
-    - zeroLowerTimeDimensions(date1, 's')) / secondsInMilliseconds;
-};
-
-// Mapping of dimension string with their respective diff function
-const diffs = {
-  M: monthWindowDiff,
-  D: dateWindowDiff,
-  h: hoursWindowDiff,
-  m: minutesWindowDiff,
-  s: secondsWindowDiff
+// Takes two dates and a dimension, and returns the difference from
+// the second date to the first date within that time dimension
+const diff = (date1, date2, dim) => {
+  debug('Difference between %s and %s in dimension %s', date1, date2, dim);
+  return moment.utc(date2).startOf(shortcut[dim])
+    .diff(moment.utc(date1).startOf(shortcut[dim]), shortcut[dim]);
 };
 
 // Returns the index within the windows that the time falls
 // under based upon the given current time and time dimension
 const timeWindowIndex = (windows, current, time, dim, exceedWindow) => {
-  const index = diffs[dim](time, current);
+  const index = diff(time, current, dim);
   // Return -1 if the calculated index falls outside the window width
   // Return 0 in the case of a negative index
   return exceedWindow ? Math.max(0, index) :
@@ -98,22 +45,18 @@ const timeWindowIndex = (windows, current, time, dim, exceedWindow) => {
 
 // Return the start and end bounds of a time window to given dimension
 // The window can optionally be shifted
-const timeWindowBounds = (date, dimension, shift) => {
-  // Object containing the ability to shift a date based on the dimension
-  const windowShift = {
-    M: (d, t) => d.setUTCMonth(d.getUTCMonth() + (t || 0)),
-    D: (d, t) => d.setUTCDate(d.getUTCDate() + (t || 0)),
-    h: (d, t) => d.setUTCHours(d.getUTCHours() + (t || 0)),
-    m: (d, t) => d.setUTCMinutes(d.getUTCMinutes() + (t || 0)),
-    s: (d, t) => d.setUTCSeconds(d.getUTCSeconds() + (t || 0))
-  };
+const timeWindowBounds = (date, dim, shift) => {
+  // Zero out the lower time dimensions
+  const bound = moment.utc(zeroLowerTimeDimensions(date, dim));
 
-  // Copy the date to prevent modifying the passed in parameter
-  const boundDate = zeroLowerTimeDimensions(date, dimension);
-  windowShift[dimension](boundDate, shift || 0);
-  const from = new Date(boundDate.getTime());
-  windowShift[dimension](boundDate, 1);
-  const to = new Date(boundDate.getTime());
+  // Get the from bound based on the optional shift parameter
+  bound.add(shift || 0, shortcut[dim]);
+  const from = new Date(bound.valueOf());
+
+  // Get the to bound based on being 1 more than from in the current dimension
+  bound.add(1, shortcut[dim]);
+  const to = new Date(bound.valueOf());
+
   return {
     from: from,
     to: to
@@ -121,20 +64,16 @@ const timeWindowBounds = (date, dimension, shift) => {
 };
 
 // Shift the time windows by the difference in windows per dimension
-const shiftWindow = (before, after, twindow, dimension) => {
+const shiftWindow = (before, after, twindow, dim) => {
   map(Array(Math.max(0,
-  Math.min(twindow.length, diffs[dimension](before, after)))), () => {
+  Math.min(twindow.length, diff(before, after, dim)))), () => {
     twindow.unshift(null);
     twindow.pop();
   });
 };
 
 module.exports.zeroLowerTimeDimensions = zeroLowerTimeDimensions;
-module.exports.monthWindowDiff = monthWindowDiff;
-module.exports.dateWindowDiff = dateWindowDiff;
-module.exports.hoursWindowDiff = hoursWindowDiff;
-module.exports.minutesWindowDiff = minutesWindowDiff;
-module.exports.secondsWindowDiff = secondsWindowDiff;
+module.exports.diff = diff;
 module.exports.timeWindowIndex = timeWindowIndex;
 module.exports.timeWindowBounds = timeWindowBounds;
 module.exports.shiftWindow = shiftWindow;


### PR DESCRIPTION
Since this is introducing a new library and removing some of the exported functions in abacus-timewindow, I wanted to make a pull request for more visibility and review.