### PR TITLE
Move resource instance references to consumers

### DIFF
--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -133,8 +133,7 @@ const Org = function(id) {
   extend(this, {
     organization_id: id,
     resources: [],
-    spaces: [],
-    resource_instances: []
+    spaces: []
   });
 };
 const newOrg = function(id) {
@@ -166,21 +165,7 @@ Org.Space.prototype.consumer = function(id, doctime) {
     shouldNotPrune(c.t.match(/(\d+)/)[0]));
 };
 
-// Represent a resource instance reference
-Org.ResourceInstance = function(key) {
-  extend(this, {
-    key: key
-  });
-};
-Org.prototype.resource_instance = function(key, time, processed) {
-  const instance = lazyCons(this.resource_instances, 'key', key,
-    Org.ResourceInstance);
-  instance.id = dbclient.kturi(key, time);
-  instance.processed = processed;
-  this.resource_instances = filter(this.resource_instances,
-    (ri) => shouldNotPrune(ri.processed));
-  return instance;
-};
+
 
 // Represent a consumer reference
 // id represents consumer_id
@@ -200,9 +185,6 @@ const Consumer = function(id) {
 };
 const newConsumer = function(id) {
   return new Consumer(id);
-};
-Consumer.prototype.resource = function(id) {
-  return lazyCons(this.resources, 'resource_id', id, Org.Resource);
 };
 
 // Represent a resource and its aggregated metric usage
@@ -248,11 +230,62 @@ Org.Metric = function(metric) {
   });
 };
 
