### PR TITLE
Configurable number of retries for app start

### DIFF
--- a/etc/concourse/acceptance-test-pipeline-vars.yml
+++ b/etc/concourse/acceptance-test-pipeline-vars.yml
@@ -87,7 +87,7 @@ hystrix-client-id: abacus-hystrix
 # UAA client: Client secret for Abacus Hystrix streams
 hystrix-client-secret: secret
 
-# How many times the script will try to restart all the failing applications until it fails. If no value is provided, the default one is 5.
+# How many times the script will try to restart all the failing applications. If no value is provided, the default one is 5.
 restart-retries: 3
 
 # Authentication server: api.<cf-api>:443

--- a/etc/concourse/acceptance-test-pipeline-vars.yml
+++ b/etc/concourse/acceptance-test-pipeline-vars.yml
@@ -87,6 +87,9 @@ hystrix-client-id: abacus-hystrix
 # UAA client: Client secret for Abacus Hystrix streams
 hystrix-client-secret: secret
 
+# How many times the script will try to restart all the failing applications until it fails. If no value is provided, the default one is 5.
+restart-retries: 3
+
 # Authentication server: api.<cf-api>:443
 auth-server: https://api.cf.mycompany.com:443
 

--- a/etc/concourse/acceptance-test-pipeline.yml
+++ b/etc/concourse/acceptance-test-pipeline.yml
@@ -102,5 +102,6 @@ jobs:
             SKIP_SSL_VALIDATION: {{skip-ssl-validation}}
             CI_START_TIMEOUT: 50000
             CI_PIPELINE_TIMEOUT: 1000000
+            RESTART_RETRIES: {{restart-retries}}
           run:
             path: landscape/cf-abacus/etc/concourse/scripts/cf-acceptance-test

--- a/etc/concourse/deploy-pipeline-vars.yml
+++ b/etc/concourse/deploy-pipeline-vars.yml
@@ -109,7 +109,7 @@ bind-security-group: false
 # Authentication server: api.<cf-api>:443
 auth-server: https://api.cf.mycompany.com:443
 
-# How many times the script will try to restart all the failing applications until it fails. If no value is provided, the default one is 5.
+# How many times the script will try to restart all the failing applications. If no value is provided, the default one is 5.
 restart-retries: 3
 
 # JWT Key

--- a/etc/concourse/deploy-pipeline-vars.yml
+++ b/etc/concourse/deploy-pipeline-vars.yml
@@ -109,6 +109,9 @@ bind-security-group: false
 # Authentication server: api.<cf-api>:443
 auth-server: https://api.cf.mycompany.com:443
 
+# How many times the script will try to restart all the failing applications until it fails. If no value is provided, the default one is 5.
+restart-retries: 3
+
 # JWT Key
 jwtkey: |
       -----BEGIN PUBLIC KEY-----

--- a/etc/concourse/deploy-pipeline.yml
+++ b/etc/concourse/deploy-pipeline.yml
@@ -158,6 +158,7 @@ jobs:
             SKIP_SSL_VALIDATION: {{skip-ssl-validation}}
             # Save file handlers and offload CF stagers
             JOBS: 2
+            RESTART_RETRIES: {{restart-retries}}
           run:
             path: built-project/etc/concourse/scripts/cf-deploy-deploy
 

--- a/etc/concourse/scripts/cf-acceptance-test
+++ b/etc/concourse/scripts/cf-acceptance-test
@@ -45,15 +45,9 @@ pushd $abacus_dir
   echo "Start all apps in $CF_ORG/$CF_SPACE ..."
   getApps
   echo ${APPS[@]} | xargs -n1 | xargs -P 5 -i cf start {}
-  for i in {1..3}
-  do
-    echo "Restarting failed apps (retry $i / 5) ..."
-    restartApps
-  done
-  set -e
 
-  echo "Restarting apps ..."
-  restartApps
+  echo "Restarting failed apps ..."
+  restartAppsWithRetry
 
   echo "Starting Acceptance test ..."
   npm run acceptance -- --organization-guid=$ORG_GUID \

