### PR TITLE
Drop unused renewer client credentials.

### DIFF
--- a/etc/concourse/deploy-pipeline-vars.yml
+++ b/etc/concourse/deploy-pipeline-vars.yml
@@ -111,12 +111,6 @@ jwtalgo: algo
 # Use templates true/false
 abacus-configure: true
 
-# UAA client: "Renewer" client id
-renewer-client-id: renewer-client
-
-# UAA client: "Renewer" client secret
-renewer-client-secret: secret
-
 # Abacus repo URI (or landscape project URI)
 landscape-git-repo: https://github.com/cloudfoundry-incubator/cf-abacus.git
 

--- a/etc/concourse/deploy-pipeline.yml
+++ b/etc/concourse/deploy-pipeline.yml
@@ -39,8 +39,6 @@ jobs:
               SYSTEM_CLIENT_SECRET: {{system-client-secret}}
               BRIDGE_CLIENT_ID: {{bridge-client-id}}
               BRIDGE_CLIENT_SECRET: {{bridge-client-secret}}
-              RENEWER_CLIENT_ID: {{renewer-client-id}}
-              RENEWER_CLIENT_SECRET: {{renewer-client-secret}}
               CONTAINER_CLIENT_ID: {{container-client-id}}
               CONTAINER_CLIENT_SECRET: {{container-client-secret}}
 


### PR DESCRIPTION
The concourse pipeline specifies renewer client credentials but doesn't appear to use them anywhere, and it looks like the renewer app expects to use the system credentials: https://github.com/cloudfoundry-incubator/cf-abacus/blob/master/lib/cf/renewer/src/index.js#L89-L93. This patch drops the renewer credentials.