+Consumer.Resource = function(id) {
+  extend(this, {
+    resource_id: id,
+    plans: [],
+    aggregated_usage: []
+  });
+};
+
+Consumer.prototype.resource = function(id) {
+  return lazyCons(this.resources, 'resource_id', id, Consumer.Resource);
+};
+
+Consumer.Resource.prototype.metric = function(metric) {
+  return lazyCons(this.aggregated_usage, 'metric', metric, Org.Metric);
+};
+
+Consumer.Plan = function(id) {
+  extend(this, {
+    plan_id: id,
+    aggregated_usage: [],
+    resource_instances: []
+  }, object(
+    ['metering_plan_id', 'rating_plan_id', 'pricing_plan_id'],
+    rest(id.split('/'))
+  ));
+};
+
+Consumer.Resource.prototype.plan = function(id) {
+  return lazyCons(this.plans, 'plan_id', id, Consumer.Plan);
+};
+
+Consumer.Plan.prototype.metric = function(metric) {
+  return lazyCons(this.aggregated_usage, 'metric', metric, Org.Metric);
+};
+
+// Represent a resource instance reference
+Consumer.ResourceInstance = function(rid) {
+  extend(this, {
+    id: rid
+  });
+};
+
+Consumer.Plan.prototype.resource_instance = function(rid, time, processed) {
+  const instance = lazyCons(this.resource_instances, 'id', rid,
+    Consumer.ResourceInstance);
+  instance.t = time;
+  instance.p = processed;
+  this.resource_instances = filter(this.resource_instances,
+    (ri) => shouldNotPrune(ri.p));
+  return instance;
+};
+
 // Revive an org object
 const reviveOrg = (org) => {
   org.resource = Org.prototype.resource;
   org.space = Org.prototype.space;
-  org.resource_instance = Org.prototype.resource_instance;
   map(org.resources, (s) => {
     s.plan = Org.Resource.prototype.plan;
     s.metric = Org.Resource.prototype.metric;
@@ -278,10 +311,11 @@ const reviveOrg = (org) => {
 const reviveCon = (con) => {
   con.resource = Consumer.prototype.resource;
   map(con.resources, (r) => {
-    r.plan = Org.Resource.prototype.plan;
-    r.metric = Org.Resource.prototype.metric;
+    r.plan = Consumer.Resource.prototype.plan;
+    r.metric = Consumer.Resource.prototype.metric;
     map(r.plans, (p) => {
-      p.metric = Org.Plan.prototype.metric;
+      p.metric = Consumer.Plan.prototype.metric;
+      p.resource_instance = Consumer.Plan.prototype.resource_instance;
     });
   });
   return con;
@@ -466,14 +500,14 @@ const aggregate = function *(aggrs, u) {
     aggr(
       newa.space(u.space_id).resource(u.resource_id).plan(pid)
       .metric(ua.metric), true);
-    newa.resource_instance(okeys(u)[2], otimes(u)[2], u.processed);
 
     // Apply the aggregate function to the consumer usage tree
     newa.space(u.space_id).consumer(u.consumer_id || 'UNKNOWN',
       seqid.sample(dbclient.t(u.id), sampling));
     aggr(newc.resource(u.resource_id).metric(ua.metric), false);
-    aggr(
-      newc.resource(u.resource_id).plan(pid).metric(ua.metric), true);
+    aggr(newc.resource(u.resource_id).plan(pid).metric(ua.metric), true);
+    newc.resource(u.resource_id).plan(pid).resource_instance(
+      u.resource_instance_id, otimes(u)[2], u.processed);
   });
 
   // Remove aggregated usage object behavior and return

--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -122,7 +122,7 @@ describe('abacus-usage-aggregator', () => {
       });
     };
 
-    const resource = (quantities, costs) => {
+    const resource = (quantities, costs, instances) => {
       return [{
         resource_id: 'test-resource',
         aggregated_usage: [{
@@ -145,11 +145,6 @@ describe('abacus-usage-aggregator', () => {
     const aggregated = [{
       organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
       resources: resource([12, 22, 32, 42, 52], [1, 2, 3, 4, 5]),
-      resource_instances: [{
-        key: 'key',
-        id: 'k/key/t/0001420286400000',
-        processed: 1420286400000
-      }],
       spaces: [
         {
           space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
@@ -162,11 +157,6 @@ describe('abacus-usage-aggregator', () => {
     }, {
       organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
       resources: resource([112, 122, 132, 142, 152], [11, 12, 13, 14, 15]),
-      resource_instances: [{
-        key: 'key',
-        id: 'k/key/t/0001420286400000',
-        processed: 1420286400000
-      }],
       spaces: [
         {
           space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
@@ -202,8 +192,6 @@ describe('abacus-usage-aggregator', () => {
       'aaeae239-f3f8-483c-9dd0-de5d41c38b6a').consumer(
         'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
         '0001420286400000/0001420286400000');
-    agg[0].resource_instance('key', '0001420286400000', 1420286400000);
-    agg[0].resource_instance('keys', '0001420286400000', 0);
 
     // Serialize to JSON to simulate db storage and retrieval, and expect
     // the object tree to match
@@ -233,8 +221,6 @@ describe('abacus-usage-aggregator', () => {
       'aaeae239-f3f8-483c-9dd0-de5d41c38b6a').consumer(
         'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
         '0001420286400000/0001420286400000');
-    agg[1].resource_instance('key', '0001420286400000', 1420286400000);
-    agg[1].resource_instance('keys', '0001420286400000', 0);
 
     // Serialize to JSON to simulate db storage and retrieval, and expect
     // the object tree to match
@@ -319,7 +305,7 @@ describe('abacus-usage-aggregator', () => {
         return win;
       };
 
-      // Helper function for creating resources
+      // Helper function for creating org resources
       const resource = (apiDQ, apiMQ, memDQ, memMQ, apiDC, apiMC,
         memDC, memMC) => {
         return [{
@@ -347,19 +333,6 @@ describe('abacus-usage-aggregator', () => {
         }];
       };
 
-      // Helper function for creating resource instance references
-      const resourceInstance = (a) => {
-        const key = [[a.organization_id, secured ? 1 : 0].join('-'),
-          a.resource_instance_id, a.consumer_id || 'UNKNOWN',
-          a.plan_id, a.metering_plan_id, a.rating_plan_id,
-          a.pricing_plan_id].join('/');
-        return {
-          key: key,
-          id: ['k', key,
-            't', seqid.pad16(a.start), seqid.pad16(a.end)].join('/'),
-          processed: now.getTime()
-        };
-      };
       // Helper function for creating consumer references
       const consumer = (u, seq) => ({
         id: u.consumer_id,
@@ -377,7 +350,6 @@ describe('abacus-usage-aggregator', () => {
           { consumed: 13996800000, consuming: 6 }, 1.8, 1.8,
           { consumed: 518400000, consuming: 6, price: 0.00014 },
           { consumed: 13996800000, consuming: 6, price: 0.00014 }),
-        resource_instances: [resourceInstance(usage[0])],
         spaces: [
           {
             space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
@@ -398,7 +370,6 @@ describe('abacus-usage-aggregator', () => {
           { consumed: 18655200000, consuming: 8 }, 3.3, 3.3,
           { consumed: 684000000, consuming: 8, price: 0.00014 },
           { consumed: 18655200000, consuming: 8, price: 0.00014 }),
-        resource_instances: [resourceInstance(usage[1])],
         spaces: [
           {
             space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
@@ -419,8 +390,6 @@ describe('abacus-usage-aggregator', () => {
           { consumed: 25630800000, consuming: 11 }, 4.5, 4.5,
           { consumed: 920400000, consuming: 11, price: 0.00014 },
           { consumed: 25630800000, consuming: 11, price: 0.00014 }),
-        resource_instances: [resourceInstance(usage[1]),
-          resourceInstance(usage[2])],
         spaces: [
           {
             space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
@@ -441,8 +410,6 @@ describe('abacus-usage-aggregator', () => {
           { consumed: 23309600000, consuming: 10 }, 4.8, 4.8,
           { consumed: 845600000, consuming: 10, price: 0.00014 },
           { consumed: 23309600000, consuming: 10, price: 0.00014 }),
-        resource_instances: [resourceInstance(usage[1]),
-          resourceInstance(usage[3])],
         spaces: [
           {
             space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
@@ -454,30 +421,71 @@ describe('abacus-usage-aggregator', () => {
               (3 + (secured ? 4 : 0)))]
           }]
       }];
+
+      // Helper function to create resource instance reference
+      const rireference = (usage) => {
+        return {
+          id: usage.resource_instance_id,
+          t: [seqid.pad16(usage.start), seqid.pad16(usage.end)].join('/'),
+          p: Date.now()
+        };
+      };
+
+      // Helper function for creating consumer resources
+      const cresource = (apiDQ, apiMQ, memDQ, memMQ, apiDC, apiMC,
+        memDC, memMC, usages) => {
+        return [{
+          resource_id: 'test-resource',
+          aggregated_usage: [{
+            metric: 'heavy_api_calls',
+            windows: twindows(apiDQ, apiMQ)
+          }, {
+            metric: 'memory',
+            windows: twindows(memDQ, memMQ)
+          }],
+          plans: [{
+            plan_id: pid,
+            rating_plan_id: 'test-rating-plan',
+            pricing_plan_id: 'test-pricing-basic',
+            metering_plan_id: 'test-metering-plan',
+            resource_instances: map(usages, rireference),
+            aggregated_usage: [{
+              metric: 'heavy_api_calls',
+              windows: twindows(apiDQ, apiMQ, apiDC, apiMC)
+            }, {
+              metric: 'memory',
+              windows: twindows(memDQ, memMQ, memDC, memMC)
+            }]
+          }]
+        }];
+      };
+
       const consumers = [{
         consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
-        resources: resource(12, 12, { consumed: 518400000, consuming: 6 },
+        resources: cresource(12, 12, { consumed: 518400000, consuming: 6 },
           { consumed: 13996800000, consuming: 6 }, 1.8, 1.8,
           { consumed: 518400000, consuming: 6, price: 0.00014 },
-          { consumed: 13996800000, consuming: 6, price: 0.00014 })
+          { consumed: 13996800000, consuming: 6, price: 0.00014 }, [usage[0]])
       },{
         consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
-        resources: resource(22, 22, { consumed: 684000000, consuming: 8 },
+        resources: cresource(22, 22, { consumed: 684000000, consuming: 8 },
           { consumed: 18655200000, consuming: 8 }, 3.3, 3.3,
           { consumed: 684000000, consuming: 8, price: 0.00014 },
-          { consumed: 18655200000, consuming: 8, price: 0.00014 })
+          { consumed: 18655200000, consuming: 8, price: 0.00014 }, [usage[1]])
       },{
         consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
-        resources: resource(30, 30, { consumed: 920400000, consuming: 11 },
+        resources: cresource(30, 30, { consumed: 920400000, consuming: 11 },
           { consumed: 25630800000, consuming: 11 }, 4.5, 4.5,
           { consumed: 920400000, consuming: 11, price: 0.00014 },
-          { consumed: 25630800000, consuming: 11, price: 0.00014 })
+          { consumed: 25630800000, consuming: 11, price: 0.00014 }, [usage[1],
+          usage[2]])
       },{
         consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
-        resources: resource(32, 32, { consumed: 845600000, consuming: 10 },
+        resources: cresource(32, 32, { consumed: 845600000, consuming: 10 },
           { consumed: 23309600000, consuming: 10 }, 4.8, 4.8,
           { consumed: 845600000, consuming: 10, price: 0.00014 },
-          { consumed: 23309600000, consuming: 10, price: 0.00014 })
+          { consumed: 23309600000, consuming: 10, price: 0.00014 }, [usage[1],
+          usage[3]])
       }];
 
       // Set the SECURED environment variable

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -34,6 +34,7 @@ const filter = _.filter;
 const reduce = _.reduce;
 const zip = _.zip;
 const unzip = _.unzip;
+const find = _.find;
 
 const tmap = yieldable(transform.map);
 
@@ -71,8 +72,34 @@ const uris = urienv({
 // Configure rated usage db
 const aggregatordb = dataflow.db('abacus-aggregator-aggregated-usage');
 
+
+// The scaling factor of each time window for creating the date string
+// [Second, Minute, Hour, Day, Month]
+const slack = () => /^[0-9]+[MDhms]$/.test(process.env.SLACK) ? {
+  scale : process.env.SLACK.charAt(process.env.SLACK.length - 1),
+  width : process.env.SLACK.match(/[0-9]+/)[0]
+} : {
+  scale : 'm',
+  width : 10
+};
+
+// Returns first day of the month
+const firstday = (t) => {
+  const d = new Date(t);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
+};
+
 // Time dimensions
 const dimensions = ['s', 'm', 'h', 'D', 'M'];
+
+// Millisecond representation of the time dimensions
+const msDimensions = {
+  M: 2678400000,
+  D: 86400000,
+  h: 3600000,
+  m: 60000,
+  s: 1000
+};
 
 // Return the charge function for a given plan and metric
 const chargefn = (metrics, metric) => {
@@ -400,6 +427,7 @@ const consumerUsage = function *(u) {
               });
             });
             map(resource.plans, (plan) => {
+              delete plan.resource_instances;
               map(plan.aggregated_usage, (au) => {
                 map(au.windows, (w, i) => {
                   timewindow.shiftWindow(new Date(consumer.processed),
@@ -482,8 +510,8 @@ const orgsUsage = function *(orgids, time, auth) {
 
 // Return the usage for a resource instance for a particular plan in a given
 // organization, consumer, time period
-const resourceInstanceUsage = function *(
-  orgid, resid, conid, planid, mplanid, rplanid, pplanid, time, auth) {
+const resourceInstanceUsage = function *(orgid, spaceid, resid, conid, planid,
+  mplanid, rplanid, pplanid, time, auth) {
   // Forward authorization header field to account to authorize
   const o = auth ? { headers: { authorization: auth } } : {};
 
@@ -503,15 +531,18 @@ const resourceInstanceUsage = function *(
     throw res;
   }
 
+
   // Compute the query range
   const t = time || Date.now();
-  const d = new Date(t);
-  const mt = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
-  const sid = dbclient.kturi(orgid, seqid.pad16(t)) + 'ZZZ';
-  const eid = dbclient.kturi(orgid, seqid.pad16(mt));
+  const slackLimit = msDimensions[slack().scale] * slack().width;
+  const mt = firstday(firstday(t) - slackLimit);
+  const sid = dbclient.kturi([orgid, spaceid, conid].join('/'), seqid.pad16(t))
+    + '~';
+  const eid = dbclient.kturi([orgid, spaceid, conid].join('/'),
+    seqid.pad16(mt));
 
-  debug('Retrieving latest rated usage between %s and %s', eid, sid);
-  const org = yield aggregatordb.allDocs({
+  debug('Retrieving latest consumer usage between %s and %s', eid, sid);
+  const consumer = yield aggregatordb.allDocs({
     endkey: eid,
     startkey: sid,
     descending: true,
@@ -519,21 +550,34 @@ const resourceInstanceUsage = function *(
     include_docs: true
   });
 
-  if(!org.rows.length) {
-    debug('No existing rated usage');
+  if(!consumer.rows.length) {
+    debug('No existing consumer aggregated usage');
 
     // Return an empty usage report if no usage was found
     return {};
   }
-  const instance = filter(org.rows[0].doc.resource_instances, (i) => i.key ===
-    [orgid, resid, conid, planid, mplanid, rplanid, pplanid].join('/'));
 
-  if(!instance.length) {
-    debug('Resource instance %s not found for organization %s', resid, orgid);
+  const plankey = [planid, mplanid, rplanid, pplanid].join('/');
+  let id = '';
+  find(consumer.rows[0].doc.resources, (r) => {
+    return find(r.plans, (p) => {
+      return p.plan_id === plankey ? find(p.resource_instances, (ri) => {
+        if(ri.id === resid) {
+          id = ['k', orgid, resid, conid, planid, mplanid, rplanid,
+          pplanid, 't', ri.t].join('/');
+          return id;
+        }
+        return false;
+      }) : false;
+    });
+  });
+
+  if(!id) {
+    debug('Resource instances %s not found for organization %s', resid, orgid);
     return {};
   }
 
-  const doc = yield aggregatordb.get(instance[0].id);
+  const doc = yield aggregatordb.get(id);
 
   debug('Found accumulated usage %o', doc);
   return yield chargeInstanceUsage(t,
@@ -646,6 +690,10 @@ const graphSchema = new GraphQLSchema({
             name: 'organization_id',
             type: new GraphQLNonNull(GraphQLString)
           },
+          space_id: {
+            name: 'space_id',
+            type: new GraphQLNonNull(GraphQLString)
+          },
           consumer_id: {
             name: 'consumer_id',
             type: new GraphQLNonNull(GraphQLString)
@@ -681,9 +729,10 @@ const graphSchema = new GraphQLSchema({
         },
         resolve: (root, args) => {
           return yieldable.promise(resourceInstanceUsage)(
-            args.organization_id, args.resource_instance_id, args.consumer_id,
-            args.plan_id, args.metering_plan_id, args.rating_plan_id,
-            args.pricing_plan_id, args.time, args.authorization);
+            args.organization_id, args.space_id, args.resource_instance_id,
+            args.consumer_id, args.plan_id, args.metering_plan_id,
+            args.rating_plan_id, args.pricing_plan_id, args.time,
+            args.authorization);
         }
       }
     })
@@ -721,8 +770,8 @@ const retrieveResourceInstanceUsage = function *(req) {
     req.params.resource_instance_id, req.params.time);
 
   const doc = yield resourceInstanceUsage(req.params.organization_id,
-    req.params.resource_instance_id, req.params.consumer_id,
-    req.params.plan_id, req.params.metering_plan_id,
+    req.params.space_id, req.params.resource_instance_id,
+    req.params.consumer_id, req.params.plan_id, req.params.metering_plan_id,
     req.params.rating_plan_id, req.params.pricing_plan_id,
     req.params.time ? parseInt(req.params.time) : undefined,
     req.headers && req.headers.authorization);
@@ -746,16 +795,16 @@ routes.get(
   throttle(retrieveUsage));
 
 routes.get(
-  '/v1/metering/organizations/:organization_id/resource_instances/' +
-  ':resource_instance_id/consumers/:consumer_id/plans/:plan_id/' +
-  'metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/' +
+  '/v1/metering/organizations/:organization_id/spaces/:space_id/' +
+  'resource_instances/:resource_instance_id/consumers/:consumer_id/plans/' +
+  ':plan_id/metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/' +
   'pricing_plans/:pricing_plan_id/aggregated/usage/:time',
   throttle(retrieveResourceInstanceUsage));
 
 routes.get(
-  '/v1/metering/organizations/:organization_id/resource_instances/' +
-  ':resource_instance_id/consumers/:consumer_id/plans/:plan_id/' +
-  'metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/' +
+  '/v1/metering/organizations/:organization_id/spaces/:space_id/' +
+  'resource_instances/:resource_instance_id/consumers/:consumer_id/plans/' +
+  ':plan_id/metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/' +
   'pricing_plans/:pricing_plan_id/aggregated/usage',
   throttle(retrieveResourceInstanceUsage));
 

--- a/lib/aggregation/reporting/src/test/test.js
+++ b/lib/aggregation/reporting/src/test/test.js
@@ -13,8 +13,6 @@ const dbclient = require('abacus-dbclient');
 
 const map = _.map;
 const extend = _.extend;
-const initial = _.initial;
-const rest = _.rest;
 
 const brequest = batch(request);
 
@@ -2821,11 +2819,20 @@ describe('abacus-usage-report', () => {
   context('when accumulated usage has small numbers', () => {
     before((done) => {
 
-      const aggregated = {
-        id: 'k/a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27/t/0001446508700000',
-        resource_instances: [{
-          id: accid,
-          key: rest(initial(accid.split('/'), 2)).join('/')
+      const caggregated = {
+        id: 'k/a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27/' +
+        'aaeae239-f3f8-483c-9dd0-de5d41c38b6a/UNKNOWN/t/0001446508700000',
+        resources: [{
+          resource_id: 'test-resource',
+          plans: [{
+            plan_id: 'basic/test-metering-plan/test-rating-plan/' +
+              'test-pricing-basic',
+            resource_instances: [{
+              id: rid,
+              t: '0001446418800000',
+              processed: 1446418800000
+            }]
+          }]
         }]
       };
 
@@ -2833,7 +2840,7 @@ describe('abacus-usage-report', () => {
         { current: 1 }, { current: 1 }, { current: 100 }, 1, 0.03, 15,
         undefined, true, undefined));
 
-      storeRatedUsage(aggregated, () => storeRatedUsage(accumulated, done));
+      storeRatedUsage(caggregated, () => storeRatedUsage(accumulated, done));
     });
 
     it('Retrieve accumulated usage', (done) => {
@@ -2872,16 +2879,17 @@ describe('abacus-usage-report', () => {
 
         // Get the accumulated usage
         request.get(
-          'http://localhost::p/v1/metering/organizations/' +
-          ':organization_id/resource_instances/:resource_instance_id/' +
-          'consumers/:consumer_id/plans/:plan_id/' +
-          'metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/' +
+          'http://localhost::p/v1/metering/organizations/:organization_id/' +
+          'spaces/:space_id/resource_instances/:resource_instance_id/' +
+          'consumers/:consumer_id/plans/:plan_id/metering_plans/' +
+          ':metering_plan_id/rating_plans/:rating_plan_id/' +
           'pricing_plans/:pricing_plan_id/aggregated/usage/:time', {
             p: server.address().port,
             organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
             resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
             consumer_id: 'UNKNOWN',
             plan_id: 'basic',
+            space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
             metering_plan_id: 'test-metering-plan',
             rating_plan_id: 'test-rating-plan',
             pricing_plan_id: 'test-pricing-basic',
@@ -2907,7 +2915,8 @@ describe('abacus-usage-report', () => {
 
         // Define the graphql query
         const query = '{ resource_instance(organization_id: ' +
-          '"a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27", consumer_id: "UNKNOWN", ' +
+          '"a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27", space_id: ' +
+          '"aaeae239-f3f8-483c-9dd0-de5d41c38b6a", consumer_id: "UNKNOWN", ' +
           'resource_instance_id: "0b39fa70-a65f-4183-bae8-385633ca5c87", ' +
           'plan_id: "basic", metering_plan_id: "test-metering-plan", ' +
           'rating_plan_id: "test-rating-plan", pricing_plan_id: ' +
@@ -2962,13 +2971,20 @@ describe('abacus-usage-report', () => {
   context('when querying complex usage with graphql', () => {
 
     before((done) => {
-      const aggregated = {
-        id: 'k/org/t/0001456185600000',
-        resource_instances: [{
-          id: 'k/org/ins/con/basic/test-metering-plan/test-rating-plan/' +
-            'test-pricing-basic/t/0001456185600000',
-          key: 'org/ins/con/basic/test-metering-plan/test-rating-plan/' +
-            'test-pricing-basic'
+
+      const caggregated = {
+        id: 'k/org/spa/con/t/0001456185600000',
+        resources: [{
+          resource_id: 'test-resource',
+          plans: [{
+            plan_id: 'basic/test-metering-plan/test-rating-plan/' +
+              'test-pricing-basic',
+            resource_instances: [{
+              id: 'ins',
+              t: '0001456185600000',
+              processed: 1456185600000
+            }]
+          }]
         }]
       };
       const accumulated = {
@@ -3001,7 +3017,7 @@ describe('abacus-usage-report', () => {
         }]
       };
 
-      storeRatedUsage(aggregated, () => storeRatedUsage(accumulated, done));
+      storeRatedUsage(caggregated, () => storeRatedUsage(accumulated, done));
     });
 
     it('Retrieve complex accumulated usage using a GraphQL query', (done) => {
@@ -3036,8 +3052,8 @@ describe('abacus-usage-report', () => {
 
         // Query with no sub selections in quantity
         const query1 = '{ resource_instance(organization_id: ' +
-          '"org", consumer_id: "con", resource_instance_id: "ins", ' +
-          'plan_id: "basic", metering_plan_id: "test-metering-plan", ' +
+          '"org", space_id: "spa", consumer_id: "con", resource_instance_id: ' +
+          '"ins", plan_id: "basic", metering_plan_id: "test-metering-plan", ' +
           'rating_plan_id: "test-rating-plan", pricing_plan_id: ' +
           '"test-pricing-basic", time: 1456185600000) { organization_id, ' +
           'consumer_id, resource_instance_id, plan_id, ' +


### PR DESCRIPTION
Removed the redundant information in the consumer references and moved them to the consumer aggregated documents. Address issue https://github.com/cloudfoundry-incubator/cf-abacus/issues/337