### PR TITLE
Update deploy directory on build.

### DIFF
--- a/etc/concourse/scripts/cf-deploy-build
+++ b/etc/concourse/scripts/cf-deploy-build
@@ -15,7 +15,7 @@ if [[ $CONFIGURE = true ]]; then
 fi
 
 echo "Copying custom settings ..."
-cp -r landscape/abacus-config/. built-project
+cp -r $abacus_config_dir/. built-project
 
 echo "Building Abacus ..."
 pushd built-project


### PR DESCRIPTION
It looks like https://github.com/cloudfoundry-incubator/cf-abacus/pull/472 changed the directory structure of the landscape directory, moving deploy config from landscape/abacus-config to landscape/abacus-config/deploy. This patch updates the concourse build script to copy the new deploy directory to the task output so that the correct manifests are used during deploy.