### PR TITLE
Timewindow's cellfn access the object.

### DIFF
--- a/lib/utils/timewindow/src/index.js
+++ b/lib/utils/timewindow/src/index.js
@@ -84,8 +84,7 @@ const cellfn = (timeWindow, processed, usageTime) => {
       indexOf(dimension)], new Date(processed), new Date(usageTime),
       dimensions[dimensions.indexOf(dimension)]);
     
-    return timeWindow[dimensions.indexOf(dimension)][index] &&
-      timeWindow[dimensions.indexOf(dimension)][index].quantity;
+    return timeWindow[dimensions.indexOf(dimension)][index];
   };
 };
 

--- a/lib/utils/timewindow/src/test/test.js
+++ b/lib/utils/timewindow/src/test/test.js
@@ -158,8 +158,8 @@ describe('abacus-timewindow', () => {
     expect(cellfn('s')).to.equal(undefined);
     expect(cellfn('m')).to.equal(undefined);
     expect(cellfn('h')).to.equal(undefined);
-    expect(cellfn('D')).to.equal(25);
-    expect(cellfn('M')).to.equal(30);
+    expect(cellfn('D')).to.deep.equal({ quantity: 25 });
+    expect(cellfn('M')).to.deep.equal({ quantity: 30 });
 
     // Slack set to 2D. processed June8th, doc is at June8th
     cellfn = time.cellfn([[null],
@@ -171,8 +171,8 @@ describe('abacus-timewindow', () => {
     expect(cellfn('s')).to.equal(null);
     expect(cellfn('m')).to.equal(null);
     expect(cellfn('h')).to.equal(null);
-    expect(cellfn('D')).to.equal(5);
-    expect(cellfn('M')).to.equal(30);
+    expect(cellfn('D')).to.deep.equal({ quantity: 5 });
+    expect(cellfn('M')).to.deep.equal({ quantity: 30 });
   });
 });
 


### PR DESCRIPTION
With the recent changes that adds previous_quantity in the aggregator(5dddabf8991bdcc92076b3f1965ac16a39c2a905), the timewindow's cellfn should be able to access it.

Changes: Move up the timewindow's cellfn to access the whole object instead of just the quantity.