### PR TITLE
Utility changes

### DIFF
--- a/lib/utils/dataflow/src/test/test.js
+++ b/lib/utils/dataflow/src/test/test.js
@@ -1653,7 +1653,7 @@ describe('abacus-dataflow', () => {
           // Check for the expected output docs
           const odoc = val.body;
           expect(odoc.id).to.match(new RegExp(
-            'k/' + igroups(odoc).join('/') + '/t/00014.*-0-0-0'));
+            'k/' + igroups(odoc).join('/') + '/t/00014.*'));
           expect(odoc.nb_id).to.match(new RegExp(
             't/00014.*-0-0-0/k/' + odoc.x));
   

--- a/lib/utils/dedupe/src/index.js
+++ b/lib/utils/dedupe/src/index.js
@@ -5,15 +5,36 @@
 const _ = require('underscore');
 const bloem = require('bloem');
 const lru = require('abacus-lrucache');
+const zlib = require('zlib');
 
 const first = _.first;
 const last = _.last;
 const map = _.map;
 const defaults = _.defaults;
+const extend = _.extend;
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-dedupe');
 const edebug = require('abacus-debug')('e-abacus-dedupe');
+
+// The scaling factor of each time window for creating the date string
+// [Second, Minute, Hour, Day, Month]
+const slacks = () => /^[0-9]+[MDhms]$/.test(process.env.SLACK) ? {
+  scale : process.env.SLACK.charAt(process.env.SLACK.length - 1),
+  width : process.env.SLACK.match(/[0-9]+/)[0]
+} : {
+  scale : 'm',
+  width : 10
+};
+
+// Millisecond representation of the time dimensions
+const msDimensions = {
+  M: 2678400000,
+  D: 86400000,
+  h: 3600000,
+  m: 60000,
+  s: 1000
+};
 
 // Return a value dedupe filter
 const deduper = (slack, max, cache) => {
@@ -22,9 +43,9 @@ const deduper = (slack, max, cache) => {
     max: max,
     cache: cache
   }, {
-    slack: parseInt(process.env.DEDUPE_SLACK) || 1000 * 3600 * 48,
+    slack: msDimensions[slacks().scale] * slacks().width,
     max: parseInt(process.env.DEDUPE_MAX) || 10000000,
-    cache: 1000
+    cache: parseInt(process.env.DEDUPE_CACHE) || 1000
   });
 
   // Cache the values in a LRU cache
