### PR TITLE
Post to output DB when sink returns 409

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -174,7 +174,7 @@ const accumulate = function *(accums, u) {
     throw extend(new Error('The usage submitted is older than ' + slackLimit +
       ' milliseconds'), {
         status: 409,
-        error: 'conflict',
+        error: 'slack',
         reason: 'The usage submitted is older than ' + slackLimit +
           ' milliseconds',
         noretry: true,

--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -346,8 +346,10 @@ const postOutput = function *(odoc, skey, stime,
         body: omit(odoc, 'rev')
       }));
 
-    // Report sink service status
-    if(res.statusCode !== 201)
+    // Report sink service status. Allow sink duplicate to go through normally.
+    if(res.statusCode !== 201 && res.statusCode !== 409)
+      throw postError(odoc.id, res);
+    if(res.statusCode === 409 && res.body && res.body.error === 'slack')
       throw postError(odoc.id, res);
 
     debug('Posted %s successfully to sink', odoc.id);
@@ -386,10 +388,11 @@ const postOutputs = function *(odocs, skeys, stimes,
 
   debug('Checking results of post to sink');
 
-  // Compile any errors returned from the sink
+  // Compile any errors other than duplicate returned from the sink
   const ereasons = reduce(responses, (a, response) => {
     debug('post returns %o', response);
-    return response.body && response.body.error ? a.concat(response.body) : a;
+    return response.statusCode !== 409 &&
+      response.body && response.body.error ? a.concat(response.body) : a;
   }, []);
 
   // return errors if one is found from the sink
@@ -556,7 +559,7 @@ const mapper = (mapfn, opt) => {
       debug('Processed input doc %s, produced output docs %o',
         pidoc.id, map(podocs, (podoc) => podoc.id));
 
-      // Post the output docs to the configured sink
+      // Post the output docs to the configured sink.
       if(opt.sink.host && opt.sink.posts)
         error = yield postOutputs(podocs, skeys, stimes,
           opt.sink.host, opt.sink.apps, opt.sink.posts,

--- a/lib/utils/dataflow/src/test/test.js
+++ b/lib/utils/dataflow/src/test/test.js
@@ -214,6 +214,186 @@ describe('abacus-dataflow', () => {
         });
       });
     });
