### PR TITLE
Update OAuth token refresh time

### DIFF
--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -271,7 +271,9 @@ const cache = (authServer, id, secret, scopes) => {
 
           debug('Got OAuth bearer access token');
           token = t;
-          refresh(Math.max(token.expires_in - 120000, 120000));
+          // Convert token expiration period from seconds to milliseconds
+          // Without conversion, the token will refresh every 2 minutes
+          refresh(Math.max(token.expires_in * 1000 - 120000, 120000));
           done();
         });
       });


### PR DESCRIPTION
Update refresh time for the token by converting token expiration time from seconds to milliseconds. The token.expires_in value is usually 12 hours or 43200 seconds so max picks 120000 forcing token refresh every 2 minutes. 