@@ -37,7 +58,6 @@ const deduper = (slack, max, cache) => {
   const filter = (t) => {
     const f = new bloem.SafeBloem(opt.max, 0.01);
     f.time = t;
-    f.count = 0;
     return f;
   };
 
@@ -45,7 +65,7 @@ const deduper = (slack, max, cache) => {
   // Warning: filters is a mutable variable but it's really the simplest
   // way to implement this
   const t = Date.now();
-  let filters = [filter(t), filter(t)];
+  let filters = [filter(t + opt.slack), filter(t)];
 
   return {
     // Add the value to the dedupe filter
@@ -59,12 +79,11 @@ const deduper = (slack, max, cache) => {
       const t = Date.now();
       if(last(filters).time < t - opt.slack)
         // Warning: mutating variable filters
-        filters = [filter(t)].concat([first(filters)]);
+        filters = [filter(t + opt.slack)].concat([first(filters)]);
 
       // Add value to the bloom filter
       map(filters, (f) => {
         f.add(val);
-        f.count = f.count + 1;
       });
       if(filters[1].count >= opt.max)
         edebug('Dedupe filter capacity exceeded %d', filters[1].count);
@@ -82,6 +101,43 @@ const deduper = (slack, max, cache) => {
       }
       debug('Value %s not found in dedupe filter, not a duplicate', val);
       return false;
+    },
+
+    // Serialize the bloom filter to be stored to the db.
+    serialize: () => {
+      return {
+        filters: map(filters, (filter) => {
+          return extend({}, filter, {
+            filter: { 
+              bitfield: {
+                buffer: zlib.deflateSync(filter.filter.bitfield.buffer)
+                  .toString('base64')
+              }
+            }
+          });
+        }),
+        times: map(filters, (filter) => filter.time),
+        counts: map(filters, (filter) => filter.count)
+      };
+    },
+
+    // Deserialize the bloom filter and use it.
+    deserialize: (sFilters) => {      
+      filters = map(sFilters.filters, (filter, i) => {
+        const df = extend({ }, filter, {
+          filter: { 
+            bitfield: {
+              buffer: zlib.inflateSync(
+                new Buffer(filter.filter.bitfield.buffer, 
+                  'base64'))                
+            }
+          }
+        });
+        const f = new bloem.SafeBloem.destringify(df);
+        f.time = sFilters.times[i];
+        f.count = sFilters.counts[i];
+        return f;
+      });
     }
   };
 };

--- a/lib/utils/dedupe/src/test/test.js
+++ b/lib/utils/dedupe/src/test/test.js
@@ -25,5 +25,36 @@ describe('abacus-dedupe', () => {
     expect(f.has('d')).to.equal(true);
     expect(f.has('x')).to.equal(false);
   });
+
+  it('serializes and deserializes the filters', () => {
+    // Create a dedupe filter
+    const f = dedupe(undefined, undefined);
+
+    // Add some values
+    f.add('a');
+    f.add('b');
+    f.add('c');
+    f.add('d');
+
+    // Serialize the filters
+    const serialized = f.serialize();
+    expect(serialized).to.have.all.keys('filters', 'times', 'counts');
+
+    // Create a new dedupe filter
+    const newf = dedupe(undefined, undefined);
+    // They should not be in the filter
+    expect(newf.has('a')).to.equal(false);
+    expect(newf.has('b')).to.equal(false);
+    expect(newf.has('c')).to.equal(false);
+    expect(newf.has('d')).to.equal(false);
+
+    // Deserialize filters
+    newf.deserialize(serialized);
+    // They should be in the filter now
+    expect(newf.has('a')).to.equal(undefined);
+    expect(newf.has('b')).to.equal(undefined);
+    expect(newf.has('c')).to.equal(undefined);
+    expect(newf.has('d')).to.equal(undefined);
+  });
 });
 

--- a/lib/utils/request/src/index.js
+++ b/lib/utils/request/src/index.js
@@ -48,7 +48,7 @@ const drequest = rrequest.defaults({
   rejectUnauthorized: false,
   forever: true,
   pool: {
-    maxSockets: 100
+    maxSockets: parseInt(process.env.THROTTLE) || 1000
   }
 });
 

--- a/lib/utils/request/src/index.js
+++ b/lib/utils/request/src/index.js
@@ -263,6 +263,8 @@ const batchOp = (m, opt) => {
       // protocol, auth, host and OAuth bearer access token
       const groups = map(groupBy(targets, (t) => 
         [url.resolve(t.target.uri, '/'),
+          t.target.options.headers && t.target.options.headers['X-BATCH-ID'] ?
+          t.target.options.headers['X-BATCH-ID'] : '',
           t.target.options.headers && t.target.options.headers.authorization ?
           t.target.options.headers.authorization : ''].join('-')));
 

--- a/lib/utils/request/src/test/test.js
+++ b/lib/utils/request/src/test/test.js
@@ -407,6 +407,75 @@ describe('abacus-request', () => {
       });
     });
 
