### PR TITLE
resource instance usage report update.

### DIFF
--- a/demo/client/src/test/test.js
+++ b/demo/client/src/test/test.js
@@ -292,6 +292,9 @@ describe('abacus-demo-client', function() {
               rating_plan_id: 'object-rating-plan',
               pricing_plan_id: 'object-pricing-basic',
               windows: buildWindow(46.09),
+              resource_instances: [{
+                id: '0b39fa70-a65f-4183-bae8-385633ca5c87'
+              }],
               aggregated_usage: [{
                 metric: 'storage',
                 windows: buildWindow(1, 1, 1, 1)
@@ -356,6 +359,10 @@ describe('abacus-demo-client', function() {
 
         // Compare the usage report we got with the expected report
         console.log('Processed %d usage docs', processed(val));
+        if(val.body)
+          val.body.spaces[0].consumers[0].resources[0].plans[0]
+            .resource_instances[0] = omit(val.body.spaces[0].consumers[0]
+            .resources[0].plans[0].resource_instances[0], 't', 'p');
         const actual = clone(omit(val.body,
           'id', 'processed', 'processed_id', 'start', 'end'), prune);
 

--- a/demo/client/src/test/test.js
+++ b/demo/client/src/test/test.js
@@ -359,14 +359,13 @@ describe('abacus-demo-client', function() {
 
         // Compare the usage report we got with the expected report
         console.log('Processed %d usage docs', processed(val));
-        if(val.body)
-          val.body.spaces[0].consumers[0].resources[0].plans[0]
-            .resource_instances[0] = omit(val.body.spaces[0].consumers[0]
-            .resources[0].plans[0].resource_instances[0], 't', 'p');
         const actual = clone(omit(val.body,
           'id', 'processed', 'processed_id', 'start', 'end'), prune);
 
         try {
+          actual.spaces[0].consumers[0].resources[0].plans[0]
+            .resource_instances[0] = omit(actual.spaces[0].consumers[0]
+            .resources[0].plans[0].resource_instances[0], 't', 'p');
           expect(actual).to.deep.equal(report);
           console.log('\n', util.inspect(val.body, {
             depth: 20

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -34,7 +34,6 @@ const filter = _.filter;
 const reduce = _.reduce;
 const zip = _.zip;
 const unzip = _.unzip;
-const find = _.find;
 const contains = _.contains;
 
 const tmap = yieldable(transform.map);
@@ -75,34 +74,8 @@ const aggregatordb = dataflow.db('abacus-aggregator-aggregated-usage');
 // Configure accumulated usage db
 const accumulatordb = dataflow.db('abacus-accumulator-accumulated-usage');
 
-
-// The scaling factor of each time window for creating the date string
-// [Second, Minute, Hour, Day, Month]
-const slack = () => /^[0-9]+[MDhms]$/.test(process.env.SLACK) ? {
-  scale : process.env.SLACK.charAt(process.env.SLACK.length - 1),
-  width : process.env.SLACK.match(/[0-9]+/)[0]
-} : {
-  scale : 'm',
-  width : 10
-};
-
-// Returns first day of the month
-const firstday = (t) => {
-  const d = new Date(t);
-  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
-};
-
 // Time dimensions
 const dimensions = ['s', 'm', 'h', 'D', 'M'];
-
-// Millisecond representation of the time dimensions
-const msDimensions = {
-  M: 2678400000,
-  D: 86400000,
-  h: 3600000,
-  m: 60000,
-  s: 1000
-};
 
 // Return the charge function for a given plan and metric
 const chargefn = (metrics, metric) => {
@@ -446,7 +419,6 @@ const consumerUsage = function *(u) {
           // Shift all the windows
           map(consumer.resources, (resource) => {
             map(resource.plans, (plan) => {
-              delete plan.resource_instances;
               map(plan.aggregated_usage, (au) => {
                 map(au.windows, (w, i) => {
                   timewindow.shiftWindow(new Date(consumer.processed),
@@ -553,58 +525,21 @@ const resourceInstanceUsage = function *(orgid, spaceid, resid, conid, planid,
     throw res;
   }
 
+  const id = ['k', orgid, resid, conid, planid, mplanid, rplanid, pplanid, 't',
+    time].join('/');
 
-  // Compute the query range
-  const t = time || Date.now();
-  const slackLimit = msDimensions[slack().scale] * slack().width;
-  const mt = firstday(firstday(t) - slackLimit);
-  const sid = dbclient.kturi([orgid, spaceid, conid].join('/'), seqid.pad16(t))
-    + '~';
-  const eid = dbclient.kturi([orgid, spaceid, conid].join('/'),
-    seqid.pad16(mt));
+  const doc = yield accumulatordb.get(id);
 
-  debug('Retrieving latest consumer usage between %s and %s', eid, sid);
-  const consumer = yield aggregatordb.allDocs({
-    endkey: eid,
-    startkey: sid,
-    descending: true,
-    limit: 1,
-    include_docs: true
-  });
-
-  if(!consumer.rows.length) {
-    debug('No existing consumer aggregated usage');
+  if(!doc) {
+    debug('No resource instance usage found for %s on %s', resid, time);
 
     // Return an empty usage report if no usage was found
     return {};
   }
 
-  const plankey = [planid, mplanid, rplanid, pplanid].join('/');
-  let id = '';
-  debug('Looking for resource instance %s with plan %s', resid, plankey);
-  find(consumer.rows[0].doc.resources, (r) => {
-    return find(r.plans, (p) => {
-      return p.plan_id === plankey ? find(p.resource_instances, (ri) => {
-        if(ri.id === resid) {
-          id = ['k', orgid, resid, conid, planid, mplanid, rplanid,
-          pplanid, 't', ri.t].join('/');
-          return id;
-        }
-        return false;
-      }) : false;
-    });
-  });
-
-  if(!id) {
-    debug('Resource instance %s not found for organization %s', resid, orgid);
-    return {};
-  }
-
-  const doc = yield accumulatordb.get(id);
-
   debug('Found accumulated usage %o', doc);
-  return yield chargeInstanceUsage(t,
-    yield summarizeInstanceUsage(t, doc, auth), auth);
+  return yield chargeInstanceUsage(doc.processed,
+    yield summarizeInstanceUsage(doc.processed, doc, auth), auth);
 };
 
 // Return the usage for an account in a given time period
@@ -742,7 +677,7 @@ const graphSchema = new GraphQLSchema({
           },
           time: {
             name: 'time',
-            type: GraphQLFloat
+            type: GraphQLString
           },
           authorization: {
             name: 'authorization',
@@ -796,7 +731,7 @@ const retrieveResourceInstanceUsage = function *(req) {
     req.params.space_id, req.params.resource_instance_id,
     req.params.consumer_id, req.params.plan_id, req.params.metering_plan_id,
     req.params.rating_plan_id, req.params.pricing_plan_id,
-    req.params.time ? parseInt(req.params.time) : undefined,
+    req.params.time,
     req.headers && req.headers.authorization);
 
   return {
@@ -822,13 +757,6 @@ routes.get(
   'resource_instances/:resource_instance_id/consumers/:consumer_id/plans/' +
   ':plan_id/metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/' +
   'pricing_plans/:pricing_plan_id/aggregated/usage/:time',
-  throttle(retrieveResourceInstanceUsage));
-
-routes.get(
-  '/v1/metering/organizations/:organization_id/spaces/:space_id/' +
-  'resource_instances/:resource_instance_id/consumers/:consumer_id/plans/' +
-  ':plan_id/metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/' +
-  'pricing_plans/:pricing_plan_id/aggregated/usage',
   throttle(retrieveResourceInstanceUsage));
 
 // Retrieve a usage summary using a GraphQL query

--- a/lib/aggregation/reporting/src/test/test.js
+++ b/lib/aggregation/reporting/src/test/test.js
@@ -2750,29 +2750,11 @@ describe('abacus-usage-report', () => {
   context('when accumulated usage has small numbers', () => {
     before((done) => {
 
-      const caggregated = {
-        id: 'k/a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27/' +
-        'aaeae239-f3f8-483c-9dd0-de5d41c38b6a/UNKNOWN/t/0001446508700000',
-        resources: [{
-          resource_id: 'test-resource',
-          plans: [{
-            plan_id: 'basic/test-metering-plan/test-rating-plan/' +
-              'test-pricing-basic',
-            resource_instances: [{
-              id: rid,
-              t: '0001446418800000',
-              processed: 1446418800000
-            }]
-          }]
-        }]
-      };
-
       const accumulated = accumulatedTemplate(buildAccumulatedUsage(
         { current: 1 }, { current: 1 }, { current: 100 }, 1, 0.03, 15,
         undefined, true, undefined));
 
-      storeRatedUsage(caggregated, () =>
-        storeAccumulatedUsage(accumulated, done));
+      storeAccumulatedUsage(accumulated, done);
     });
 
     it('Retrieve accumulated usage', (done) => {
@@ -2825,7 +2807,7 @@ describe('abacus-usage-report', () => {
             metering_plan_id: 'test-metering-plan',
             rating_plan_id: 'test-rating-plan',
             pricing_plan_id: 'test-pricing-basic',
-            time: 1446508800000
+            time: '0001446418800000'
           }, (err, val) => {
             expect(err).to.equal(undefined);
             expect(val.body).to.deep.equal(expected);
@@ -2852,8 +2834,8 @@ describe('abacus-usage-report', () => {
           'resource_instance_id: "0b39fa70-a65f-4183-bae8-385633ca5c87", ' +
           'plan_id: "basic", metering_plan_id: "test-metering-plan", ' +
           'rating_plan_id: "test-rating-plan", pricing_plan_id: ' +
-          '"test-pricing-basic", time: 1446508800000) { organization_id, ' +
-          'consumer_id, resource_instance_id, plan_id, ' +
+          '"test-pricing-basic", time: "0001446418800000") ' +
+          '{ organization_id, consumer_id, resource_instance_id, plan_id, ' +
           'accumulated_usage { metric, windows { quantity, cost, charge, ' +
           'summary } }, windows { charge }}}';
 
@@ -2903,22 +2885,6 @@ describe('abacus-usage-report', () => {
   context('when querying complex usage with graphql', () => {
 
     before((done) => {
-
-      const caggregated = {
-        id: 'k/org/spa/con/t/0001456185600000',
-        resources: [{
-          resource_id: 'test-resource',
-          plans: [{
-            plan_id: 'basic/test-metering-plan/test-rating-plan/' +
-              'test-pricing-basic',
-            resource_instances: [{
-              id: 'ins',
-              t: '0001456185600000',
-              processed: 1456185600000
-            }]
-          }]
-        }]
-      };
       const accumulated = {
         id: 'k/org/ins/con/basic/' +
           'test-metering-plan/test-rating-plan/' +
@@ -2949,8 +2915,7 @@ describe('abacus-usage-report', () => {
         }]
       };
 
-      storeRatedUsage(caggregated,
-          () => storeAccumulatedUsage(accumulated, done));
+      storeAccumulatedUsage(accumulated, done);
     });
 
     it('Retrieve complex accumulated usage using a GraphQL query', (done) => {
@@ -2988,8 +2953,8 @@ describe('abacus-usage-report', () => {
           '"org", space_id: "spa", consumer_id: "con", resource_instance_id: ' +
           '"ins", plan_id: "basic", metering_plan_id: "test-metering-plan", ' +
           'rating_plan_id: "test-rating-plan", pricing_plan_id: ' +
-          '"test-pricing-basic", time: 1456185600000) { organization_id, ' +
-          'consumer_id, resource_instance_id, plan_id, ' +
+          '"test-pricing-basic", time: "0001456185600000") ' +
+          '{ organization_id, consumer_id, resource_instance_id, plan_id, ' +
           'accumulated_usage { metric, windows { quantity }}}}';
 
         request.get(

--- a/test/perf/src/test/test.js
+++ b/test/perf/src/test/test.js
@@ -372,6 +372,10 @@ describe('abacus-perf-test', () => {
           console.log('Processed %d usage docs for org%d',
             processed(val), o + 1);
           try {
+            // Can't check the dynamic time in resource_instances
+            val.body.spaces[0].consumers[0].resources[0].plans[0] =
+              omit(val.body.spaces[0].consumers[0]
+              .resources[0].plans[0], 'resource_instances');
             expect(fixup(omit(
               val.body, 'id', 'processed', 'processed_id', 'start', 'end')))
                 .to.deep.equal(fixup(report(o, resourceInstances, usage)));


### PR DESCRIPTION
The resource instance usage report's intention is to let UI integrator see hierarchical view. It is currently inefficient as the caller needs to call the consumer doc before it is able to get to the resource instance report. The orgUsage report will also returns the list of resource_instances for this optimization.