### PR TITLE
Introduce DB_OPTS in mongo and couch clients

### DIFF
--- a/doc/conf.md
+++ b/doc/conf.md
@@ -62,9 +62,10 @@ Abacus has two database clients:
 * [couchclient](https://github.com/cloudfoundry-incubator/cf-abacus/tree/master/lib/utils/couchclient) - supports CouchDB and the development/testing PouchDB
 * [mongoclient](https://github.com/cloudfoundry-incubator/cf-abacus/tree/master/lib/utils/mongoclient) - supports MongoDB
 
-The DB is configured using these environemnt variables:
+The DB is configured using these environment variables:
 * `DB` - URL of the database. By default Abacus uses local PouchDB (`localhost:5984`) if this variable is missing
 * `DBCLIENT` - DB client to use. The default one is the `couchclient`.
+* `DB_OPTS` - DB-specific connections configuration. Accepts JSON with either [Mongo](http://mongodb.github.io/node-mongodb-native/2.2/reference/connecting/connection-settings/) or [Couch/Pouch](https://pouchdb.com/api.html#create_database) connection settings.
 
 ### Local configuration
 

--- a/lib/utils/couchclient/src/index.js
+++ b/lib/utils/couchclient/src/index.js
@@ -113,16 +113,22 @@ const dburi = (server, name) => {
   return (p) => [path, p.join('-')].join('-');
 };
 
+const dbOpts = (uri, opt) => {
+  const defaultOpts = process.env.DB_OPTS ?
+    JSON.parse(process.env.DB_OPTS) : {};
+  return /:/.test(uri) ? defaults(opt || {}, defaultOpts) :
+    defaults(opt || {}, defaultOpts, { db: memdown });
+};
+
 // Construct a db handle for a db uri, use the memdown adapter to create an
 // local in-memory db if the uri is just a local name not containing a :
-const dbcons = (uri, opt, cb) => cb(undefined,
-  /:/.test(uri) ? new PouchDB(uri, defaults(opt || {}, {
-    ajax: {
-      rejectUnauthorized: false
-    }
-  })) : new PouchDB(uri, defaults(opt || {}, {
-    db: memdown
-  })));
+const dbcons = (uri, opt, cb) => {
+  const options = dbOpts(uri, opt);
+  const db = new PouchDB(uri, options);
+  db.dbconsUrl = uri;
+  db.dbconsOptions = options;
+  cb(undefined, db);
+};
 
 // Return a db handle for an erroneous db partition, which will return
 // the given error on all db operations

--- a/lib/utils/couchclient/src/test/test.js
+++ b/lib/utils/couchclient/src/test/test.js
@@ -4,9 +4,10 @@
 // partitions
 
 const _ = require('underscore');
-const sample = _.sample;
+const extend = _.extend;
 const flatten = _.flatten;
 const map = _.map;
+const sample = _.sample;
 const range = _.range;
 
 const memdown = require('memdown');
@@ -42,6 +43,10 @@ describe('abacus-couchclient', (d) => {
 
     // Delete test dbs on the configured db server
     couchclient.drop(dbserver(), /^abacus-couchclient-/, done);
+  });
+
+  afterEach(() => {
+    delete process.env.DB_OPTS;
   });
 
   it('distributes db operations over several db partitions', (done) => {
@@ -1479,6 +1484,35 @@ describe('abacus-couchclient', (d) => {
 
     // Run the above steps
     clean(db, () => put(db, () => get(db, done)));
+  });
+
+  it('reads custom Couch options from environment', (done) => {
+    process.env.DB_OPTS = `{
+      "ajax": {
+        "rejectUnauthorized": false
+      }
+    }`;
+
+    const checkOptions = (err, db) => {
+      debug('custom Couch opts: check options started ...');
+      expect(err).to.equal(undefined);
+      expect(db).to.not.equal(undefined);
+      expect(db.dbconsOptions).to.deep.equal(
+        extend(JSON.parse(process.env.DB_OPTS),
+          // Check for default skip_setup
+          { skip_setup: true })
+      );
+      debug('custom Couch opts: check options finished');
+      done();
+    };
+
+    const db = couchclient(undefined, couchclient.dburi(dbserver(),
+      'abacus-couchclient-couchoptions-test/collection'),
+      (uri, opt, cb) => couchclient.dbcons(uri, opt, checkOptions));
+
+    debug('custom Couch opts: db get starting ...');
+    db.get(helloKey);
+    debug('custom Couch opts: db get finished');
   });
 
   it('range test', (done) => {

--- a/lib/utils/couchclient/src/test/test.js
+++ b/lib/utils/couchclient/src/test/test.js
@@ -7,6 +7,7 @@ const _ = require('underscore');
 const extend = _.extend;
 const flatten = _.flatten;
 const map = _.map;
+const omit = _.omit;
 const sample = _.sample;
 const range = _.range;
 
@@ -1497,7 +1498,11 @@ describe('abacus-couchclient', (d) => {
       debug('custom Couch opts: check options started ...');
       expect(err).to.equal(undefined);
       expect(db).to.not.equal(undefined);
-      expect(db.dbconsOptions).to.deep.equal(
+
+      // Remove memdown functions
+      const dbOptions = omit(db.dbconsOptions, 'db');
+
+      expect(dbOptions).to.deep.equal(
         extend(JSON.parse(process.env.DB_OPTS),
           // Check for default skip_setup
           { skip_setup: true })

--- a/lib/utils/mongoclient/README.md
+++ b/lib/utils/mongoclient/README.md
@@ -9,18 +9,6 @@ Dependencies
 The module is using `mongodb` [native NodeJS driver](https://github.com/mongodb/node-mongodb-native).
 
 
-Configuration
--------------
-The DB connections can be configured using `MONGO_OPTS` environment variable. It accepts JSON with [connection settings](http://mongodb.github.io/node-mongodb-native/2.2/reference/connecting/connection-settings/).
-
-To enable auto reconnect on error and reduce reconnect retries:
-```bash
-export MONGO_OPTS='{"autoReconnect": "false", "reconnectTries": 5}'
-```
-
-For Cloud Foundry you should set `MONGO_OPTS` as application environment variable by modifying the `manifest.yml` files of the Abacus applications.
-
-
 Differences between Couch and Mongo
 -----------------------------------
 

--- a/lib/utils/mongoclient/src/index.js
+++ b/lib/utils/mongoclient/src/index.js
@@ -141,9 +141,9 @@ const removeCollectionFromUrl = (u) => {
   return result;
 };
 
-const mongoOpts = (opt) => {
-  const defaultOpts = process.env.MONGO_OPTS ?
-    JSON.parse(process.env.MONGO_OPTS) : {};
+const dbOpts = (opt) => {
+  const defaultOpts = process.env.DB_OPTS ?
+    JSON.parse(process.env.DB_OPTS) : {};
   return defaults(opt || {}, defaultOpts, {
     poolSize: 1
   });
@@ -154,7 +154,7 @@ const dbcons = (uri, opt, cb) => {
   const url = /:/.test(uri) ? uri : 'mongodb://localhost:27017/' + uri;
   const driverUrl = removeCollectionFromUrl(url);
 
-  const options = mongoOpts(opt);
+  const options = dbOpts(opt);
   debug('Connecting to DB on %s with options %o', puri(driverUrl), options);
   mongoDB.connect(driverUrl, options, (err, db) => {
     if (err) edebug('Failed to connect to mongodb uri %s because of %o',
@@ -903,7 +903,7 @@ const drop = (server = 'mongodb://localhost:27017', regex, cb) => {
     }
 
     // Connect to Mongo server
-    const options = mongoOpts();
+    const options = dbOpts();
     debug('Connecting to MongoDB %s with options %o', server, options);
     mongoDB.connect(server, options, (err, db) => {
       if (err) {

--- a/lib/utils/mongoclient/src/test/test.js
+++ b/lib/utils/mongoclient/src/test/test.js
@@ -44,7 +44,7 @@ describe('abacus-mongoclient', () => {
   });
 
   afterEach(() => {
-    delete process.env.MONGO_OPTS;
+    delete process.env.DB_OPTS;
   });
   
   it('distributes db operations over several db partitions', (done) => {
@@ -1738,25 +1738,24 @@ describe('abacus-mongoclient', () => {
   });
 
   it('reads custom Mongo options from environment', (done) => {
-    process.env.MONGO_OPTS = '{' +
-      // override one of the internal default values
-      '"poolSize": 2,' +
-      // set default values
-      '"_id" : "testSet",' +
-      '"version" : 1,' +
-      '"protocolVersion" : 1,' +
-      '"members" : [' +
-      '  {"_id" : 1, "host" : "server1:31000"},' +
-      '  {"_id" : 2, "host" : "server2:31001"},' +
-      '  {"_id" : 3, "host" : "server3:31002"}' +
-      ']}';
+    // override the poolSize internal default
+    process.env.DB_OPTS = `{
+      "poolSize": 2,
+      "_id" : "testSet",
+      "version" : 1,
+      "protocolVersion" : 1,
+      "members" : [
+        {"_id" : 1, "host" : "server1:31000"},
+        {"_id" : 2, "host" : "server2:31001"},
+        {"_id" : 3, "host" : "server3:31002"}
+      ]}`;
 
     const checkOptions = (err, db) => {
       debug('custom Mongo opts: check options started ...');
       expect(err).to.equal(null);
       expect(db).to.not.equal(undefined);
       expect(db.dbconsOptions).to.deep.equal(
-        JSON.parse(process.env.MONGO_OPTS)
+        JSON.parse(process.env.DB_OPTS)
       );
       debug('custom Mongo opts: check options finished');
       done();


### PR DESCRIPTION
Enable ssl validation in couch by default