### PR TITLE
Add more flexibility to accumulate and aggregate functions in formula.

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -195,6 +195,10 @@ const accumulate = function *(a, u) {
       const rp = price(u.prices.metrics, mu.metric);
 
       const aw = accum(amerge.accumulated_usage, mu.metric);
+  
+      // a function that gives the value of the submitted usage in the
+      // dimension window.
+      const getCell = timewindow.cellfn(aw, now, u.end);
 
       return {
         metric: mu.metric,
@@ -219,7 +223,8 @@ const accumulate = function *(a, u) {
             const current = tw && tw.quantity && tw.quantity.current ?
               tw.quantity.current : 0;
             const accumulated = accumfn(mplan.metering_plan.metrics, mu.metric)
-              (current, mu.quantity, u.start, u.end, bounds.from, bounds.to);
+              (current, mu.quantity, u.start, u.end, bounds.from, bounds.to,
+                getCell);
 
             // Do not accumulate if the function returns null
             if(accumulated === null) {

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -403,7 +403,12 @@ const aggregate = function *(aggrs, u) {
     // Find the price for the metric
     const rp = price(u.prices.metrics, ua.metric);
 
+    // getCell on incoming usage's time windows
+    const accGetCell = timewindow.cellfn(ua.windows, newend, docend);
+
     const aggr = (am, addCost) => {
+      // getCell on previous aggregated usage's time windows
+      const aggGetCell = timewindow.cellfn(am.windows, newend, docend);
       // We're mutating the input windows property here
       // but it's really the simplest way to apply the aggregation formula
       am.windows = map(am.windows, (w, i) => {
@@ -428,7 +433,7 @@ const aggregate = function *(aggrs, u) {
           return {
             quantity: afn(q && q.quantity || 0,
               ua.windows[i][j].quantity.previous || 0,
-              ua.windows[i][j].quantity.current)
+              ua.windows[i][j].quantity.current, aggGetCell, accGetCell)
           };
         });
 

--- a/lib/config/metering/src/index.js
+++ b/lib/config/metering/src/index.js
@@ -38,9 +38,10 @@ const uris = urienv({
 
 // Default metering and aggregation functions
 const meter = (name) => (m) => m[name];
-const accumulate = (a, qty, start, end, from, to) => end < from || end >= to ?
-  null : new BigNumber(a || 0).add(qty).toNumber();
-const aggregate = (a, prev, curr) => new BigNumber(
+const accumulate = (a, qty, start, end, from, to, twCell) =>
+  end < from || end >= to ? null :
+  new BigNumber(a || 0).add(qty).toNumber();
+const aggregate = (a, prev, curr, aggTwCell, accTwCell) => new BigNumber(
   a || 0).add(curr).sub(prev).toNumber();
 const summarize = (t, qty) => qty ? qty : 0;
 

--- a/lib/config/metering/src/test/test-metering-plan.js
+++ b/lib/config/metering/src/test/test-metering-plan.js
@@ -42,15 +42,15 @@ module.exports = {
       unit: 'GIGABYTE',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to) => end < from || end >= to ?
-        null : Math.max(a, qty)).toString()
+      accumulate: ((a, qty, start, end, from, to, twCell) =>
+        end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
       name: 'thousand_light_api_calls',
       unit: 'THOUSAND_CALLS',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr) => new BigNumber(a || 0)
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => new BigNumber(a || 0)
         .add(curr).sub(prev).toNumber()).toString()
     },
     {
@@ -70,7 +70,7 @@ module.exports = {
           .div(1073741824).mul(m.current_running_instances || 0).toNumber()
       })).toString(),
 
-      accumulate: ((a, qty, start, end, from, to) => {
+      accumulate: ((a, qty, start, end, from, to, twCell) => {
         // Do not accumulate usage out of boundary
         if (end < from || end >= to)
           return null;
@@ -88,7 +88,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr) => {
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/plugins/provisioning/src/plans/metering/basic-linux-container.js
+++ b/lib/plugins/provisioning/src/plans/metering/basic-linux-container.js
@@ -37,7 +37,7 @@ module.exports = {
           .div(1073741824).mul(m.current_running_instances || 0).toNumber()
       })).toString(),
 
-      accumulate: ((a, qty, start, end, from, to) => {
+      accumulate: ((a, qty, start, end, from, to, twCell) => {
         // Do not accumulate usage out of boundary
         if (end < from || end >= to)
           return null;
@@ -55,7 +55,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr) => {
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/plugins/provisioning/src/plans/metering/basic-object-storage.js
+++ b/lib/plugins/provisioning/src/plans/metering/basic-object-storage.js
@@ -27,8 +27,8 @@ module.exports = {
       type: 'discrete',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to) => end < from || end >= to ?
-        null : Math.max(a, qty)).toString()
+      accumulate: ((a, qty, start, end, from, to, twCell) =>
+        end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
       name: 'thousand_light_api_calls',
@@ -36,8 +36,8 @@ module.exports = {
       type: 'discrete',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr) => new BigNumber(a || 0)
-        .add(curr).sub(prev).toNumber()).toString()
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) =>
+        new BigNumber(a || 0).add(curr).sub(prev).toNumber()).toString()
     },
     {
       name: 'heavy_api_calls',

--- a/lib/plugins/provisioning/src/plans/metering/standard-linux-container.js
+++ b/lib/plugins/provisioning/src/plans/metering/standard-linux-container.js
@@ -37,7 +37,7 @@ module.exports = {
           .div(1073741824).mul(m.current_running_instances || 0).toNumber()
       })).toString(),
 
-      accumulate: ((a, qty, start, end, from, to) => {
+      accumulate: ((a, qty, start, end, from, to, twCell) => {
         // Do not accumulate usage out of boundary
         if (end < from || end >= to)
           return null;
@@ -55,7 +55,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr) => {
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/plugins/provisioning/src/plans/metering/standard-object-storage.js
+++ b/lib/plugins/provisioning/src/plans/metering/standard-object-storage.js
@@ -27,8 +27,8 @@ module.exports = {
       type: 'discrete',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to) => end < from || end >= to ?
-        null : Math.max(a, qty)).toString()
+      accumulate: ((a, qty, start, end, from, to, twCell) =>
+        end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
       name: 'thousand_light_api_calls',
@@ -36,8 +36,8 @@ module.exports = {
       type: 'discrete',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr) => new BigNumber(a || 0)
-        .add(curr).sub(prev).toNumber()).toString()
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) =>
+        new BigNumber(a || 0).add(curr).sub(prev).toNumber()).toString()
     },
     {
       name: 'heavy_api_calls',

--- a/lib/plugins/provisioning/src/plans/metering/test-metering-plan.js
+++ b/lib/plugins/provisioning/src/plans/metering/test-metering-plan.js
@@ -74,8 +74,8 @@ module.exports = {
       type: 'discrete',
       meter: ((m) => new BigNumber(m.storage)
         .div(1073741824).toNumber()).toString(),
-      accumulate: ((a, qty, start, end, from, to) => end < from || end >= to ?
-        null : Math.max(a, qty)).toString()
+      accumulate: ((a, qty, start, end, from, to, twCell) =>
+        end < from || end >= to ? null : Math.max(a, qty)).toString()
     },
     {
       name: 'thousand_light_api_calls',
@@ -83,8 +83,8 @@ module.exports = {
       type: 'discrete',
       meter: ((m) => new BigNumber(m.light_api_calls)
         .div(1000).toNumber()).toString(),
-      aggregate: ((a, prev, curr) => new BigNumber(a || 0)
-        .add(curr).sub(prev).toNumber()).toString()
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) =>
+        new BigNumber(a || 0).add(curr).sub(prev).toNumber()).toString()
     },
     {
       name: 'heavy_api_calls',
@@ -105,7 +105,7 @@ module.exports = {
           .div(1073741824).mul(m.current_running_instances || 0).toNumber()
       })).toString(),
 
-      accumulate: ((a, qty, start, end, from, to) => {
+      accumulate: ((a, qty, start, end, from, to, twCell) => {
         // Do not accumulate usage out of boundary
         if (end < from || end >= to)
           return null;
@@ -123,7 +123,7 @@ module.exports = {
         }
       }).toString(),
 
-      aggregate: ((a, prev, curr) => {
+      aggregate: ((a, prev, curr, aggTwCell, accTwCell) => {
         // Usage was rejected by accumulate
         if (!curr)
           return a;

--- a/lib/utils/timewindow/src/index.js
+++ b/lib/utils/timewindow/src/index.js
@@ -19,6 +19,9 @@ const shortcut = {
   s: 's'
 };
 
+// Time dimension keys corresponding to their respective window positions
+const dimensions = ['s', 'm', 'h', 'D', 'M'];
+
 // Takes a Date or moment.js object and returns a Javascript Date equivalent
 // with all dimensions lower than the given one set to 0
 const zeroLowerTimeDimensions = (date, dim) => {
@@ -73,9 +76,22 @@ const shiftWindow = (before, after, twindow, dim) => {
   });
 };
 
+// a function that gives the value of the submitted usage in the
+// dimension window.
+const cellfn = (timeWindow, processed, usageTime) => {
+  return (dimension) => {
+    const index = timeWindowIndex(timeWindow[dimensions.
+      indexOf(dimension)], new Date(processed), new Date(usageTime),
+      dimensions[dimensions.indexOf(dimension)]);
+    
+    return timeWindow[dimensions.indexOf(dimension)][index] &&
+      timeWindow[dimensions.indexOf(dimension)][index].quantity;
+  };
+};
+
 module.exports.zeroLowerTimeDimensions = zeroLowerTimeDimensions;
 module.exports.diff = diff;
 module.exports.timeWindowIndex = timeWindowIndex;
 module.exports.timeWindowBounds = timeWindowBounds;
 module.exports.shiftWindow = shiftWindow;
-
+module.exports.cellfn = cellfn;

--- a/lib/utils/timewindow/src/test/test.js
+++ b/lib/utils/timewindow/src/test/test.js
@@ -142,5 +142,37 @@ describe('abacus-timewindow', () => {
       to: to
     });
   });
+
+  it('provides get cell function', () => {
+    const June7th = 1465282800001;
+    const June8th = 1465369200001;
+
+    // Slack set to 2D. processed June8th, doc is at June7th
+    let cellfn = time.cellfn([[null],
+      [null],
+      [null],
+      [{ quantity: 5 }, { quantity: 25 }],
+      [{ quantity: 30 }, null]], June8th, June7th);
+
+    
+    expect(cellfn('s')).to.equal(undefined);
+    expect(cellfn('m')).to.equal(undefined);
+    expect(cellfn('h')).to.equal(undefined);
+    expect(cellfn('D')).to.equal(25);
+    expect(cellfn('M')).to.equal(30);
+
+    // Slack set to 2D. processed June8th, doc is at June8th
+    cellfn = time.cellfn([[null],
+      [null],
+      [null],
+      [{ quantity: 5 }, { quantity: 25 }],
+      [{ quantity: 30 }, null]], June8th, June8th);
+
+    expect(cellfn('s')).to.equal(null);
+    expect(cellfn('m')).to.equal(null);
+    expect(cellfn('h')).to.equal(null);
+    expect(cellfn('D')).to.equal(5);
+    expect(cellfn('M')).to.equal(30);
+  });
 });
 


### PR DESCRIPTION
- Accumulate will have access to the previous accumulated time window.
- Aggregate will have access to the previous aggregated time window and the incoming accumulated usage.
- Add cellfn in timewindow. Given a timewindow, the time the timewindow was created, and the usage's event time, it will returns a function that takes in a timewindow dimension(s, m, h, D, M) and returns the timewindow[dimension][event time].