### PR TITLE
Separate setup and deploy steps.

### DIFF
--- a/etc/concourse/deploy-pipeline.yml
+++ b/etc/concourse/deploy-pipeline.yml
@@ -10,82 +10,85 @@ resources:
       skip-ssl-verification: true
 
 jobs:
+  - name: abacus-setup
+    plan:
+      - get: landscape
+      - task: setup-abacus-infra
+        attempts: 2
+        timeout: 35m
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: godofcontainers/ubuntu-14.04-cf
+              tag: 'latest'
+          inputs:
+            - name: landscape
+          params:
+            CF_API: {{cf-api}}
+            CF_USER: {{cf-user}}
+            CF_PASSWORD: {{cf-password}}
+            CF_ADMIN_USER: {{cf-admin-user}}
+            CF_ADMIN_PASSWORD: {{cf-admin-password}}
+            CF_ORG: {{cf-org}}
+            CF_SPACE: {{cf-space}}
+            CF_DOMAIN: {{cf-domain}}
+            CREATE_DB_SERVICE: {{create-db-service}}
+            DB_SERVICE_NAME: {{db-service-name}}
+            DB_PLAN_NAME: {{db-plan-name}}
+            UAA_ADMIN: {{uaa-admin}}
+            UAA_SECRET: {{uaa-secret}}
+            SYSTEM_CLIENT_ID: {{system-client-id}}
+            SYSTEM_CLIENT_SECRET: {{system-client-secret}}
+            CC_CLIENT_ID: {{cc-client-id}}
+            CC_CLIENT_SECRET: {{cc-client-secret}}
+            BRIDGE_CLIENT_ID: {{bridge-client-id}}
+            BRIDGE_CLIENT_AUTHORITIES: {{bridge-client-authorities}}
+            BRIDGE_CLIENT_SECRET: {{bridge-client-secret}}
+            CF_CLIENT_ID: {{cf-client-id}}
+            CF_CLIENT_SECRET: {{cf-client-secret}}
+            CONTAINER_CLIENT_ID: {{container-client-id}}
+            CONTAINER_CLIENT_SECRET: {{container-client-secret}}
+            OBJECT_STORAGE_CLIENT_ID: {{object-storage-client-id}}
+            OBJECT_STORAGE_CLIENT_SECRET: {{object-storage-client-secret}}
+            HYSTRIX_CLIENT_ID: {{hystrix-client-id}}
+            HYSTRIX_CLIENT_SECRET: {{hystrix-client-secret}}
+            PURGE_APP_USAGE_EVENTS: {{purge-app-usage-events}}
+          run:
+            path: landscape/cf-abacus/etc/concourse/scripts/cf-deploy-infra
+
   - name: abacus-deploy
     plan:
       - get: landscape
         trigger: true
-      - aggregate:
-        - task: build-abacus
-          timeout: 30m
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: godofcontainers/node-mongodb
-                tag: '6.9.1'
-            inputs:
-              - name: landscape
-            outputs:
-              - name: built-project
-            run:
-              path: landscape/cf-abacus/etc/concourse/scripts/cf-deploy-build
-            params:
-              AUTH_SERVER: {{auth-server}}
-              JWTKEY: {{jwtkey}}
-              JWTALGO: {{jwtalgo}}
-              CONFIGURE: {{abacus-configure}}
-              SYSTEM_CLIENT_ID: {{system-client-id}}
-              SYSTEM_CLIENT_SECRET: {{system-client-secret}}
-              BRIDGE_CLIENT_ID: {{bridge-client-id}}
-              BRIDGE_CLIENT_SECRET: {{bridge-client-secret}}
-              CONTAINER_CLIENT_ID: {{container-client-id}}
-              CONTAINER_CLIENT_SECRET: {{container-client-secret}}
+      - task: build-abacus
+        timeout: 30m
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: godofcontainers/node-mongodb
+              tag: '6.9.1'
+          inputs:
+            - name: landscape
+          outputs:
+            - name: built-project
+          run:
+            path: landscape/cf-abacus/etc/concourse/scripts/cf-deploy-build
+          params:
+            AUTH_SERVER: {{auth-server}}
+            JWTKEY: {{jwtkey}}
+            JWTALGO: {{jwtalgo}}
+            CONFIGURE: {{abacus-configure}}
+            SYSTEM_CLIENT_ID: {{system-client-id}}
+            SYSTEM_CLIENT_SECRET: {{system-client-secret}}
+            BRIDGE_CLIENT_ID: {{bridge-client-id}}
+            BRIDGE_CLIENT_SECRET: {{bridge-client-secret}}
+            CONTAINER_CLIENT_ID: {{container-client-id}}
+            CONTAINER_CLIENT_SECRET: {{container-client-secret}}
 
-        - task: setup-abacus-infra
-          attempts: 2
-          timeout: 35m
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: godofcontainers/ubuntu-14.04-cf
-                tag: 'latest'
-            inputs:
-              - name: landscape
-            params:
-              CF_API: {{cf-api}}
-              CF_USER: {{cf-user}}
-              CF_PASSWORD: {{cf-password}}
-              CF_ADMIN_USER: {{cf-admin-user}}
-              CF_ADMIN_PASSWORD: {{cf-admin-password}}
-              CF_ORG: {{cf-org}}
-              CF_SPACE: {{cf-space}}
-              CF_DOMAIN: {{cf-domain}}
-              CREATE_DB_SERVICE: {{create-db-service}}
-              DB_SERVICE_NAME: {{db-service-name}}
-              DB_PLAN_NAME: {{db-plan-name}}
-              UAA_ADMIN: {{uaa-admin}}
-              UAA_SECRET: {{uaa-secret}}
-              SYSTEM_CLIENT_ID: {{system-client-id}}
-              SYSTEM_CLIENT_SECRET: {{system-client-secret}}
-              CC_CLIENT_ID: {{cc-client-id}}
-              CC_CLIENT_SECRET: {{cc-client-secret}}
-              BRIDGE_CLIENT_ID: {{bridge-client-id}}
-              BRIDGE_CLIENT_AUTHORITIES: {{bridge-client-authorities}}
-              BRIDGE_CLIENT_SECRET: {{bridge-client-secret}}
-              CF_CLIENT_ID: {{cf-client-id}}
-              CF_CLIENT_SECRET: {{cf-client-secret}}
-              CONTAINER_CLIENT_ID: {{container-client-id}}
-              CONTAINER_CLIENT_SECRET: {{container-client-secret}}
-              OBJECT_STORAGE_CLIENT_ID: {{object-storage-client-id}}
-              OBJECT_STORAGE_CLIENT_SECRET: {{object-storage-client-secret}}
-              HYSTRIX_CLIENT_ID: {{hystrix-client-id}}
-              HYSTRIX_CLIENT_SECRET: {{hystrix-client-secret}}
-              PURGE_APP_USAGE_EVENTS: {{purge-app-usage-events}}
-            run:
-              path: landscape/cf-abacus/etc/concourse/scripts/cf-deploy-infra
       - task: deploy-abacus
         attempts: 3
         timeout: 1h
@@ -114,6 +117,7 @@ jobs:
             JOBS: 2
           run:
             path: built-project/etc/concourse/scripts/cf-deploy-deploy
+
       - task: test-abacus
         attempts: 2
         timeout: 20m


### PR DESCRIPTION
The current concourse pipeline destroys and recreates uaa / cf infrastructure and deploys abacus in the same job. This patch separates infrastructure setup from deployment so that users can push out a new version of abacus without tearing down infrastructure.