### PR TITLE
Pass the timewindow with cell function to the accumulate and aggregate.

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -196,6 +196,15 @@ const accumulate = function *(a, u) {
 
       const aw = accum(amerge.accumulated_usage, mu.metric);
 
+      // a function that gives the index of the usage in the
+      // dimension window.
+      aw.cell = (dimension) => {
+        return timewindow.timeWindowIndex(aw[dimensions.
+          indexOf(dimension)],
+          new Date(now), new Date(u.end), dimensions[
+          dimensions.indexOf(dimension)], true);
+      };
+
       return {
         metric: mu.metric,
         windows: map(aw, (w, i) => {
@@ -219,7 +228,8 @@ const accumulate = function *(a, u) {
             const current = tw && tw.quantity && tw.quantity.current ?
               tw.quantity.current : 0;
             const accumulated = accumfn(mplan.metering_plan.metrics, mu.metric)
-              (current, mu.quantity, u.start, u.end, bounds.from, bounds.to);
+              (current, mu.quantity, u.start, u.end, bounds.from, bounds.to,
+              aw);
 
             // Do not accumulate if the function returns null
             if(accumulated === null) {

--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -196,14 +196,9 @@ const accumulate = function *(a, u) {
 
       const aw = accum(amerge.accumulated_usage, mu.metric);
 
-      // a function that gives the index of the usage in the
+      // a function that gives the value of the submitted usage in the
       // dimension window.
-      aw.cell = (dimension) => {
-        return timewindow.timeWindowIndex(aw[dimensions.
-          indexOf(dimension)],
-          new Date(now), new Date(u.end), dimensions[
-          dimensions.indexOf(dimension)], true);
-      };
+      const getCell = timewindow.cellfn(aw, now, u.end);
 
       return {
         metric: mu.metric,
@@ -227,9 +222,10 @@ const accumulate = function *(a, u) {
               dimensions[i], -j);
             const current = tw && tw.quantity && tw.quantity.current ?
               tw.quantity.current : 0;
+
             const accumulated = accumfn(mplan.metering_plan.metrics, mu.metric)
               (current, mu.quantity, u.start, u.end, bounds.from, bounds.to,
-              aw);
+              getCell);
 
             // Do not accumulate if the function returns null
             if(accumulated === null) {

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -408,7 +408,7 @@ const aggregate = function *(aggrs, u) {
 
     const aggr = (am, addCost) => {
       // getCell on accumulated time windows
-      const aggGetCell = timewindow.cellfn(am.windows, newend, docend)
+      const aggGetCell = timewindow.cellfn(am.windows, newend, docend);
 
       // We're mutating the input windows property here
       // but it's really the simplest way to apply the aggregation formula
@@ -434,7 +434,7 @@ const aggregate = function *(aggrs, u) {
           return {
             quantity: afn(q && q.quantity || 0,
               ua.windows[i][j].quantity.previous || 0,
-              ua.windows[i][j].quantity.current, aggGetCell, accGetCell)
+              ua.windows[i][j].quantity.current, aggGetCell, accGetCell);
           };
         });
 

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -434,7 +434,7 @@ const aggregate = function *(aggrs, u) {
           return {
             quantity: afn(q && q.quantity || 0,
               ua.windows[i][j].quantity.previous || 0,
-              ua.windows[i][j].quantity.current, aggGetCell, accGetCell);
+              ua.windows[i][j].quantity.current, aggGetCell, accGetCell)
           };
         });
 

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -404,11 +404,11 @@ const aggregate = function *(aggrs, u) {
     const rp = price(u.prices.metrics, ua.metric);
 
     // getCell on aggregated time windows
-    const aggGetCell = timewindow.cellfn(ua.windows, newend, docend);
+    const accGetCell = timewindow.cellfn(ua.windows, newend, docend);
 
     const aggr = (am, addCost) => {
       // getCell on accumulated time windows
-      const accGetCell = timewindow.cellfn(am.windows, newend, docend)
+      const aggGetCell = timewindow.cellfn(am.windows, newend, docend)
 
       // We're mutating the input windows property here
       // but it's really the simplest way to apply the aggregation formula

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -403,22 +403,13 @@ const aggregate = function *(aggrs, u) {
     // Find the price for the metric
     const rp = price(u.prices.metrics, ua.metric);
 
-    // a function that gives the index of the usage in the
-    // dimension window.
-    ua.windows.cell = (dimension) => {   
-      return timewindow.timeWindowIndex(ua.windows[dimensions.
-        indexOf(dimension)], new Date(newend), new Date(docend), dimensions[
-        dimensions.indexOf(dimension)]);     
-    }
+    // getCell on aggregated time windows
+    const aggGetCell = timewindow.cellfn(ua.windows, newend, docend);
 
     const aggr = (am, addCost) => {
-      // a function that gives the index of the usage in the
-      // dimension window.
-      am.windows.cell = (dimension) => {
-        return timewindow.timeWindowIndex(am.windows[dimensions.
-          indexOf(dimension)], new Date(newend), new Date(docend), dimensions[
-          dimensions.indexOf(dimension)]);
-      }
+      // getCell on accumulated time windows
+      const accGetCell = timewindow.cellfn(am.windows, newend, docend)
+
       // We're mutating the input windows property here
       // but it's really the simplest way to apply the aggregation formula
       am.windows = map(am.windows, (w, i) => {
@@ -443,7 +434,7 @@ const aggregate = function *(aggrs, u) {
           return {
             quantity: afn(q && q.quantity || 0,
               ua.windows[i][j].quantity.previous || 0,
-              ua.windows[i][j].quantity.current, am.windows, ua.windows)
+              ua.windows[i][j].quantity.current, aggGetCell, accGetCell)
           };
         });
 

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -403,7 +403,22 @@ const aggregate = function *(aggrs, u) {
     // Find the price for the metric
     const rp = price(u.prices.metrics, ua.metric);
 
+    // a function that gives the index of the usage in the
+    // dimension window.
+    ua.windows.cell = (dimension) => {   
+      return timewindow.timeWindowIndex(ua.windows[dimensions.
+        indexOf(dimension)], new Date(newend), new Date(docend), dimensions[
+        dimensions.indexOf(dimension)]);     
+    }
+
     const aggr = (am, addCost) => {
+      // a function that gives the index of the usage in the
+      // dimension window.
+      am.windows.cell = (dimension) => {
+        return timewindow.timeWindowIndex(am.windows[dimensions.
+          indexOf(dimension)], new Date(newend), new Date(docend), dimensions[
+          dimensions.indexOf(dimension)]);
+      }
       // We're mutating the input windows property here
       // but it's really the simplest way to apply the aggregation formula
       am.windows = map(am.windows, (w, i) => {
@@ -428,7 +443,7 @@ const aggregate = function *(aggrs, u) {
           return {
             quantity: afn(q && q.quantity || 0,
               ua.windows[i][j].quantity.previous || 0,
-              ua.windows[i][j].quantity.current)
+              ua.windows[i][j].quantity.current, am.windows, ua.windows)
           };
         });
 

--- a/lib/config/metering/src/index.js
+++ b/lib/config/metering/src/index.js
@@ -38,9 +38,9 @@ const uris = urienv({
 
 // Default metering and aggregation functions
 const meter = (name) => (m) => m[name];
-const accumulate = (a, qty, start, end, from, to) => end < from || end >= to ?
-  null : new BigNumber(a || 0).add(qty).toNumber();
-const aggregate = (a, prev, curr) => new BigNumber(
+const accumulate = (a, qty, start, end, from, to, tw) =>
+  end < from || end >= to ? null : new BigNumber(a || 0).add(qty).toNumber();
+const aggregate = (a, prev, curr, aggtw, acctw) => new BigNumber(
   a || 0).add(curr).sub(prev).toNumber();
 const summarize = (t, qty) => qty ? qty : 0;
 

--- a/lib/config/metering/src/index.js
+++ b/lib/config/metering/src/index.js
@@ -38,9 +38,9 @@ const uris = urienv({
 
 // Default metering and aggregation functions
 const meter = (name) => (m) => m[name];
-const accumulate = (a, qty, start, end, from, to, tw) =>
+const accumulate = (a, qty, start, end, from, to, twCell) =>
   end < from || end >= to ? null : new BigNumber(a || 0).add(qty).toNumber();
-const aggregate = (a, prev, curr, aggtw, acctw) => new BigNumber(
+const aggregate = (a, prev, curr, aggTwCell, accTwCell) => new BigNumber(
   a || 0).add(curr).sub(prev).toNumber();
 const summarize = (t, qty) => qty ? qty : 0;
 

--- a/lib/config/metering/src/test/test-metering-plan.js
+++ b/lib/config/metering/src/test/test-metering-plan.js
@@ -42,16 +42,16 @@ module.exports = {
       unit: 'GIGABYTE',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to) => end < from || end >= to ?
-        null : Math.max(a, qty)).toString()
+      accumulate: ((a, qty, start, end, from, to, tw) =>
+        end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
       name: 'thousand_light_api_calls',
       unit: 'THOUSAND_CALLS',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr) => new BigNumber(a || 0)
-        .add(curr).sub(prev).toNumber()).toString()
+      aggregate: ((a, prev, curr, aggtw, acctw) => new BigNumber(a || 0)
+          .add(curr).sub(prev).toNumber()).toString()
     },
     {
       name: 'heavy_api_calls',
@@ -70,7 +70,7 @@ module.exports = {
           .div(1073741824).mul(m.current_running_instances || 0).toNumber()
       })).toString(),
 
-      accumulate: ((a, qty, start, end, from, to) => {
+      accumulate: ((a, qty, start, end, from, to, tw) => {
         // Do not accumulate usage out of boundary
         if (end < from || end >= to)
           return null;
@@ -88,7 +88,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr) => {
+      aggregate: ((a, prev, curr, aggtw, acctw) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/config/metering/src/test/test-metering-plan.js
+++ b/lib/config/metering/src/test/test-metering-plan.js
@@ -42,7 +42,7 @@ module.exports = {
       unit: 'GIGABYTE',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to, tw) =>
+      accumulate: ((a, qty, start, end, from, to, twCell) =>
         end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
@@ -50,7 +50,7 @@ module.exports = {
       unit: 'THOUSAND_CALLS',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr, aggtw, acctw) => new BigNumber(a || 0)
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => new BigNumber(a || 0)
           .add(curr).sub(prev).toNumber()).toString()
     },
     {
@@ -70,7 +70,7 @@ module.exports = {
           .div(1073741824).mul(m.current_running_instances || 0).toNumber()
       })).toString(),
 
-      accumulate: ((a, qty, start, end, from, to, tw) => {
+      accumulate: ((a, qty, start, end, from, to, twCell) => {
         // Do not accumulate usage out of boundary
         if (end < from || end >= to)
           return null;
@@ -88,7 +88,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr, aggtw, acctw) => {
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/plugins/provisioning/src/plans/metering/basic-linux-container.js
+++ b/lib/plugins/provisioning/src/plans/metering/basic-linux-container.js
@@ -36,7 +36,7 @@ module.exports = {
           .div(1073741824).mul(m.current_running_instances || 0).toNumber()
       })).toString(),
 
-      accumulate: ((a, qty, start, end, from, to, tw) => {
+      accumulate: ((a, qty, start, end, from, to, twCell) => {
         // Do not accumulate usage out of boundary
         if (end < from || end >= to)
           return null;
@@ -54,7 +54,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr, aggtw, acctw) => {
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/plugins/provisioning/src/plans/metering/basic-linux-container.js
+++ b/lib/plugins/provisioning/src/plans/metering/basic-linux-container.js
@@ -36,7 +36,7 @@ module.exports = {
           .div(1073741824).mul(m.current_running_instances || 0).toNumber()
       })).toString(),
 
-      accumulate: ((a, qty, start, end, from, to) => {
+      accumulate: ((a, qty, start, end, from, to, tw) => {
         // Do not accumulate usage out of boundary
         if (end < from || end >= to)
           return null;
@@ -54,7 +54,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr) => {
+      aggregate: ((a, prev, curr, aggtw, acctw) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/plugins/provisioning/src/plans/metering/basic-object-storage.js
+++ b/lib/plugins/provisioning/src/plans/metering/basic-object-storage.js
@@ -26,15 +26,15 @@ module.exports = {
       unit: 'GIGABYTE',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to) => end < from || end >= to ?
-        null : Math.max(a, qty)).toString()
+      accumulate: ((a, qty, start, end, from, to, tw) =>
+        end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
       name: 'thousand_light_api_calls',
       unit: 'THOUSAND_CALLS',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr) => new BigNumber(a || 0)
+      aggregate: ((a, prev, curr, aggtw, acctw) => new BigNumber(a || 0)
         .add(curr).sub(prev).toNumber()).toString()
     },
     {

--- a/lib/plugins/provisioning/src/plans/metering/basic-object-storage.js
+++ b/lib/plugins/provisioning/src/plans/metering/basic-object-storage.js
@@ -26,7 +26,7 @@ module.exports = {
       unit: 'GIGABYTE',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to, tw) =>
+      accumulate: ((a, qty, start, end, from, to, twCell) =>
         end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
@@ -34,7 +34,7 @@ module.exports = {
       unit: 'THOUSAND_CALLS',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr, aggtw, acctw) => new BigNumber(a || 0)
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => new BigNumber(a || 0)
         .add(curr).sub(prev).toNumber()).toString()
     },
     {

--- a/lib/plugins/provisioning/src/plans/metering/standard-linux-container.js
+++ b/lib/plugins/provisioning/src/plans/metering/standard-linux-container.js
@@ -36,7 +36,7 @@ module.exports = {
           .div(1073741824).mul(m.current_running_instances || 0).toNumber()
       })).toString(),
 
-      accumulate: ((a, qty, start, end, from, to, tw) => {
+      accumulate: ((a, qty, start, end, from, to, twCell) => {
         // Do not accumulate usage out of boundary
         if (end < from || end >= to)
           return null;
@@ -54,7 +54,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr, aggtw, acctw) => {
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/plugins/provisioning/src/plans/metering/standard-linux-container.js
+++ b/lib/plugins/provisioning/src/plans/metering/standard-linux-container.js
@@ -36,7 +36,7 @@ module.exports = {
           .div(1073741824).mul(m.current_running_instances || 0).toNumber()
       })).toString(),
 
-      accumulate: ((a, qty, start, end, from, to) => {
+      accumulate: ((a, qty, start, end, from, to, tw) => {
         // Do not accumulate usage out of boundary
         if (end < from || end >= to)
           return null;
@@ -54,7 +54,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr) => {
+      aggregate: ((a, prev, curr, aggtw, acctw) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/plugins/provisioning/src/plans/metering/standard-object-storage.js
+++ b/lib/plugins/provisioning/src/plans/metering/standard-object-storage.js
@@ -26,15 +26,15 @@ module.exports = {
       unit: 'GIGABYTE',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to) => end < from || end >= to ?
-        null : Math.max(a, qty)).toString()
+      accumulate: ((a, qty, start, end, from, to, tw) =>
+        end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
       name: 'thousand_light_api_calls',
       unit: 'THOUSAND_CALLS',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr) => new BigNumber(a || 0)
+      aggregate: ((a, prev, curr, aggtw, acctw) => new BigNumber(a || 0)
         .add(curr).sub(prev).toNumber()).toString()
     },
     {

--- a/lib/plugins/provisioning/src/plans/metering/standard-object-storage.js
+++ b/lib/plugins/provisioning/src/plans/metering/standard-object-storage.js
@@ -26,7 +26,7 @@ module.exports = {
       unit: 'GIGABYTE',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to, tw) =>
+      accumulate: ((a, qty, start, end, from, to, twCell) =>
         end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
@@ -34,7 +34,7 @@ module.exports = {
       unit: 'THOUSAND_CALLS',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr, aggtw, acctw) => new BigNumber(a || 0)
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => new BigNumber(a || 0)
         .add(curr).sub(prev).toNumber()).toString()
     },
     {

--- a/lib/plugins/provisioning/src/plans/metering/test-metering-plan.js
+++ b/lib/plugins/provisioning/src/plans/metering/test-metering-plan.js
@@ -73,7 +73,7 @@ module.exports = {
       unit: 'GIGABYTE',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to, tw) =>
+      accumulate: ((a, qty, start, end, from, to, twCell) =>
         end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
@@ -81,7 +81,7 @@ module.exports = {
       unit: 'THOUSAND_CALLS',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr, aggtw, acctw) => new BigNumber(a || 0)
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => new BigNumber(a || 0)
         .add(curr).sub(prev).toNumber()).toString()
     },
     {
@@ -101,7 +101,7 @@ module.exports = {
           .div(1073741824).mul(m.current_running_instances || 0).toNumber()
       })).toString(),
 
-      accumulate: ((a, qty, start, end, from, to) => {
+      accumulate: ((a, qty, start, end, from, to, twCell) => {
         // Do not accumulate usage out of boundary
         if (end < from || end >= to)
           return null;
@@ -119,7 +119,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr, aggtw, acctw) => {
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/plugins/provisioning/src/plans/metering/test-metering-plan.js
+++ b/lib/plugins/provisioning/src/plans/metering/test-metering-plan.js
@@ -73,15 +73,15 @@ module.exports = {
       unit: 'GIGABYTE',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to) => end < from || end >= to ?
-        null : Math.max(a, qty)).toString()
+      accumulate: ((a, qty, start, end, from, to, tw) =>
+        end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
       name: 'thousand_light_api_calls',
       unit: 'THOUSAND_CALLS',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr) => new BigNumber(a || 0)
+      aggregate: ((a, prev, curr, aggtw, acctw) => new BigNumber(a || 0)
         .add(curr).sub(prev).toNumber()).toString()
     },
     {
@@ -119,7 +119,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr) => {
+      aggregate: ((a, prev, curr, aggtw, acctw) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/utils/pouchserver/.gitignore
+++ b/lib/utils/pouchserver/.gitignore
@@ -1,2 +1,3 @@
 lib/**
 node_modules/**
+config.json

--- a/lib/utils/timewindow/src/index.js
+++ b/lib/utils/timewindow/src/index.js
@@ -8,6 +8,9 @@ const map = _.map;
 // Setup debug log
 const debug = require('abacus-debug')('abacus-timewindow');
 
+// Time dimension keys corresponding to their respective window positions
+const dimensions = ['s', 'm', 'h', 'D', 'M'];
+
 // Mapping from time window shortcuts to moment.js shortcuts
 const shortcut = {
   Y: 'y',
@@ -73,9 +76,23 @@ const shiftWindow = (before, after, twindow, dim) => {
   });
 };
 
+// a function that gives the value of the submitted usage in the
+// dimension window.
+const cellfn = (timeWindow, processed, usageTime) => {
+  return (dimension) => {
+    const index = timeWindowIndex(timeWindow[dimensions.
+      indexOf(dimension)], new Date(processed), new Date(usageTime),
+      dimensions[dimensions.indexOf(dimension)]);
+    
+    return timeWindow[dimensions.indexOf(dimension)][index] &&
+      timeWindow[dimensions.indexOf(dimension)][index].quantity;
+  };
+};
+
 module.exports.zeroLowerTimeDimensions = zeroLowerTimeDimensions;
 module.exports.diff = diff;
 module.exports.timeWindowIndex = timeWindowIndex;
 module.exports.timeWindowBounds = timeWindowBounds;
 module.exports.shiftWindow = shiftWindow;
+module.exports.cellfn = cellfn;
 

--- a/lib/utils/timewindow/src/test/test.js
+++ b/lib/utils/timewindow/src/test/test.js
@@ -142,5 +142,37 @@ describe('abacus-timewindow', () => {
       to: to
     });
   });
+
+  it('provides get cell function', () => {
+    const June7th = 1465282800001;
+    const June8th = 1465369200001;
+
+    // Slack set to 2D. processed June8th, doc is at June7th
+    let cellfn = time.cellfn([[null],
+      [null],
+      [null],
+      [{ quantity: 5 }, { quantity: 25 }],
+      [{ quantity: 30 }, null]], June8th, June7th);
+
+    
+    expect(cellfn('s')).to.equal(undefined);
+    expect(cellfn('m')).to.equal(undefined);
+    expect(cellfn('h')).to.equal(undefined);
+    expect(cellfn('D')).to.equal(25);
+    expect(cellfn('M')).to.equal(30);
+
+    // Slack set to 2D. processed June8th, doc is at June8th
+    cellfn = time.cellfn([[null],
+      [null],
+      [null],
+      [{ quantity: 5 }, { quantity: 25 }],
+      [{ quantity: 30 }, null]], June8th, June8th);
+
+    expect(cellfn('s')).to.equal(null);
+    expect(cellfn('m')).to.equal(null);
+    expect(cellfn('h')).to.equal(null);
+    expect(cellfn('D')).to.equal(5);
+    expect(cellfn('M')).to.equal(30);
+  });
 });
 


### PR DESCRIPTION
The goal is to add more flexibility in the formula by giving the formula access to the hourly/minutely/daily accumulated / aggregated usage.

An example of use case is if we are in the month window, and we are interested to see the daily usages. In order to do so, the formula need to access the timewindow.

I also added a .cell method in the timewindow to let the formula knows which window the usage it is calculating belongs to.