### PR TITLE
Check business error when no sink is configured.

### DIFF
--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -365,19 +365,6 @@ const postOutput = function *(odoc, skey, stime,
 const postOutputs = function *(odocs, skeys, stimes,
   shost, spartition, sposts, authentication, ddup) {
 
-  // Find the first occurence of error in the list of docs.
-  const error = find(odocs, (odoc) => odoc.error);
-
-  // When there is an error in any of the docs, return the first
-  // encountered error.
-  if(error) {
-    debug('Document has error %o', error);
-    return {
-      error: error.error,
-      reason: error.reason
-    };
-  }
-
   // Post each docs to the sink.
   const responses = yield tmap(odocs, function *(odoc, i, l) {
     return yield postOutput(odoc, skeys[i], stimes[i],
@@ -419,6 +406,22 @@ const logOutput = function *(odoc, odb) {
   }
   odebug('Logged new output doc %s, rev %s', odoc.id, odoc.rev);
   debug('Logged output doc %s, rev %s, %o', odoc.id, odoc.rev, odoc);
+};
+
+// Find the first occurence of error in the list of docs.
+const checkError = (odocs) => {
+  const error = find(odocs, (odoc) => odoc.error);
+  // When there is an error in any of the docs, return the first
+  // encountered error.
+  if(error) {
+    debug('Document has error %o', error);
+    return {
+      error: error.error,
+      reason: error.reason
+    };
+  };
+
+  return undefined;
 };
 
 // Log a list of output docs
@@ -583,8 +586,10 @@ const mapper = (mapfn, opt) => {
       debug('Processed input doc %s, produced output docs %o',
         pidoc.id, map(podocs, (podoc) => podoc.id));
 
+      error = checkError(podocs);
+
       // Post the output docs to the configured sink.
-      if(opt.sink.host && opt.sink.posts)
+      if(opt.sink.host && opt.sink.posts && !error)
         error = yield postOutputs(podocs, skeys, stimes,
           opt.sink.host, opt.sink.apps, opt.sink.posts,
           opt.sink.authentication, ddup);
@@ -832,6 +837,10 @@ const groupReduce = (itype,
       // Post the output docs to the configured sink
       const presults = yield tmap(pgdocs,
         function *(podocs, i, l) {
+          const error = checkError(podocs);
+          if(error)
+            return error;
+
           if(!shost || !sposts)
             return undefined;
 


### PR DESCRIPTION
Address #548

When a dataflow app has no sink configured, it will not try to detect if business error exist. This PR will solve this issue.