### PR TITLE
Allow operators to configure slack interval in concourse.

### DIFF
--- a/etc/concourse/deploy-pipeline-vars.yml
+++ b/etc/concourse/deploy-pipeline-vars.yml
@@ -121,6 +121,9 @@ jwtalgo: algo
 # Use templates true/false
 abacus-configure: true
 
+# Slack interval
+slack: 10m
+
 # Abacus repo URI (or landscape project URI)
 landscape-git-repo: https://github.com/cloudfoundry-incubator/cf-abacus.git
 

--- a/etc/concourse/deploy-pipeline-vars.yml
+++ b/etc/concourse/deploy-pipeline-vars.yml
@@ -122,7 +122,7 @@ jwtalgo: algo
 abacus-configure: true
 
 # Slack interval
-slack: 10m
+slack: 5D
 
 # Abacus repo URI (or landscape project URI)
 landscape-git-repo: https://github.com/cloudfoundry-incubator/cf-abacus.git

--- a/etc/concourse/deploy-pipeline.yml
+++ b/etc/concourse/deploy-pipeline.yml
@@ -95,6 +95,7 @@ jobs:
               CONTAINER_CLIENT_ID: {{container-client-id}}
               CONTAINER_CLIENT_SECRET: {{container-client-secret}}
               SKIP_SSL_VALIDATION: {{skip-ssl-validation}}
+              SLACK: {{slack}}
         - task: update-uaa-clients
           timeout: 10m
           config:

--- a/etc/concourse/scripts/cf-deploy-build
+++ b/etc/concourse/scripts/cf-deploy-build
@@ -11,7 +11,7 @@ cp -r landscape/cf-abacus/. built-project
 abacus_config_dir="landscape/abacus-config/deploy"
 
 if [[ $CONFIGURE = true ]]; then
-  echo "Runnining custom configuration ..."
+  echo "Running custom configuration ..."
   ./landscape/cf-abacus/etc/concourse/scripts/configure $abacus_config_dir
 fi
 


### PR DESCRIPTION
So that `$SLACK` can be interpolated into cf manifests in `cf-deploy-build`.