+
+    // Simulate situation where Sink returns 409, but the current app
+    // have not written the doc in the output db. This is possible when
+    // db returns 403 because it takes longer to write to db. The next retry
+    // would returns 409, and we don't want the earlier pipelines to not write
+    // to the db. Still throw sink if it is due to out of slack.
+    it('Save to output db when it gets duplicate(409)', (done) => {
+  
+      // Create a test Web app
+      const app = webapp();
+  
+      // Create a schema for our test docs, representing pairs of numbers
+      const Pair = {
+        validate: (doc) => doc
+      };
+  
+      // Define a test map transform that computes the sum of a pair of
+      // numbers
+      const sum = function *(doc, auth) {
+        const res = {
+          t: doc.t,
+          x: doc.x,
+          y: doc.y,
+          val: doc.x + doc.y
+        };
+        return [res];
+      };
+  
+      // Define key and time functions
+      const t0 = 1443650828616;
+      const iwscope = (doc) => undefined;
+      const irscope = (doc) => undefined;
+      const ikey = (doc) => '' + doc.x + '/' + doc.y;
+      const itime = (doc) => seqid();
+      const orscope = (doc) => undefined;
+      const okeys = (doc) => ['' + doc.x + '/' + doc.y];
+      const otimes = (doc) => [doc.t];
+      const skeys = (doc) => ['' + doc.x];
+      const stimes = (doc) => [doc.t];
+  
+      // Add a dataflow mapper middleware to our test app
+      const mapper = dataflow.mapper(sum, {
+        input: {
+          type: 'pair',
+          schema: Pair,
+          post: '/v1/pairs',
+          get: '/v1/pairs/t/:t/k/:kx/:ky',
+          dbname: 'abacus-dataflow-pair-dups',
+          wscope: iwscope,
+          rscope: irscope,
+          key: ikey,
+          time: itime
+        },
+        output: {
+          type: 'sum',
+          get: '/v1/maps/t/:t/k/:kx/:ky',
+          dbname: 'abacus-dataflow-maps-dups',
+          rscope: orscope,
+          keys: okeys,
+          times: otimes
+        },
+        sink: {
+          host: 'http://localhost:9081',
+          authentication: () => 'Bearer authentication',
+          posts: ['/v2/maps'],
+          keys: skeys,
+          times: stimes
+        }
+      });
+      app.use(mapper);
+  
+      app.use(router.batch(app));
+  
+      // Initiate a replay of any old inputs
+      dataflow.replay(mapper, 1000, (err, vals) => {
+        expect(err).to.equal(null);
+        expect(vals).to.deep.equal([]);
+  
+        // Listen on an ephemeral port
+        const server = app.listen(0);
+  
+        // Handle callback checks
+        let checks = 0;
+        const check = () => {
+          if(++checks == 4) done();
+        };
+  
+        // Expect output docs to be posted to the sink service
+        const odocs = [];
+        postspy = (reqs, cb) => {
+          expect(reqs[0][0]).to.equal('http://localhost:9081/v2/maps');
+  
+          const val = reqs[0][1];
+          expect(val.headers).to.deep.equal({
+            authorization: 'Bearer authentication'
+          });
+  
+          // Check for the expected output doc
+          const odoc = odocs[val.body.t];
+          expect(omit(
+            val.body,'id', 'pair_id', 'processed', 'processed_id'))
+            .to.deep.equal(odoc);
+          expect(val.body.id).to.match(new RegExp(
+            'k/' + odoc.x + '/' + odoc.y + '/t/' + dbclient.pad16(odoc.t)));
+          expect(val.body.pair_id).to.match(new RegExp(
+            't/00014.*-0-0-0/k/' + odoc.x + '/' + odoc.y));
+
+          cb(undefined, [[undefined, odoc.x === 3 ? {
+            statusCode: 409,
+            body: {
+              error: 'slack'
+            }
+          } : {
+            statusCode: 409
+          }]]);
+  
+          check();
+        };
+  
+        // Post a set of input docs, including a duplicate
+        treduce([1, 2, 3], (accum, ival, i, l, cb) => {
+  
+          // The test input doc
+          const idoc = {
+            t: t0 + ival,
+            x: ival,
+            y: ival + 1
+          };
+  
+          // The expected output doc
+          const odoc = {
+            t: idoc.t,
+            x: idoc.x,
+            y: idoc.y,
+            val: idoc.x + idoc.y
+          };
+          odocs[odoc.t] = odoc;
+  
+          // Post the input doc
+          request.post('http://localhost::p/v1/pairs', {
+            p: server.address().port,
+            auth: {
+              bearer: 'test'
+            },
+            body: idoc
+  
+          }, (err, pval) => {
+  
+            expect(err).to.equal(undefined);
+
+            // Simulate 409 due to slack error
+            if(i === 2) {
+              // Expect a duplicate to be detected
+              expect(pval.statusCode).to.equal(409);
+              cb();
+              return;
+            }
+  
+            // Expect a 201 result
+            expect(pval.statusCode).to.equal(201);
+  
+            // Get the input doc
+            request.get(pval.headers.location, {}, (err, val) => {
+              expect(err).to.equal(undefined);
+              expect(val.statusCode).to.equal(200);
+  
+              expect(omit(val.body,
+                'id', 'processed', 'processed_id')).to.deep.equal(idoc);
+              expect(val.body.id).to.match(new RegExp(
+                't/00014.*-0-0-0/k/' + idoc.x + '/' + idoc.y));
+  
+              cb();
+            });
+          });
+        }, undefined, (err, res) => {
+          expect(err).to.equal(undefined);
+          check();
+        });
+      });
+    });
   
     it('does not store map outputs when error exists', (done) => {
       // Create a test Web app
@@ -1067,6 +1247,193 @@ describe('abacus-dataflow', () => {
   
         // Post a set of input docs
         treduce([1, 2, 3, 3, 4, 5], (accum, ival, i, l, cb) => {
+  
+          // The test input doc
+          const idoc = {
+            t: t0 + ival,
+            x: ival
+          };
+  
+          // Post input doc
+          request.post('http://localhost::p/v1/nbs', {
+            p: server.address().port,
+            auth: {
+              bearer: 'test'
+            },
+            body: idoc
+          }, (err, pval) => {
+  
+            expect(err).to.equal(undefined);
+  
+            if(i === 3) {
+              // Expect a duplicate to be detected
+              expect(pval.statusCode).to.equal(409);
+              cb();
+              return;
+            }
+  
+            // Expect a 201 result
+            expect(pval.statusCode).to.equal(201);
+  
+            // Get the input doc
+            request.get(pval.headers.location, {}, (err, val) => {
+              expect(err).to.equal(undefined);
+              expect(val.statusCode).to.equal(200);
+  
+              expect(omit(val.body,
+                'id', 'processed', 'processed_id')).to.deep.equal(idoc);
+              expect(val.body.id).to.match(
+                new RegExp('t/00014.*-0-0-0/k/' + idoc.x));
+  
+              cb();
+            });
+          });
+        }, {
+          even: 0,
+          odd: 0
+        }, (err, res) => {
+          expect(err).to.equal(undefined);
+          check();
+        });
+      });
+    });
+
+    // Simulate situation where Sink returns 409, but the current app
+    // have not written the doc in the output db. This is possible when
+    // db returns 403 because it takes longer to write to db. The next retry
+    // would returns 409, and we don't want the earlier pipelines to not write
+    // to the db.
+    it('runs a reduce transform and stores its inputs and outputs', (done) => {
+  
+      // Create a test Web app
+      const app = webapp();
+  
+      // Create a schema for our test docs, representing pairs of numbers
+      const Nb = {
+        validate: (doc) => doc
+      };
+  
+      // Define a test reduce transform that accumulates the sum of 
+      // numbers
+      const sum = function *(accums, docs, auth) {
+        return rest(reduce(docs, (log, doc) => {
+          const res = {
+            t: doc.t,
+            x: doc.x,
+            val: last(log)[0].val + doc.x
+          };
+          return log.concat([[res]]);
+        }, [accums[0] ? accums : [{
+          val: 0
+        }, {}]]));
+      };
+  
+      // Define key, time and group functions
+      const t0 = 1443650828616;
+      const iwscope = (doc) => undefined;
+      const irscope = (doc) => undefined;
+      const ikey = (doc) => '' + doc.x;
+      const itime = (doc) => seqid();
+      const igroups = (doc) => [doc.x % 2 ? 'odd' : 'even'];
+      const orscope = (doc) => undefined;
+      const okeys = (doc) => igroups(doc);
+      const otimes = (doc) => [doc.t];
+      const skeys = (doc) => igroups(doc);
+      const stimes = (doc) => [doc.t];
+  
+      // Add a dataflow reducer middleware to our test app
+      const reducer = dataflow.reducer(sum, {
+        input: {
+          type: 'nb',
+          schema: Nb,
+          post: '/v1/nbs',
+          get: '/v1/nbs/t/:t/k/:kx',
+          dbname: 'abacus-dataflow-nbs-dups',
+          wscope: iwscope,
+          rscope: irscope,
+          key: ikey,
+          time: itime,
+          groups: igroups
+        },
+        output: {
+          type: 'sum',
+          get: '/v1/reductions/t/:t/k/:kg',
+          dbname: 'abacus-dataflow-reductions-dups',
+          rscope: orscope,
+          keys: okeys,
+          times: otimes
+        },
+        sink: {
+          host: 'http://localhost:9081',
+          authentication: () => 'Bearer authentication',
+          posts: ['/v2/reductions'],
+          keys: skeys,
+          times: stimes
+        }
+      });
+      app.use(reducer);
+  
+      app.use(router.batch(app));
+  
+      // Replay any old inputs
+      dataflow.replay(reducer, 1000, (err, vals) => {
+        expect(err).to.equal(null);
+        expect(vals).to.deep.equal([]);
+  
+        // Listen on an ephemeral port
+        const server = app.listen(0);
+  
+        // Handle callback checks
+        let checks = 0;
+        const check = () => {
+          if(++checks == 4) done();
+        };
+  
+        // Expect output docs to be posted to the sink service
+        const oaccum = {
+          odd: {
+            val: 9
+          },
+          even: {
+            val: 6
+          }
+        };
+  
+        postspy = (reqs, cb) => {
+          expect(reqs[0][0]).to.equal('http://localhost:9081/v2/reductions');
+  
+          const val = reqs[0][1];
+          expect(val.headers).to.deep.equal({
+            authorization: 'Bearer authentication'
+          });
+  
+          // Check for the expected output docs
+          const odoc = val.body;
+          expect(odoc.id).to.match(new RegExp(
+            'k/' + igroups(odoc).join('/') + '/t/' + dbclient.pad16(odoc.t)));
+          expect(odoc.nb_id).to.match(new RegExp(
+            't/00014.*-0-0-0/k/' + odoc.x));
+  
+          map(keys(oaccum), (group) => {
+            try {
+              expect(omit(odoc,
+                'id', 'nb_id', 'processed', 'processed_id', 't', 'x'))
+                .to.deep.equal(oaccum[group]);
+              check();
+            }
+            catch(e) {
+            }
+          });
+  
+          cb(undefined, [[undefined, {
+            statusCode: 409
+          }]]);
+  
+          check();
+        };
+  
+        // Post a set of input docs
+        treduce([1, 2, 3], (accum, ival, i, l, cb) => {
   
           // The test input doc
           const idoc = {


### PR DESCRIPTION
This is to solve the problem with database latency. When database write returns timeout, it doesn't means that the database write has failed. In the next retry, the duplicate detections would kicks in which will make the earlier components to not write to its output db.

Example: 
aggregator returns 403 (Even though the write didn't fail).
retry happens, and aggregator returns 409 to accumulator.
accumulator, meter, and collector would see 409 and doesn't write to its db.

Fix: when sink returns 409, treats it as 201.
