### PR TITLE
Lower case headers 'x-batch-id'

### DIFF
--- a/lib/utils/request/src/index.js
+++ b/lib/utils/request/src/index.js
@@ -263,8 +263,8 @@ const batchOp = (m, opt) => {
       // protocol, auth, host and OAuth bearer access token
       const groups = map(groupBy(targets, (t) => 
         [url.resolve(t.target.uri, '/'),
-          t.target.options.headers && t.target.options.headers['X-BATCH-ID'] ?
-          t.target.options.headers['X-BATCH-ID'] : '',
+          t.target.options.headers && t.target.options.headers['x-batch-id'] ?
+          t.target.options.headers['x-batch-id'] : '',
           t.target.options.headers && t.target.options.headers.authorization ?
           t.target.options.headers.authorization : ''].join('-')));
 

--- a/lib/utils/request/src/test/test.js
+++ b/lib/utils/request/src/test/test.js
@@ -407,7 +407,7 @@ describe('abacus-request', () => {
       });
     });
 
-  it('batches HTTP requests using X-BATCH-ID',
+  it('batches HTTP requests using x-batch-id',
     (done) => {
       let batches = 0;
       // Create a test HTTP server
@@ -450,7 +450,7 @@ describe('abacus-request', () => {
           r: 'request',
           headers: {
             authorization: 'Bearer valid',
-            'X-BATCH-ID': 'group1'
+            'x-batch-id': 'group1'
           }
         }, (err, val) => {
           expect(err).to.equal(undefined);
@@ -465,7 +465,7 @@ describe('abacus-request', () => {
           r: 'request',
           headers: {
             authorization: 'Bearer valid',
-            'X-BATCH-ID': 'group2'
+            'x-batch-id': 'group2'
           }
         }, (err, val) => {
           expect(err).to.equal(undefined);


### PR DESCRIPTION
Headers are case insensitive. However, we use lowercase characters for all the headers in abacus. Hence I am changing X-BATCH-ID to x-batch-id