--- a/etc/concourse/scripts/cf-deploy-deploy
+++ b/etc/concourse/scripts/cf-deploy-deploy
@@ -77,15 +77,7 @@ echo "Applications:"
 cf apps
 
 echo "Restarting failed apps ..."
-for i in {1..3}
-do
-  echo "Restarting failed apps (retry $i / 5) ..."
-  restartApps
-done
-set -e
-
-echo "Restarting failed apps ..."
-restartApps
+restartAppsWithRetry
 
 echo "Applications:"
 cf apps

--- a/etc/concourse/scripts/cf-test-test
+++ b/etc/concourse/scripts/cf-test-test
@@ -45,15 +45,9 @@ pushd $abacus_dir
   echo "Start all apps in $CF_ORG/$CF_SPACE ..."
   getApps
   echo ${APPS[@]} | xargs -n1 | xargs -P 5 -i cf start {}
-  for i in {1..3}
-  do
-    echo "Restarting failed apps (retry $i / 5) ..."
-    restartApps
-  done
-  set -e
 
-  echo "Restarting apps ..."
-  restartApps
+  echo "Restarting failed apps ..."
+  restartAppsWithRetry
 
   echo "Starting Demo ..."
   npm run demo -- \

--- a/etc/concourse/scripts/common-functions
+++ b/etc/concourse/scripts/common-functions
@@ -18,3 +18,21 @@ function restartApps {
   getApps '0/'
   echo ${APPS[@]} | xargs -n1 -P 5 -r cf restart
 }
+
+function restartAppsWithRetry {
+  retries=$RESTART_RETRIES
+  if [[ -z "$retries" ]]; then
+    retries=5
+  elif [[ $retries -eq 0 ]]; then
+    return
+  fi
+
+  for (( i=1; i<=$retries ; i++ ))
+  do
+    if [[ $i -eq $retries ]]; then
+      set -e
+    fi
+    echo "Restarting failed apps (retry $i / $retries) ..."
+    restartApps
+  done
+}

--- a/etc/concourse/scripts/common-functions
+++ b/etc/concourse/scripts/common-functions
@@ -34,5 +34,9 @@ function restartAppsWithRetry {
     fi
     echo "Restarting failed apps (retry $i / $retries) ..."
     restartApps
+
+    if [[ $? -eq 0 ]]; then
+      return
+    fi
   done
 }

--- a/etc/concourse/test-pipeline-vars.yml
+++ b/etc/concourse/test-pipeline-vars.yml
@@ -81,3 +81,6 @@ hystrix-client-secret: secret
 
 # Authentication server: api.<cf-api>:443
 auth-server: https://api.cf.mycompany.com:443
+
+# How many times the script will try to restart all the failing applications until it fails. If no value is provided, the default one is 5.
+restart-retries: 3

--- a/etc/concourse/test-pipeline-vars.yml
+++ b/etc/concourse/test-pipeline-vars.yml
@@ -82,5 +82,5 @@ hystrix-client-secret: secret
 # Authentication server: api.<cf-api>:443
 auth-server: https://api.cf.mycompany.com:443
 
-# How many times the script will try to restart all the failing applications until it fails. If no value is provided, the default one is 5.
+# How many times the script will try to restart all the failing applications. If no value is provided, the default one is 5.
 restart-retries: 3

--- a/etc/concourse/test-pipeline.yml
+++ b/etc/concourse/test-pipeline.yml
@@ -332,5 +332,6 @@ jobs:
             DEBUG: {{debug}}
             ABACUS_PREFIX: {{abacus-prefix}}
             SKIP_SSL_VALIDATION: {{skip-ssl-validation}}
+            RESTART_RETRIES: {{restart-retries}}
           run:
             path: abacus/etc/concourse/scripts/cf-test-test


### PR DESCRIPTION
Extract a property that configures how many times the scripts will try to restart all failing applications until it fails.