### PR TITLE
Solved processed time overwrite issue #371

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -166,7 +166,9 @@ const accumulate = function *(accums, u) {
   // produced at each reduction iteration
   const a = accums[0];
 
-  const now = Date.now();
+  // Even a millisecond difference could have the usage misplaced in the windows
+  // Use time from processed_id
+  const now = parseInt(u.processed_id);
   const slackLimit = msDimensions[slack().scale] * slack().width;
   if(u.end < now - slackLimit)
     throw extend(new Error('The usage submitted is older than ' + slackLimit +

--- a/lib/aggregation/accumulator/src/test/test.js
+++ b/lib/aggregation/accumulator/src/test/test.js
@@ -718,9 +718,9 @@ describe('abacus-usage-accumulator', () => {
     process.env.SECURED = false;
 
     // Set the clock to 2015-01-03:05:00:00
-    clock = sinon.useFakeTimers(Date.UTC(2015, 0, 3, 5), 'Date');
+    clock = sinon.useFakeTimers(Date.UTC(2016, 0, 29, 2), 'Date');
     // Returns 2015-01-03 with the given hour for testing
-    const time = (h) => Date.UTC(2015, 0, 3, h);
+    const time = (h) => Date.UTC(2016, 0, 29, h);
 
     // Create a test accumulator app
     const app = accumulator();

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -516,6 +516,9 @@ const aggregate = function *(aggrs, u) {
       dbclient.t(u.accumulated_usage_id), u.processed);
   });
 
+  shift(newa, u, parseInt(u.processed_id));
+  shift(newc, u, parseInt(u.processed_id));
+
   // Remove aggregated usage object behavior and return
   const jsa = JSON.parse(JSON.stringify([newa, newc, iddoc]));
   debug('New aggregated usage %o', jsa);

--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -109,6 +109,7 @@ describe('abacus-usage-aggregator', () => {
 
   beforeEach(() => {
     clock = sinon.useFakeTimers(Date.UTC(2015, 0, 3, 12), 'Date');
+    authorizespy = spy(function() {});
   });
 
   afterEach(() => {
@@ -437,7 +438,7 @@ describe('abacus-usage-aggregator', () => {
         return {
           id: usage.resource_instance_id,
           t: dbclient.t(usage.id),
-          p: Date.now()
+          p: usage.processed
         };
       };
 
@@ -1196,6 +1197,159 @@ describe('abacus-usage-aggregator', () => {
           .to.deep.equal(usage);
 
         check();
+      });
+    });
+  });
+
+  it('processed time falls in prev day/month', (done) => {
+    process.env.SLACK = '1D';
+    clock.restore();
+    let records = 0;
+    const usage = [
+      accumulatedUsage('p', 1467244799999, 1467244799999, 1467244799999),
+      accumulatedUsage('p', 1467331199999, 1467331199999, 1467331199999),
+      accumulatedUsage('p', 1467417599999, 1467417599999, 1467417599999),
+      accumulatedUsage('p', 1467503999999, 1467503999999, 1467503999999)
+    ];
+
+    map(usage, (u) => {
+      u.organization_id = 'timeorg';
+    });
+
+    usage[0].accumulated_usage = [{
+      metric: 'heavy_api_calls',
+      windows: [
+        [null],
+        [null],
+        [null],
+        [
+          { quantity: { current: 100 }, cost: 15 },
+          null
+        ],
+        [
+          { quantity: { current: 100 }, cost: 15 },
+          null
+        ]
+      ]
+    }];
+    usage[1].accumulated_usage = [{
+      metric: 'heavy_api_calls',
+      windows: [
+        [null],
+        [null],
+        [null],
+        [
+          { quantity: { current: 200 }, cost: 30 },
+          { quantity: { current: 100 }, cost: 15 }
+        ],
+        [
+          { quantity: { previous: 100, current: 300 }, cost: 45 },
+          null
+        ]
+      ]
+    }];
+
+    usage[2].accumulated_usage = [{
+      metric: 'heavy_api_calls',
+      windows: [
+        [null],
+        [null],
+        [null],
+        [
+          { quantity: { current: 300 }, cost: 45 },
+          { quantity: { current: 200 }, cost: 30 }
+        ],
+        [ { quantity: { current: 300 }, cost: 45 },
+          { quantity: { previous: 100, current: 300 }, cost: 45 }
+        ]
+      ]
+    }];
+
+    usage[3].accumulated_usage = [{
+      metric: 'heavy_api_calls',
+      windows: [
+        [null],
+        [null],
+        [null],
+        [
+          { quantity: { current: 400 }, cost: 60 },
+          { quantity: { current: 300 }, cost: 45 }
+        ],
+        [
+          { quantity: { previous: 300, current: 700 }, cost: 105 },
+          { quantity: { previous: 100, current: 300 }, cost: 45 }
+        ]
+      ]
+    }];
+
+    // Expected values for the different levels of aggregation
+    const expected = {
+      metric: 'heavy_api_calls',
+      windows: [[null], [null], [null],
+        [null, { quantity: 400 }],
+        [{ quantity: 700 }, { quantity: 300 }]]
+    };
+    const expectedBasic = {
+      metric: 'heavy_api_calls',
+      windows: [[null], [null], [null],
+        [null, { quantity: 400, cost: 60 }],
+        [{ quantity: 700, cost: 105 }, { quantity: 300, cost: 45 }]]
+    };
+
+    // Create a test aggregator app
+    const app = aggregator();
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    postspy = (reqs, cb) => {
+      records++;
+      cb(undefined, [[undefined, {
+        statusCode: 201
+      }], [undefined, {
+        statusCode: 201
+      }]]);
+      if(records === 4) {
+        const org = reqs[0][1].body;
+        const con = reqs[1][1].body;
+        // Check the org aggregated resources
+        expect(org.resources[0].aggregated_usage[0]).to.deep.equal(expected);
+        expect(org.resources[0].plans[0].aggregated_usage[0])
+          .to.deep.equal(expectedBasic);
+
+        // Check the space aggregated resources
+        expect(org.spaces[0].resources[0].aggregated_usage[0])
+          .to.deep.equal(expected);
+        expect(org.spaces[0].resources[0].plans[0].aggregated_usage[0])
+          .to.deep.equal(expectedBasic);
+        // Check the consumer
+        expect(con.resources[0].aggregated_usage[0]).to.deep.equal(expected);
+        expect(con.resources[0].plans[0].aggregated_usage[0])
+          .to.deep.equal(expectedBasic);
+        done();
+      }
+    };
+
+    const post = (u, done) => {
+      request.post('http://localhost::p/v1/metering/accumulated/usage', {
+        p: server.address().port,
+        body: u
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(201);
+        if(done)
+          done();
+      });
+    };
+    clock = sinon.useFakeTimers(usage[0].processed + 1, 'Date');
+    post(usage[0], () => {
+      clock = sinon.useFakeTimers(usage[1].processed + 1, 'Date');
+      post(usage[1], () => {
+        clock = sinon.useFakeTimers(usage[2].processed + 1, 'Date');
+        post(usage[2], () => {
+          clock = sinon.useFakeTimers(usage[3].processed + 1, 'Date');
+          post(usage[3], () => {});
+        });
       });
     });
   });

--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -521,7 +521,7 @@ const mapper = (mapfn, opt) => {
     const pidoc = extend({}, idoc, {
       id: dbclient.tkuri(ikey, itime),
       processed_id: seqid.pad16(itime),
-      processed: parseInt(itime)
+      processed: idoc.processed || parseInt(itime)
     }, idoc.id ? object([[idname(opt.input.type), idoc.id]]) : {});
 
     let error;
@@ -895,7 +895,7 @@ const reducer = (reducefn, opt) => {
     const pidoc = extend({}, idoc, {
       id: dbclient.tkuri(ikey, itime),
       processed_id: seqid.pad16(itime),
-      processed: parseInt(itime)
+      processed: idoc.processed || parseInt(itime)
     }, idoc.id ? object([[idname(opt.input.type), idoc.id]]) : {});
 
     // Serialize processing on leaf output doc id


### PR DESCRIPTION
Dataflow was overwriting the _processed_ time of the input docs with _itime_ which resulted in the usage in the windows being incorrect when the submissions span across time boundaries (month, day, ...) 

With the changes in this pull request,  dataflow does not alter the _processed_ filed if it is already present in the input doc. However the _processed_id_ field has the _itime_ value so that the time at which the current document is being processed can be inferred.

As a result of this change, once the aggregation is completed, the window contents needs to be shifted with respect to processed time of input accumulated usage and time at which the aggregator processed the document.

Also in the accumulator, the processed time of the output document and the time at which the measures were accumulated were not the same. That has also been fixed.

Addressed Issue https://github.com/cloudfoundry-incubator/cf-abacus/issues/371