### PR TITLE
Support doc updates on MongoDB

### DIFF
--- a/lib/utils/mongoclient/src/index.js
+++ b/lib/utils/mongoclient/src/index.js
@@ -193,7 +193,7 @@ const errdb = (name, err) => ({
     deleteOne: (doc, cb) => setImmediate(() => cb(err)),
     deleteMany: (docs, opt, cb) => setImmediate(() => cb(err)),
     initializeOrderedBulkOp: () => ({
-      insertOne: (doc) => {},
+      insert: (doc) => {},
       find: (id) => ({
         upsert: () => ({
           updateOne: (doc) => {}
@@ -576,7 +576,7 @@ const mongoclient = (part, uri, cons) => {
             cb(null, undefined);
             return;
           }
-          cb(error(err), val);
+          cb(error(err), val ? extend(val, { _rev: '1' }) : val);
         });
       }, 'read', {
         _id: id
@@ -592,18 +592,35 @@ const mongoclient = (part, uri, cons) => {
       const t0 = Date.now();
       singleOp((db, doc, cb) => {
         const collection = db.collection(getCollectionName(db));
-        collection.insertOne(doc, (err, val) => {
-          if (err && err.code && err.code === 11000) {
-            // Warning: mutating variable err, but that's intentional
-            err.status = 409;
-            cb(error(err), undefined);
-            return;
-          }
-          cb(error(err), {
-            ok: true,
-            id: val ? val.insertedId : undefined
+        if(doc._rev)
+          collection.updateOne({ _id: doc._id },
+            { $set: omit(doc, '_rev') }, (err, val) => {
+              if (err && err.code && err.code === 11000) {
+                // Warning: mutating variable err, but that's intentional
+                err.status = 409;
+                cb(error(err), undefined);
+                return;
+              }
+              cb(error(err), {
+                ok: val && val.modifiedCount,
+                id: val && val.modifiedCount ? doc._id : undefined,
+                rev: val && val.modifiedCounti ? '1' : undefined
+              });
+            });
+        else
+          collection.insertOne(doc, (err, val) => {
+            if (err && err.code && err.code === 11000) {
+              // Warning: mutating variable err, but that's intentional
+              err.status = 409;
+              cb(error(err), undefined);
+              return;
+            }
+            cb(error(err), {
+              ok: true,
+              id: val ? val.insertedId : undefined,
+              rev: val ? '1' : undefined
+            });
           });
-        });
       }, 'write', dbify(doc), dbopt.partition, pool, (err, val) => {
         perf.report('db.put', t0);
         cb(err, val);
@@ -617,7 +634,7 @@ const mongoclient = (part, uri, cons) => {
       singleOp((db, doc, cb) => {
         const collection = db.collection(getCollectionName(db));
         collection.deleteOne({ _id: doc._id },
-          (err, val) => cb(error(err), { ok: true, id: doc._id })
+          (err, val) => cb(error(err), { ok: true, id: doc._id, rev: '1' })
         );
       }, 'write', dbify(doc, {
         _deleted: true
@@ -653,7 +670,8 @@ const mongoclient = (part, uri, cons) => {
               return cb(null, []);
             }
             return cb(null, map(res, (result) =>
-              extend(opt.include_docs === true ? { doc: result } : {},
+              extend(opt.include_docs === true ?
+                { doc: result ? extend(result, { _rev: '1' }) : result } : {},
                 { id: result._id })
             ));
           });
@@ -687,7 +705,8 @@ const mongoclient = (part, uri, cons) => {
               })));
             }
             return cb(null, map(res, (result) =>
-              extend(opt.include_docs === true ? { doc: result } : {},
+              extend(opt.include_docs === true ?
+                { doc: result ? extend(result, { _rev: '1' }) : result } : {},
                 { id: result._id })
             ));
           });
@@ -710,10 +729,13 @@ const mongoclient = (part, uri, cons) => {
         const collection = db.collection(getCollectionName(db));
         const bulk = collection.initializeOrderedBulkOp();
         each(docs, (doc) => {
-          bulk.find({ _id: doc._id }).upsert().updateOne(doc);
+          if(doc._rev)
+            bulk.find({ _id: doc._id }).updateOne(omit(doc, '_rev'));
+          else
+            bulk.find({ _id: doc._id }).upsert().updateOne(doc);
         });
         bulk.execute((err, res) => err ? cb(error(err)) :
-          cb(null, map(docs, (doc) => ({ ok: true, id: doc._id })))
+          cb(null, map(docs, (doc) => ({ ok: true, id: doc._id, rev: '1' })))
         );
       }, 'write', map(docs, (doc) => dbify(doc)),
       opt, dbopt.partition, pool, (err, val) => {
@@ -748,9 +770,11 @@ const mongoclient = (part, uri, cons) => {
               error: 'not_found'
             })));
           }
-          return cb(null, map(docs, (doc) =>
+          return cb(null, map(map(docs, (doc) =>
             ({ doc: find(res, (r) => doc._id === r._id) })
-          ));
+          ), (row) => ({
+            doc: row.doc ? extend(row.doc, { _rev: '1' }) : row.doc
+          })));
         });
       }, 'read', map(batch, (args) => ({
         _id: args[0]
@@ -781,9 +805,15 @@ const mongoclient = (part, uri, cons) => {
         // Update the proper subset of the list of docs on each
         // selected db partition
         const collection = db.collection(getCollectionName(db));
-        collection.insertMany(docs, opt,
-          (err, res) => err ? cb(error(err)) :
-            cb(null, map(res.insertedIds, (id) => ({ ok: true, id: id })))
+        const bulk = collection.initializeOrderedBulkOp();
+        each(docs, (doc) => {
+          if(doc._rev)
+            bulk.find({ _id: doc._id }).updateOne(omit(doc, '_rev'));
+          else
+            bulk.insert(doc);
+        });
+        bulk.execute((err, res) => err ? cb(error(err)) :
+          cb(null, map(docs, (doc) => ({ ok: true, id: doc._id, rev: '1' })))
         );
       }, 'write', map(batch, (args) => dbify(args[0])),
       {}, dbopt.partition, pool,
@@ -815,7 +845,7 @@ const mongoclient = (part, uri, cons) => {
         collection.deleteMany({
           _id: { $in: pluck(docs, '_id') }
         }, opt, (err, res) => err ? cb(error(err)) :
-          cb(null, map(docs, (doc) => ({ ok: true, id: doc._id })))
+          cb(null, map(docs, (doc) => ({ ok: true, id: doc._id, rev: '1' })))
         );
       }, 'write', map(batch, (args) => dbify(args[0], {
         _deleted: true


### PR DESCRIPTION
Adjust the mongoclient module to provide support for updates, _rev and
rev fields compatible with the couchclient module.

Put now uses updateOne if the given doc contains a _rev field.

Batch_put and bulkDocs now use a MongoDB Bulk op with either updateOnes
for updates and insertOnes for inserts.

Documents returned by geti, batch_get, and allDocs now return a _rev field
set to '1' to allow the caller to detect that the doc comes from a version
of the doc in the DB (as opposed to a new doc that's not been written to
the DB yet).

Put, batch_put, remove, batch_remove and bulkDocs now return a rev field
set to '1' in their results, to allow the caller to use that rev field
and propagate it to updates of the retrieved doc.

Fixes #347.