### PR TITLE
Use endtime/startime in duplicate detection documents

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -87,7 +87,7 @@ const sampling = parseInt(process.env.SAMPLING) || 1;
 
 const otimes = (udoc, itime) =>
   [seqid.sample(itime, sampling),
-    map([udoc.start, udoc.end], seqid.pad16).join('/')];
+    map([udoc.end, udoc.start], seqid.pad16).join('/')];
 
 const stimes = (udoc, itime) =>
   [seqid.sample(itime, sampling), undefined];
@@ -152,7 +152,7 @@ const accum = (au, metric) => {
     maxSlack(1), maxSlack(2), maxSlack(3), maxSlack(4)];
 };
 
-// find info with error and reason to redirect 
+// find info with error and reason to redirect
 // usage to error db and stop processing it to the next pipeline.
 const findError = (info) => find(info, (i) => i.error);
 
@@ -215,7 +215,7 @@ const accumulate = function *(accums, u) {
       const rp = price(u.prices.metrics, mu.metric);
 
       const aw = accum(amerge.accumulated_usage, mu.metric);
-  
+
       // a function that gives the value of the submitted usage in the
       // dimension window.
       const getCell = timewindow.cellfn(aw, now, u.end);

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -92,7 +92,7 @@ const sampling = parseInt(process.env.SAMPLING) || 1;
 
 const otimes = (udoc, itime) =>
   [seqid.sample(itime, sampling), seqid.sample(itime, sampling),
-    map([udoc.start, udoc.end], seqid.pad16).join('/')];
+    map([udoc.end, udoc.start], seqid.pad16).join('/')];
 
 const stimes = (udoc, itime) =>
   [seqid.sample(itime, sampling), undefined];
@@ -515,11 +515,11 @@ const aggregate = function *(aggrs, u) {
     // Apply the aggregate function to the aggregated usage tree
     const pid = [u.plan_id, u.metering_plan_id, u.rating_plan_id,
       u.pricing_plan_id].join('/');
-    
+
     aggr(
       newa.resource(u.resource_id).plan(pid)
       .metric(ua.metric), true);
-    
+
     aggr(
       newa.space(u.space_id).resource(u.resource_id).plan(pid)
       .metric(ua.metric), true);
@@ -527,7 +527,7 @@ const aggregate = function *(aggrs, u) {
     // Apply the aggregate function to the consumer usage tree
     newa.space(u.space_id).consumer(u.consumer_id || 'UNKNOWN',
       seqid.sample(dbclient.t(u.id), sampling));
-    
+
     aggr(newc.resource(u.resource_id).plan(pid).metric(ua.metric), true);
 
     newc.resource(u.resource_id).plan(pid).resource_instance(


### PR DESCRIPTION
In order to keep all the duplicate detection docs for usages in a month in one database, the duplicate detection doc id has otime with endtime/starttime.