### PR TITLE
No breaker on throttled functions

### DIFF
--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -45,7 +45,18 @@ const treduce = yieldable(transform.reduce);
 const retries = process.env.SINK_RETRIES ?
   parseInt(process.env.SINK_RETRIES) : 5;
 
-const brequest = yieldable(retry(breaker(batch(throttle(request))), retries));
+const throttlelimit = process.env.THROTTLE ? parseInt(process.env.THROTTLE) :
+  100;
+const batchsize = process.env.BATCH_SIZE ? parseInt(process.env.BATCH_SIZE) :
+  100;
+
+// if a batch is throttled then, throttle limits the number of calls made to
+// the batch function limiting the number of batches. In order to avoid that
+// all the batch functions when throttled should have a throttle value that is
+// multiplied by the batch.
+
+const brequest = yieldable(throttle(retry(breaker(batch(request)),
+  retries), batchsize * throttlelimit));
 
 const lock = yieldable(lockcb);
 


### PR DESCRIPTION
When breaker is enclosed onto a throttled function, throttling might cause the breaker to timeout and throw an error. 
```
breaker(throttle(fn));
```
So throttle needs to be enclosed within breaker instead
```
throttle(breaker(fn));
```




