### PR TITLE
removed eureka's dependency on SECURED env var

### DIFF
--- a/lib/utils/eureka/src/index.js
+++ b/lib/utils/eureka/src/index.js
@@ -7,7 +7,9 @@ const perf = require('abacus-perf');
 const urienv = require('abacus-urienv');
 const oauth = require('abacus-oauth');
 
-const secured = () => process.env.SECURED === 'true' ? true : false;
+const defaultSecurity = process.env.SECURED === 'true' ? true : false;
+const secured = () => process.env.HEALTHCHECK_SECURED === 'false' ? false :
+                        defaultSecurity;
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-eureka');
@@ -176,4 +178,3 @@ module.exports.register = register;
 module.exports.deregister = deregister;
 module.exports.instance = instance;
 module.exports.heartbeat = heartbeat;
-


### PR DESCRIPTION
This allows the secured flag to be set for eureka's healthcheck with the SECURED_HEALTH flag. This allows the rest of the modules to be secure will letting eureka stay open so I can handle a large amount of requests without being dependent on outside tokens.