### PR TITLE
Fetch accumulated usage of all resource instances in an org

### DIFF
--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -477,6 +477,58 @@ const orgsUsage = function *(orgids, time, auth) {
   });
 };
 
+// Returns the accumulated usage of all the resource instances in an orgid
+// in a given time period
+const accumulatedUsage = function *(orgid, time, auth) {
+  // Forward authorization header field to account to authorize
+  const o = auth ? { headers: { authorization: auth } } : {};
+
+  const res = yield brequest.get(
+    uris.account + '/v1/organizations/:org_id/account/:time', extend(o, {
+      org_id: orgid,
+      time: time
+    }));
+
+  // Authorization failed. Unable to retrieve account information
+  // for the given organization
+  if (res.statusCode !== 200) {
+    edebug('Unable to retrieve account information, %o', res);
+    debug('Unable to retrieve account information, %o', res);
+
+    // Throw response object as an exception to stop further processing
+    throw res;
+  }
+
+  // Compute the query range
+  const t = time || Date.now();
+  const d = new Date(t);
+  const mt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
+  const sid = dbclient.kturi(orgid, seqid.pad16(t)) + 'ZZZ';
+  const eid = dbclient.kturi(orgid, seqid.pad16(mt));
+
+  debug('Retrieving latest rated usage between %s and %s', eid, sid);
+  const org = yield aggregatordb.allDocs({
+    endkey: eid,
+    startkey: sid,
+    descending: true,
+    limit: 1,
+    include_docs: true
+  });
+
+  if(!org.rows.length) {
+    debug('No existing rated usage');
+    return [];
+  }
+
+  const docs = yield tmap(org.rows[0].doc.resource_instances, function *(r) {
+    const doc = yield aggregatordb.get(r.id);
+    return omit(dbclient.undbify(yield chargeInstanceUsage(t,
+      yield summarizeInstanceUsage(t, doc, auth), auth)),
+      ['last_rated_usage_id', 'aggregated_usage_id', 'accumulated_usage_id'])
+  });
+  return docs;
+}
+
 // Return the usage for a resource instance for a particular plan in a given
 // organization, consumer, time period
 const resourceInstanceUsage = function *(
@@ -730,6 +782,19 @@ const retrieveResourceInstanceUsage = function *(req) {
   };
 };
 
+const retrieveAccumulatedUsage = function *(req) {
+  debug('Retrieving accumulated usage for resource instances in org %s at %s',
+    req.params.organization_id, req.params.time);
+
+  const doc = yield accumulatedUsage(req.params.organization_id,
+    req.params.time ? parseInt(req.params.time) : undefined,
+    req.headers && req.headers.authorization);
+
+  return {
+    body: doc
+  };
+}
+
 // Create an express router
 const routes = router();
 
@@ -741,6 +806,13 @@ routes.get(
 routes.get(
   '/v1/metering/organizations/:organization_id/aggregated/usage',
   throttle(retrieveUsage));
+
+// Retrieve resource instances usage report for a given org and time in msec
+routes.get('/v1/metering/organizations/:organization_id/resource_instances/' +
+  'accumulated/usage/:time', throttle(retrieveAccumulatedUsage));
+
+routes.get('/v1/metering/organizations/:organization_id/resource_instances/' +
+  'accumulated/usage', throttle(retrieveAccumulatedUsage));
 
 routes.get(
   '/v1/metering/organizations/:organization_id/resource_instances/' +

--- a/lib/aggregation/reporting/src/test/test.js
+++ b/lib/aggregation/reporting/src/test/test.js
@@ -2839,6 +2839,12 @@ describe('abacus-usage-report', () => {
         // Listen on an ephemeral port
         const server = app.listen(0);
 
+        let cbs = 0;
+        const cb = () => {
+          if(++cbs === 2)
+            done();
+        };
+
         const expected = {
           id: accid,
           end: 1446415200000,
@@ -2884,7 +2890,20 @@ describe('abacus-usage-report', () => {
           }, (err, val) => {
             expect(err).to.equal(undefined);
             expect(val.body).to.deep.equal(expected);
-            done();
+            cb();
+          });
+
+          // Get the accumulated usage
+        request.get(
+          'http://localhost::p/v1/metering/organizations/' +
+          ':organization_id/resource_instances/accumulated/usage/:time', {
+            p: server.address().port,
+            organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+            time: 1446508800000
+          }, (err, val) => {
+            expect(err).to.equal(undefined);
+            expect(val.body).to.deep.equal([expected]);
+            cb();
           });
       };
 


### PR DESCRIPTION
Retrieves report for all resource instances in an org in one call.