### PR TITLE
Duplicate Detection while extending the Pipeline #364

### DIFF
--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -410,16 +410,27 @@ const aggregate = function *(aggrs, u) {
   const newa = a ?
     extend(reviveOrg(JSON.parse(JSON.stringify(a))), {
       account_id: u.account_id,
-      end: u.end
-    }) :
-    extend(newOrg(u.organization_id), {
       start: u.start,
       end: u.end,
-      account_id: u.account_id
+      resource_instance_id: u.resource_instance_id,
+      consumer_id: u.consumer_id
+    }) :
+    extend(newOrg(u.organization_id), {
+      account_id: u.account_id,
+      start: u.start,
+      end: u.end,
+      resource_instance_id: u.resource_instance_id,
+      consumer_id: u.consumer_id
     });
 
   const newc = c ? reviveCon(JSON.parse(JSON.stringify(c))) :
     newConsumer(u.consumer_id || 'UNKNOWN');
+  extend(newc, {
+    start: u.start,
+    end: u.end,
+    organization_id: u.organization_id,
+    resource_instance_id: u.resource_instance_id
+  });
 
   // An empty doc only used to detect duplicate usage
   const iddoc = {

--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -345,6 +345,8 @@ describe('abacus-usage-aggregator', () => {
       const aggregated = [{
         organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
         account_id: '1234',
+        consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
+        resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
         accumulated_usage_id: '222',
         start: 1420243200000,
         end: 1420245000000,
@@ -365,8 +367,10 @@ describe('abacus-usage-aggregator', () => {
       }, {
         organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
         account_id: '1234',
+        consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
+        resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
         accumulated_usage_id: '223',
-        start: 1420243200000,
+        start: 1420245000000,
         end: 1420247000000,
         resources: resource(22, 22, { consumed: 684000000, consuming: 8 },
           { consumed: 18655200000, consuming: 8 }, 3.3, 3.3,
@@ -386,7 +390,9 @@ describe('abacus-usage-aggregator', () => {
         organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
         account_id: '1234',
         accumulated_usage_id: '224',
-        start: 1420243200000,
+        consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
+        resource_instance_id: '1b39fa70-a65f-4183-bae8-385633ca5c88',
+        start: 1420247000000,
         end: 1420249000000,
         resources: resource(30, 30, { consumed: 920400000, consuming: 11 },
           { consumed: 25630800000, consuming: 11 }, 4.5, 4.5,
@@ -406,7 +412,9 @@ describe('abacus-usage-aggregator', () => {
         organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
         account_id: '1234',
         accumulated_usage_id: '225',
-        start: 1420243200000,
+        consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
+        resource_instance_id: '1b39fa70-a65f-4183-bae8-385633ca5c88',
+        start: 1420249000000,
         end: 1420251000000,
         resources: resource(32, 32, { consumed: 845600000, consuming: 10 },
           { consumed: 23309600000, consuming: 10 }, 4.8, 4.8,
@@ -464,18 +472,30 @@ describe('abacus-usage-aggregator', () => {
 
       const consumers = [{
         consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
+        organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
+        start: 1420243200000,
+        end: 1420245000000,
+        resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
         resources: cresource(12, 12, { consumed: 518400000, consuming: 6 },
           { consumed: 13996800000, consuming: 6 }, 1.8, 1.8,
           { consumed: 518400000, consuming: 6, price: 0.00014 },
           { consumed: 13996800000, consuming: 6, price: 0.00014 }, [usage[0]])
       },{
         consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
+        organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
+        start: 1420245000000,
+        end: 1420247000000,
+        resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
         resources: cresource(22, 22, { consumed: 684000000, consuming: 8 },
           { consumed: 18655200000, consuming: 8 }, 3.3, 3.3,
           { consumed: 684000000, consuming: 8, price: 0.00014 },
           { consumed: 18655200000, consuming: 8, price: 0.00014 }, [usage[1]])
       },{
         consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
+        organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
+        resource_instance_id: '1b39fa70-a65f-4183-bae8-385633ca5c88',
+        start: 1420247000000,
+        end: 1420249000000,
         resources: cresource(30, 30, { consumed: 920400000, consuming: 11 },
           { consumed: 25630800000, consuming: 11 }, 4.5, 4.5,
           { consumed: 920400000, consuming: 11, price: 0.00014 },
@@ -483,6 +503,10 @@ describe('abacus-usage-aggregator', () => {
           usage[2]])
       },{
         consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
+        organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
+        resource_instance_id: '1b39fa70-a65f-4183-bae8-385633ca5c88',
+        start: 1420249000000,
+        end: 1420251000000,
         resources: cresource(32, 32, { consumed: 845600000, consuming: 10 },
           { consumed: 23309600000, consuming: 10 }, 4.8, 4.8,
           { consumed: 845600000, consuming: 10, price: 0.00014 },
@@ -535,7 +559,11 @@ describe('abacus-usage-aggregator', () => {
           'id', 'processed', 'processed_id', 'accumulated_usage_id'))
           .to.deep.equal(
           extend({},
-            omit(consumers[posts], 'accumulated_usage_id')));
+            omit(consumers[posts], 'accumulated_usage_id'), {
+              organization_id: [
+                'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
+                secured ? 1 : 0].join('-')
+            }));
         posts = posts + 1;
 
         cb(undefined, [[undefined, {

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -440,7 +440,8 @@ const consumerUsage = function *(u) {
           });
           return omit(consumer,
             ['_id', 'id', '_rev', 'accumulated_usage_id',
-            'processed', 'processed_id']);
+            'processed', 'processed_id', 'resource_instance_id', 'start',
+            'end', 'organization_id']);
         })
       });
     })
@@ -761,7 +762,8 @@ const retrieveUsage = function *(req) {
   return {
     body: omit(dbclient.undbify(doc),
       ['last_rated_usage_id', 'aggregated_usage_id',
-      'accumulated_usage_id', 'resource_instances'])
+      'accumulated_usage_id', 'resource_instance_id',
+      'consumer_id'])
   };
 };
 

--- a/lib/aggregation/reporting/src/test/test.js
+++ b/lib/aggregation/reporting/src/test/test.js
@@ -155,16 +155,21 @@ const buildPlanUsage = (plan, planUsage) => extend(planTemplate(plan), {
   aggregated_usage: planUsage
 });
 
-const ratedConsumerTemplate = (orgid, plan, a, p, processed, coid) => ({
-  id: cdid(orgid, sid, coid || cid(plan), processed),
-  consumer_id: coid || cid(plan),
-  processed: processed,
-  resources: [{
-    resource_id: 'test-resource',
-    aggregated_usage: a,
-    plans: p
-  }]
-});
+const ratedConsumerTemplate = (orgid, start, end, plan, a, p,
+    processed, coid) => ({
+      id: cdid(orgid, sid, coid || cid(plan), processed),
+      consumer_id: coid || cid(plan),
+      organization_id: orgid,
+      resource_instance_id: 'rid',
+      start: start,
+      end: end,
+      processed: processed,
+      resources: [{
+        resource_id: 'test-resource',
+        aggregated_usage: a,
+        plans: p
+      }]
+    });
 
 const consumerReferenceTemplate = (orgid, sid, plan, processed, conid) => ({
   id: conid || cid(plan),
@@ -191,6 +196,8 @@ const ratedTemplate = (id, orgid, start, end, processed, a, p, c) => ({
   id: id,
   organization_id: orgid,
   account_id: '1234',
+  resource_instance_id: 'rid',
+  consumer_id: 'cid',
   start: start,
   end: end,
   processed: processed,
@@ -318,7 +325,8 @@ describe('abacus-usage-report', () => {
            'external:bbeae239-f3f8-483c-9dd0-de6781c38bab')
         ]);
 
-      const consumer1 = ratedConsumerTemplate(orgid, 'basic',
+      const consumer1 = ratedConsumerTemplate(orgid, 1420502400000,
+        1420502500000, 'basic',
         buildAggregatedUsage(1, 100, 300, {
           consumed: 475200000,
           consuming: 6
@@ -327,7 +335,8 @@ describe('abacus-usage-report', () => {
           consuming: 6
         }), [buildPlanUsage('basic', planAUsage)], 1420502500000);
 
-      const consumer2 = ratedConsumerTemplate(orgid, 'standard',
+      const consumer2 = ratedConsumerTemplate(orgid, 1420502400000,
+        1420502500000, 'standard',
         buildAggregatedUsage(20, 200, 3000, {
           consumed: 633600000,
           consuming: 8
@@ -616,6 +625,8 @@ describe('abacus-usage-report', () => {
     before((done) => {
       const bigNumberRated = {
         organization_id: '610f6508-8b5d-4840-888d-0615ade33117',
+        consumer_id: 'UNKNOWN',
+        resource_instance_id: rid,
         resources: [
           {
             resource_id: 'test-resource',
@@ -1728,6 +1739,10 @@ describe('abacus-usage-report', () => {
         id: 'k/610f6508-8b5d-4840-888d-0615ade33117/' +
           '582018c9-e396-4f59-9945-b1bd579a819b/UNKNOWN/t/1448457444188',
         consumer_id: 'UNKNOWN',
+        organization_id: '610f6508-8b5d-4840-888d-0615ade33117',
+        resource_instance_id: rid,
+        start: 1448284898000,
+        end: 1448457443000,
         resources: [
           {
             resource_id: 'test-resource',
@@ -1923,6 +1938,10 @@ describe('abacus-usage-report', () => {
         id: 'k/610f6508-8b5d-4840-888d-0615ade33117/' +
           'c228ecc8-15eb-446f-a4e6-a2d05a729b98/UNKNOWN/t/1448457444188',
         consumer_id: 'UNKNOWN',
+        organization_id: '610f6508-8b5d-4840-888d-0615ade33117',
+        resource_instance_id: rid,
+        start: 1448284898000,
+        end: 1448457443000,
         resources: [
           {
             resource_id: 'test-resource',
@@ -2117,6 +2136,10 @@ describe('abacus-usage-report', () => {
         id: 'k/610f6508-8b5d-4840-888d-0615ade33117/' +
           '69d4d85b-03f7-436e-b293-94d1803b42bf/UNKNOWN/t/1448457444188',
         consumer_id: 'UNKNOWN',
+        organization_id: '610f6508-8b5d-4840-888d-0615ade33117',
+        resource_instance_id: rid,
+        start: 1448284898000,
+        end: 1448457443000,
         resources: [
           {
             resource_id: 'test-resource',
@@ -2279,6 +2302,10 @@ describe('abacus-usage-report', () => {
         id: 'k/610f6508-8b5d-4840-888d-0615ade33117/' +
           '4ef2f706-f2ae-4be5-a18c-40a969cf8fb6/UNKNOWN/t/1448457444188',
         consumer_id: 'UNKNOWN',
+        organization_id: '610f6508-8b5d-4840-888d-0615ade33117',
+        resource_instance_id: rid,
+        start: 1448284898000,
+        end: 1448457443000,
         resources: [
           {
             resource_id: 'test-resource',
@@ -2736,21 +2763,23 @@ describe('abacus-usage-report', () => {
            'UNKNOWN'),consumerReferenceTemplate(orgid, sid, 'basic',
            1446163200000, 'UNKNOWN2')]);
 
-      const consumer = ratedConsumerTemplate(orgid, 'basic', [{
-        metric: 'memory',
-        windows: aggrWindow
-      }], [buildPlanUsage('basic', [{
-        metric: 'memory',
-        windows: planWindow
-      }])], 1446418800000);
+      const consumer = ratedConsumerTemplate(orgid, 1446415200000,
+        1446415200000, 'basic', [{
+          metric: 'memory',
+          windows: aggrWindow
+        }], [buildPlanUsage('basic', [{
+          metric: 'memory',
+          windows: planWindow
+        }])], 1446418800000);
 
-      const consumer2 = ratedConsumerTemplate(orgid, 'basic', [{
-        metric: 'memory',
-        windows: aggrWindow
-      }], [buildPlanUsage('basic', [{
-        metric: 'memory',
-        windows: planWindow
-      }])], 1446163200000, 'UNKNOWN2');
+      const consumer2 = ratedConsumerTemplate(orgid, 1446415200000,
+        1446415200000, 'basic', [{
+          metric: 'memory',
+          windows: aggrWindow
+        }], [buildPlanUsage('basic', [{
+          metric: 'memory',
+          windows: planWindow
+        }])], 1446163200000, 'UNKNOWN2');
 
       storeRatedUsage(rated, () => storeRatedUsage(consumer,
         () => storeRatedUsage(consumer2, done)));

--- a/test/aggregation/aggregator/src/test/test.js
+++ b/test/aggregation/aggregator/src/test/test.js
@@ -592,10 +592,10 @@ describe('abacus-usage-aggregator-itest', () => {
         include_docs: true },
         (err, val) => {
           try {
-            expect(clone(omit(val.rows[0].doc, ['id',
-              'processed', 'processed_id',
+            expect(clone(omit(val.rows[0].doc, ['id', 'processed',
+              'processed_id', 'consumer_id', 'resource_instance_id',
               '_id', '_rev', 'accumulated_usage_id', 'start']),
-                pruneWindows)).to.deep.equal(omit(expected, ['start']));
+              pruneWindows)).to.deep.equal(omit(expected, ['start']));
             done();
           }
           catch (e) {
@@ -603,10 +603,10 @@ describe('abacus-usage-aggregator-itest', () => {
             // data within the giveup time, forward the exception
             if(Date.now() >= processingDeadline) {
               debug('Unable to properly verify the last record');
-              expect(clone(omit(val.rows[0].doc, ['id',
-                'processed', 'processed_id',
+              expect(clone(omit(val.rows[0].doc, ['id', 'processed',
+                'processed_id', 'consumer_id', 'resource_instance_id',
                 '_id', '_rev', 'accumulated_usage_id', 'start']),
-                  pruneWindows)).to.deep.equal(omit(expected, ['start']));
+                pruneWindows)).to.deep.equal(omit(expected, ['start']));
             }
             else
               // Try the expected test again
@@ -641,11 +641,11 @@ describe('abacus-usage-aggregator-itest', () => {
                 });
               });
             });
-            expect(clone(omit(val.rows[0].doc, ['id',
-              'processed', 'processed_id',
-              '_id', '_rev', 'accumulated_usage_id', 'start']),
+            expect(clone(omit(val.rows[0].doc, ['id', 'processed', '_id',
+              '_rev', 'processed_id', 'resource_instance_id', 'organization_id',
+              'accumulated_usage_id', 'start', 'end']),
                 pruneWindows)).to.deep.equal(omit(expectedConsumer, ['start',
-                  'organization_id', 'space_id']));
+                  'end', 'organization_id', 'space_id' ]));
             done();
           }
           catch (e) {
@@ -653,11 +653,11 @@ describe('abacus-usage-aggregator-itest', () => {
             // data within the giveup time, forward the exception
             if(Date.now() >= processingDeadline) {
               debug('Unable to properly verify the last record');
-              expect(clone(omit(val.rows[0].doc,
-                ['id', 'processed', 'processed_id',
-                '_id', '_rev', 'accumulated_usage_id', 'start']),
+              expect(clone(omit(val.rows[0].doc, ['id', 'processed', '_id',
+                '_rev', 'processed_id', 'resource_instance_id',
+                'organization_id', 'accumulated_usage_id', 'start', 'end']),
                   pruneWindows)).to.deep.equal(omit(expectedConsumer, ['start',
-                    'organization_id', 'space_id']));
+                    'end', 'organization_id', 'space_id']));
             }
             else
               // Try the expected test again

--- a/test/aggregation/reporting/src/test/test.js
+++ b/test/aggregation/reporting/src/test/test.js
@@ -23,6 +23,7 @@ const clone = _.clone;
 const zip = _.zip;
 const unzip = _.unzip;
 const flatten = _.flatten;
+const omit = _.omit;
 
 // Batch the requests
 const brequest = batch(request);
@@ -441,6 +442,10 @@ describe('abacus-usage-reporting-itest', () => {
       // Create resource aggregations
       return create(consumers, (i) => {
         const consumer = {
+          organization_id: oid(o),
+          resource_instance_id: 'rid',
+          start: end + u,
+          end: end + u,
           consumer_id: cid(o, i === 0 ? s : s === 0 ? 4 : 5),
           resources: [{
             resource_id: 'test-resource',
@@ -562,6 +567,8 @@ describe('abacus-usage-reporting-itest', () => {
       id: dbclient.kturi(oid(o), end + u),
       organization_id: oid(o),
       account_id: '1234',
+      resource_instance_id: 'rid',
+      consumer_id: 'cid',
       start: end + u,
       end: end + u,
       processed: end + u,
@@ -615,11 +622,12 @@ describe('abacus-usage-reporting-itest', () => {
               return reduce(uu, sumCharges, { charge: 0 });
             });
           });
-          return c;
+          return omit(c, 'resource_instance_id', 'organization_id', 'start',
+            'end');
         });
         return s;
       });
-      return report;
+      return omit(report, 'resource_instance_id', 'consumer_id');
     };
 
 


### PR DESCRIPTION
Includes resource_instance_id and consumer_id as a part of org aggregated document. Addresses issue https://github.com/cloudfoundry-incubator/cf-abacus/issues/364