+  it('batches HTTP requests using X-BATCH-ID',
+    (done) => {
+      let batches = 0;
+      // Create a test HTTP server
+      const server = http.createServer((req, res) => {
+        // Handle batched requests
+        if (req.url === '/batch') {
+          if (req.headers.authorization) batches++;
+
+          res.statusCode = 200;
+          res.setHeader('Content-type', 'application/json');
+          res.end(JSON.stringify([{ statusCode: 200, body: 'okay' }]));
+        }
+      });
+
+      // Listen on an ephemeral port
+      server.listen(0);
+
+      // Wait for the server to become available
+      request.waitFor('http://localhost::p/batch', {
+        p: server.address().port
+      }, (err, val) => {
+        if(err)
+          throw err;
+
+        let cbs = 0;
+        const verifyNumberOfRequests = () => {
+          if(++cbs === 2) {
+            expect(batches).to.equal(2);
+            done();
+          }
+        };
+
+        // Use a batch version of the request module
+        const brequest = batch(request);
+
+        // Send an HTTP request, expecting an OK response
+        brequest.get('http://localhost::p/:v/:r', {
+          p: server.address().port,
+          v: 'ok',
+          r: 'request',
+          headers: {
+            authorization: 'Bearer valid',
+            'X-BATCH-ID': 'group1'
+          }
+        }, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(200);
+          expect(val.body).to.equal('okay');
+          verifyNumberOfRequests();
+        });
+
+        brequest.get('http://localhost::p/:v/:r', {
+          p: server.address().port,
+          v: 'ok',
+          r: 'request',
+          headers: {
+            authorization: 'Bearer valid',
+            'X-BATCH-ID': 'group2'
+          }
+        }, (err, val) => {
+          expect(err).to.equal(undefined);
+          expect(val.statusCode).to.equal(200);
+          expect(val.body).to.equal('okay');
+          verifyNumberOfRequests();
+        });
+      });
+    });
+  
   it('waits for request using specified timeout', (done) => {
     const timeout = 1000;
     const port = 3433;

--- a/lib/utils/seqid/src/index.js
+++ b/lib/utils/seqid/src/index.js
@@ -42,7 +42,7 @@ const sample = (id, div) => {
     return id;
   const [t, appindex, iindex, wid] = id.split('-');
   const st = Math.floor(parseInt(t) / div) * div;
-  return [pad16(st), appindex, iindex, wid, 0].join('-');
+  return div > 1 ? pad16(st) : [pad16(st), appindex, iindex, wid, 0].join('-');
 };
 
 // Export our public functions

--- a/lib/utils/seqid/src/test/test.js
+++ b/lib/utils/seqid/src/test/test.js
@@ -46,7 +46,7 @@ describe('abacus-seqid', () => {
   it('samples unique sequential ids', () => {
     const id = seqid();
     const fid = seqid.sample(id, 3600000);
-    expect(fid).to.equal('0001451606400000-0-0-0-0');
+    expect(fid).to.equal('0001451606400000');
   });
 });
 


### PR DESCRIPTION
seqid: When we have sampling on, we should not add the additional information(appindex, cluster index, etc.). Adding the additional information will results in incorrect value. Example: when we have sampling on, we would have t-0-0-0-0. When the app crashes, and it will spawn a different cluster and the next submission in the sampling period would results in t-0-1-0-0. When the app restarts, the cluster would reset back to 0, and the next submission in the sampling period would results back to t-0-0-0. The latest accumulated/aggregated usage would be in t-0-0-0, but the descending query in the report would gives back the t-0-1-0-0.

dedupe: The implementation of the rolling bloom filter list was incorrect. There was no rolling because when an addition to the filter arrived at t > the filter's time + slack, it will roll both of the filter (the second filter will be rolled by the next submission because both the filters' time are set to the same time). Dedupe is now enhanced with serialize and deserialize because we want to fix the current bug that exists in dataflow: when dataflow app restarts, the bloom filters would not be persisted. All duplicate submissions would be marked as non duplicate, and it would be accumulated to the usage doc, then it would throw 409 due to duplicate when posting the duplicate document to the db. 

request: Added optional header field: X-BATCH-ID. This would be used by the request to do an additional grouping based on the field that is specified in X-BATCH-ID. The goal of this is to avoid mixing the requests that might results in blocking requests. Another change to this utility module is to set the request's max sockets to the size of the throttle.

