### PR TITLE
Dataflow with no dedupe throws 409

### DIFF
--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -322,7 +322,7 @@ const buildOutputs = (
 
 // Post an output doc to the configured sink service
 const postOutput = function *(odoc, skey, stime,
-  shost, spartition, spost, authentication) {
+  shost, spartition, spost, authentication, ddup) {
 
   // Only post docs that have a post uri configured for them
   if(!spost) {
@@ -347,9 +347,10 @@ const postOutput = function *(odoc, skey, stime,
       }));
 
     // Report sink service status. Allow sink duplicate to go through normally.
-    if(res.statusCode !== 201 && res.statusCode !== 409)
-      throw postError(odoc.id, res);
-    if(res.statusCode === 409 && res.body && res.body.error === 'slack')
+    // When an app has no duplicate detection (i.e. collector), throw the 409
+    if(res.statusCode !== 201 && res.statusCode !== 409 ||
+      res.statusCode === 409 && (res.body && res.body.error === 'slack' ||
+      !ddup))
       throw postError(odoc.id, res);
 
     debug('Posted %s successfully to sink', odoc.id);
@@ -365,7 +366,7 @@ const postOutput = function *(odoc, skey, stime,
 
 // Post a list of output docs to the configured sink service
 const postOutputs = function *(odocs, skeys, stimes,
-  shost, spartition, sposts, authentication) {
+  shost, spartition, sposts, authentication, ddup) {
 
   // Find the first occurence of error in the list of docs.
   const error = find(odocs, (odoc) => odoc.error);
@@ -383,7 +384,7 @@ const postOutputs = function *(odocs, skeys, stimes,
   // Post each docs to the sink.
   const responses = yield tmap(odocs, function *(odoc, i, l) {
     return yield postOutput(odoc, skeys[i], stimes[i],
-      shost, spartition, sposts[i], authentication);
+      shost, spartition, sposts[i], authentication, ddup);
   });
 
   debug('Checking results of post to sink');
@@ -563,7 +564,7 @@ const mapper = (mapfn, opt) => {
       if(opt.sink.host && opt.sink.posts)
         error = yield postOutputs(podocs, skeys, stimes,
           opt.sink.host, opt.sink.apps, opt.sink.posts,
-          opt.sink.authentication);
+          opt.sink.authentication, ddup);
 
       // Log the output docs when there is no error encountered
       if(odb && !error)
@@ -738,7 +739,7 @@ const mapper = (mapfn, opt) => {
 const groupReduce = (itype,
   yreducefn,
   otype, ocache, odb,
-  shost, spartition, sposts) => {
+  shost, spartition, sposts, ddup) => {
 
   return yieldable(batch(batch.groupBy(function *(calls) {
     debug('Reducing a group of %d input docs with group key %s',
@@ -785,7 +786,7 @@ const groupReduce = (itype,
 
           return yield postOutputs(podocs,
             calls[i][0].skeys, calls[i][0].stimes,
-            shost, spartition, sposts, calls[i][0].authentication);
+            shost, spartition, sposts, calls[i][0].authentication, ddup);
         });
 
       // Find any errors in the post results
@@ -863,7 +864,7 @@ const reducer = (reducefn, opt) => {
   // Configure our batch grouping reduction function
   const greduce = groupReduce(opt.input.type, yreducefn,
     opt.output.type, ocache, odb,
-    opt.sink.host, opt.sink.apps, opt.sink.posts);
+    opt.sink.host, opt.sink.apps, opt.sink.posts, ddup);
 
   // Create an Express router
   const routes = router();


### PR DESCRIPTION
With the recent changes to allow 409, collector always returns 201 even with duplicates. The right approach is to returns 409 when dataflow doesn't have duplicate detection configured.