### PR TITLE
Add --copy-files flag to abacus-babel

### DIFF
--- a/tools/babel/src/index.js
+++ b/tools/babel/src/index.js
@@ -25,7 +25,8 @@ var runCLI = function() {
     '--presets', 'es2015', 
     /* '--auxiliary-comment-before', 'istanbul ignore next', */
     '--source-maps', 'inline',
-    '--out-dir', 'lib', 'src'
+    '--out-dir', 'lib', 'src',
+    '--copy-files'
   ].concat(commander.dir ? [commander.dir] : []);
   var babel = cp.spawn(path.resolve(
     __dirname, '../node_modules/.bin/babel'), args, {


### PR DESCRIPTION
Currently, when running abacus babel, .json files are not copied from src/ to lib/.

Here's my module's directory structure.

```
src/
    index.js
    foo.json
```

index.js has a require reference to foo.json.
Traditionally, when src/ gets transpiled to lib/, it only transpiles the .js files.

This PR would allow all files in the src/ directory to be either transpiled to lib/ _or_ copied over to lib/.  This is important when source code doesn't live in files with a .js extension.