### PR TITLE
Stop flow when business errors are found in the collector

### DIFF
--- a/lib/config/metering/src/index.js
+++ b/lib/config/metering/src/index.js
@@ -116,13 +116,6 @@ const error = (reason) => ({
 // resource type, provisioning plan and time
 const id = (oid, rtype, ppid, time, auth, cb) => {
   debug('Retrieving metering plan_id');
-
-  if (!rtype) {
-    debug('Undefined resource type');
-    return cb(undefined,
-      error('Undefined resource type'));
-  }
-
   // Round time to a 10 min boundary
   const t = Math.floor(time / 600000) * 600000;
   const k = [oid, rtype, ppid, t].join('/');

--- a/lib/config/metering/src/test/test.js
+++ b/lib/config/metering/src/test/test.js
@@ -128,26 +128,9 @@ describe('abacus-metering-config', () => {
   });
 
   it('returns with the appropriate error flag and reason', (done) => {
-    let cbs = 0;
-    const cb = () => {
-      if (++cbs === 2) done();
-    };
-
     // Mock request to simulate business error
     getspy = (reqs, cb) =>
       cb(null, [[undefined, { statusCode: 404, body: 'Not found' }]]);
-
-    // When resource type is undefined
-    config.id(
-      'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', undefined,
-      'test-plan', 1420070400000, undefined, (err, val) => {
-        expect(err).to.equal(undefined);
-        expect(val).to.deep.equal({
-          error: true,
-          reason: 'Undefined resource type'
-        });
-        cb();
-      });
  
     // When the plan id does not map to a plan
     config.id(
@@ -159,7 +142,7 @@ describe('abacus-metering-config', () => {
           reason: 'Unable to find metering plan id for resource type ' +
             'InvalidResourceType and plan id test-plan'
         });
-        cb();
+        done();
       });
   });
 

--- a/lib/config/pricing/src/index.js
+++ b/lib/config/pricing/src/index.js
@@ -69,13 +69,6 @@ const error = (reason) => ({
 const plan = (ppid, country, auth, cb) => {
   debug('Retrieving pricing plan %s', ppid);
 
-  if(!ppid || !country) {
-    debug('Undefined pricing plan id / country');
-    let eMessage = !ppid ? 'Undefined pricing plan id' : '';
-    eMessage += !country ? ' Undefined pricing country' : '';
-    return cb(undefined, error(eMessage));
-  }
-
   return lock(ppid, (err, unlock) => {
     if(err)
       return unlock(cb(err));
@@ -149,11 +142,6 @@ const cachedId = (k) => ids.get(k);
 // provisioning plan, and time
 const id = (oid, rtype, ppid, time, auth, cb) => {
   debug('Retrieving pricing plan id');
-  if(!rtype) {
-    debug('Undefined resource type');
-    return cb(undefined,
-      error('Undefined resource type'));
-  }
 
   // Round time to a 10 min boundary
   const t = Math.floor(time / 600000) * 600000;

--- a/lib/config/pricing/src/test/test.js
+++ b/lib/config/pricing/src/test/test.js
@@ -45,7 +45,7 @@ describe('abacus-pricing-config', () => {
   it('returns pricing plan given a pricing plan id', (done) => {
     let cbs = 0;
     const cb = () => {
-      if (++cbs === 5) done();
+      if (++cbs === 4) done();
     };
     const expected = {
       metrics: [
@@ -93,16 +93,6 @@ describe('abacus-pricing-config', () => {
         error: true,
         reason: 'Pricing plan ' +
           'for the pricing plan id notFound is not found'
-      });
-      cb();
-    });
-
-    // Undefined rtype and country
-    config.plan(undefined, undefined, undefined, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val).to.deep.equal({
-        error: true,
-        reason: 'Undefined pricing plan id Undefined pricing country'
       });
       cb();
     });
@@ -158,26 +148,9 @@ describe('abacus-pricing-config', () => {
   });
 
   it('returns with the appropriate error flag and reason', (done) => {
-    let cbs = 0;
-    const cb = () => {
-      if (++cbs === 2) done();
-    };
-
     // Mock request to simulate business error
     getspy = (reqs, cb) =>
       cb(null, [[undefined, { statusCode: 404, body: 'Not found' }]]);
-
-    // When resource type is undefined
-    config.id(
-      'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', undefined,
-      'test-plan', 1420070400000, undefined, (err, val) => {
-        expect(err).to.equal(undefined);
-        expect(val).to.deep.equal({
-          error: true,
-          reason: 'Undefined resource type'
-        });
-        cb();
-      });
  
     // When the plan id does not map to a plan
     config.id(
@@ -189,7 +162,7 @@ describe('abacus-pricing-config', () => {
           reason: 'Unable to find pricing plan id for resource type ' +
             'InvalidResourceType and plan id test-plan'
         });
-        cb();
+        done();
       });
   });
 });

--- a/lib/config/rating/src/index.js
+++ b/lib/config/rating/src/index.js
@@ -148,11 +148,6 @@ const cachedId = (k) => ids.get(k);
 // resource type, provisioning plan and time
 const id = (oid, rtype, ppid, time, auth, cb) => {
   debug('Retrieving rating plan id');
-  if(!rtype) {
-    debug('Undefined resource type');
-    return cb(undefined,
-      error('Undefined resource type'));
-  }
 
   // Round time to a 10 min boundary
   const t = Math.floor(time / 600000) * 600000;

--- a/lib/config/rating/src/test/test.js
+++ b/lib/config/rating/src/test/test.js
@@ -120,26 +120,9 @@ describe('abacus-rating-config', () => {
   });
 
   it('returns with the appropriate error flag and reason', (done) => {
-    let cbs = 0;
-    const cb = () => {
-      if (++cbs === 2) done();
-    };
-
     // Mock request to simulate business error
     getspy = (reqs, cb) =>
       cb(null, [[undefined, { statusCode: 404, body: 'Not found' }]]);
-
-    // When resource type is undefined
-    config.id(
-      'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27', undefined,
-      'test-plan', 1420070400000, undefined, (err, val) => {
-        expect(err).to.equal(undefined);
-        expect(val).to.deep.equal({
-          error: true,
-          reason: 'Undefined resource type'
-        });
-        cb();
-      });
  
     // When the plan id does not map to a plan
     config.id(
@@ -151,7 +134,7 @@ describe('abacus-rating-config', () => {
           reason: 'Unable to find rating plan id for resource type ' +
             'InvalidResourceType and plan id test-plan'
         });
-        cb();
+        done();
       });
   });
 });

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -202,7 +202,7 @@ const normalizeDoc = (u, info) => {
   // Attachees error flag and list of reasons
   return extend({}, u, e ? {
     error: true,
-    reason: filter(reasons, (reason) => {
+    reasons: filter(reasons, (reason) => {
       return reason;
     })
   } : {
@@ -217,6 +217,7 @@ const normalizeDoc = (u, info) => {
 };
 
 // Map submitted usage doc to normalized usage doc
+/* eslint complexity: [1, 7] */
 const normalizeUsage = function *(udoc, auth) {
   debug('Normalizing usage %o', udoc);
 
@@ -243,11 +244,15 @@ const normalizeUsage = function *(udoc, auth) {
     throw res;
   }
 
-    // Retrieve resource type given the resource id
+  // Retrieve resource type given the resource id
   const [rt, account] = yield [
     getResourceType(udoc.resource_id, auth),
     getAccount(udoc.organization_id, udoc.end, auth)
   ];
+
+  // Stop when resource type or account returns undefined.
+  if(rt.error || account.error)
+    return [normalizeDoc(udoc, [rt, account])];
 
   // Get account information and plan ids
   const [mpid, rpid, ppid] = yield [
@@ -259,16 +264,17 @@ const normalizeUsage = function *(udoc, auth) {
       udoc.end, auth)
   ];
 
+  // Stop when pricing plan id is not found
+  if(ppid.error)
+    return [normalizeDoc(udoc, [ppid])];
+
   // Get the usage prices in the account's pricing country
   const prices = yield pricingPlan(ppid.pricing_plan_id,
     !account.error && account.account.pricing_country, auth);
 
   // Extend the submitted usage with the additional information we've
   // collected
-  const nudoc = normalizeDoc(udoc, [rt, account, mpid, rpid, ppid, prices]);
-
-  // Return the normalized usage doc
-  return [nudoc];
+  return [normalizeDoc(udoc, [rt, account, mpid, rpid, ppid, prices])];
 };
 
 // Create a collector service app

--- a/lib/metering/collector/src/test/test.js
+++ b/lib/metering/collector/src/test/test.js
@@ -110,8 +110,7 @@ describe('abacus-usage-collector', () => {
             resource_id: usage.resource_id,
             cache: true
           });
-
-          // The second call to account is cached
+          // Expect a call to the account service's get account
           if(reqs[1]) {
             expect(reqs[1][0]).to.equal('http://localhost:9881/v1/' +
               'organizations/:org_id/account/:time');
@@ -132,7 +131,7 @@ describe('abacus-usage-collector', () => {
 
             check();
           }
-          else {
+          else { // The second call to account is cached
             cb(undefined, [[undefined, {
               statusCode: 200,
               body: 'test-resource'
@@ -228,7 +227,7 @@ describe('abacus-usage-collector', () => {
     verify(false, () => verify(true, done));
   });
 
-  it('reports reason of business errors', (done) => {
+  it('returns error doc due to missing account & resource type', (done) => {
     const usage = {
       start: 1420243200000,
       end: 1420245000000,
@@ -281,7 +280,7 @@ describe('abacus-usage-collector', () => {
           resource_id: usage.resource_id,
           cache: true
         });
-        // The second call to account is cached
+        // Expect a call to the account service's get account
         expect(reqs[1][0]).to.equal('http://localhost:9881/v1/' +
           'organizations/:org_id/account/:time');
         expect(reqs[1][1]).to.deep.equal(extend({}, {
@@ -289,8 +288,7 @@ describe('abacus-usage-collector', () => {
           time: usage.end
         }));
         cb(undefined, [[undefined, {
-          statusCode: 200,
-          body: 'test-resource'
+          statusCode: 404
         }], [undefined, {
           statusCode: 404
         }]]);
@@ -307,9 +305,188 @@ describe('abacus-usage-collector', () => {
         'id', 'processed', 'processed_id', 'collected_usage_id'))
         .to.deep.equal(extend({}, usage, {
           error: true,
-          reason: [
-            'Unable to retrieve account info for invalidOrg at 1420245000000',
-            ' Undefined pricing country'
+          reasons: [
+            'Unable to retrieve resource type for resource id test-resource',
+            'Unable to retrieve account info for invalidOrg at 1420245000000'
+          ]
+        }));
+      cb(undefined, [[undefined, {
+        statusCode: 201
+      }]]);
+      check();
+    };
+
+    // Post usage for a resource, expecting a 201 response
+    request.post('http://localhost::p/v1/metering/collected/usage', {
+      p: server.address().port,
+      body: usage
+    }, (err, val) => {
+      expect(err).to.equal(undefined);
+      expect(val.statusCode).to.equal(201);
+
+      // Get usage, expecting what we posted
+      brequest.get(val.headers.location, {}, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(omit(val.body, 'id', 'processed', 'processed_id'))
+        .to.deep.equal(usage);
+
+        check();
+      });
+    });
+  });
+  /* eslint complexity: [1, 7] */
+  it('returns error doc due to multiple reasons', (done) => {
+    const usage = {
+      start: 1420243200000,
+      end: 1420245000000,
+      organization_id: 'invalidOrg',
+      space_id: 'invalidSpace',
+      consumer_id: 'invalidConsumer',
+      resource_id: 'test-resource',
+      plan_id: 'invalidPlan',
+      resource_instance_id: 'invalidResourceInstance',
+      measured_usage: [{
+        measure: 'light_api_calls',
+        quantity: 12
+      }]
+    };
+
+    // Create a test collector app
+    const app = collector();
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    // Handle callback checks
+    let checks = 0;
+    const check = () => {
+      if(++checks == 8) done();
+    };
+
+    getspy = (reqs, cb) => {
+      // Expect a call to the provisioning service's validate
+      // Returns 200 so we can get into failure management
+      if(reqs[0][0] === 
+        'http://localhost:9880/v1/provisioning/organizations/' +
+        ':organization_id/spaces/:space_id/consumers/:consumer_id/' +
+        'resources/:resource_id/plans/:plan_id/instances/' +
+        ':resource_instance_id/:time') {
+        expect(omit(reqs[0][1],
+          'id', 'processed', 'processed_id')).to.deep.equal(
+          extend({}, usage, {
+            time: usage.end
+          }));
+        cb(undefined, [[undefined, {
+          statusCode: 200
+        }]]);
+        check();
+      }
+
+      // Expect a call to the provisioning service's get resource type
+      if(reqs[0][0] === 'http://localhost:9880/v1/provisioning/' +
+        'resources/:resource_id/type') {
+        expect(reqs[0][1]).to.deep.equal({
+          resource_id: usage.resource_id,
+          cache: true
+        });
+        // Expect a call to the account service's get account
+        expect(reqs[1][0]).to.equal('http://localhost:9881/v1/' +
+          'organizations/:org_id/account/:time');
+        expect(reqs[1][1]).to.deep.equal(extend({}, {
+          org_id: usage.organization_id,
+          time: usage.end
+        }));
+        cb(undefined, [[undefined, {
+          statusCode: 200,
+          body: 'fail-resource'
+        }], [undefined, {
+          statusCode: 200,
+          body: {
+            account_id: 'test-account',
+            pricing_country: 'USA'
+          }
+        }]]);
+        check();
+      }
+
+      // Expect a call to the account service's get metering plan id
+      if(reqs[0][0] === 'http://localhost:9881/v1/metering/organizations/' +
+        ':organization_id/resource_types/:resource_type/plans/' +
+        ':plan_id/time/:time/metering_plan/id') {
+        expect(reqs[0][1]).to.deep.equal({
+          organization_id: usage.organization_id,
+          resource_type: 'fail-resource',
+          plan_id: usage.plan_id,
+          time: usage.end
+        });
+        cb(undefined, [[undefined, {
+          statusCode: 404
+        }]]);
+        check();
+      }
+
+      // Expect a call to the account service's get rating plan id
+      if(reqs[0][0] === 'http://localhost:9881/v1/rating/organizations/' +
+        ':organization_id/resource_types/:resource_type/plans/' +
+        ':plan_id/time/:time/rating_plan/id') {
+        expect(reqs[0][1]).to.deep.equal({
+          organization_id: usage.organization_id,
+          resource_type: 'fail-resource',
+          plan_id: usage.plan_id,
+          time: usage.end
+        });
+        cb(undefined, [[undefined, {
+          statusCode: 404
+        }]]);
+        check();
+      }
+
+      // Expect a call to the account service's get pricing plan id
+      if(reqs[0][0] === 'http://localhost:9881/v1/pricing/organizations/' +
+        ':organization_id/resource_types/:resource_type/plans/' +
+        ':plan_id/time/:time/pricing_plan/id') {
+        expect(reqs[0][1]).to.deep.equal({
+          organization_id: usage.organization_id,
+          resource_type: 'fail-resource',
+          plan_id: usage.plan_id,
+          time: usage.end
+        });
+        cb(undefined, [[undefined, {
+          statusCode: 200,
+          body: 'test-pricing-id'
+        }]]);
+        check();
+      }
+
+      // Expect a call to the provisioning service to get pricing plan
+      if(reqs[0][0] === 'http://localhost:9880/v1/pricing/plans/' +
+        ':pricing_plan_id') {
+        expect(reqs[0][1]).to.deep.equal({
+          pricing_plan_id: 'test-pricing-id'
+        });
+        cb(undefined, [[undefined, {
+          statusCode: 404
+        }]]);
+        check();
+      }
+    };
+
+    postspy = (reqs, cb) => {
+      // Expect usage to be posted to the meter service
+      expect(reqs[0][0]).to.equal(
+        'http://localhost:9100/v1/metering/normalized/usage');
+      // Error due to no account info and no pricing country.
+      expect(omit(reqs[0][1].body,
+        'id', 'processed', 'processed_id', 'collected_usage_id'))
+        .to.deep.equal(extend({}, usage, {
+          error: true,
+          reasons: [
+            'Unable to find metering plan id for resource type fail-resource' +
+              ' and plan id invalidPlan',
+            'Unable to find rating plan id for resource type fail-resource' +
+              ' and plan id invalidPlan',
+            'Pricing plan for the pricing plan id test-pricing-id is not found'
           ]
         }));
       cb(undefined, [[undefined, {


### PR DESCRIPTION
In the collector, the steps to enrich the usage doc are as follows:
1. get the resource type and get account information.
2. get metering plan id, rating plan id, and pricing plan id.
3. get the price.

Step 2 (get metering plan id, rating plan id, and pricing plan id) would automatically returns business error when step 1 (get resource type) fails . Step 3 (get price) would automatically returns business error when step 2 (pricing plan id) or step 1 (account information) fail.

The changes in this pull request made it so that the execution of the flow is stopped when the pre-req step fails. The reported error is simply the error that cause the prereq fails.