### PR TITLE
Handle business errors in bridge and renewer

### DIFF
--- a/lib/cf/bridge/src/index.js
+++ b/lib/cf/bridge/src/index.js
@@ -110,6 +110,7 @@ const statistics = {
     reportFailures: 0,
     reportSuccess: 0,
     reportConflict: 0,
+    reportBusinessError: 0,
     loopFailures: 0,
     loopSuccess: 0,
     loopConflict: 0,
@@ -136,7 +137,7 @@ const statistics = {
 const errors = {
   missingToken: false,
   noReportEverHappened: true,
-  consecutiveFailures: 0,
+  consecutiveReportFailures: 0,
   lastError: '',
   lastErrorTimestamp: ''
 };
@@ -225,55 +226,90 @@ const writeDBCache = () => {
 
 const authHeader = (token) => token ? { authorization: token() } : {};
 
-const reportUsage = (usage, token, config, cb = () => {}) => {
+const processSuccessfulReport = (response, usage, t0, cb) => {
+  if (!response.headers || !response.headers.location) {
+    const message = util.format('No Location header found in ' +
+      'response %j for usage %j', response, usage);
+    edebug(message);
+    throw new Error(message);
+  }
+
+  debug('Successfully reported usage %j with headers %j',
+    usage, response.headers);
+  statistics.usage.reportSuccess++;
+  errors.noReportEverHappened = false;
+  errors.consecutiveReportFailures = 0;
+  perf.report('report', t0);
+
+  carryOver.write(usage, response, (error) => {
+    cb(error, response);
+  });
+};
+
+const processBusinessErrorReport = (response, usage, t0, cb) => {
+  statistics.usage.reportBusinessError++;
+  debug('Business error for usage %j. Response: %j', usage, response);
+  perf.report('report', t0, undefined, undefined, undefined, 'rejected');
+
+  if (response.statusCode === 409) {
+    statistics.usage.reportConflict++;
+    errors.noReportEverHappened = false;
+    cb(undefined, response);
+    return;
+  }
+
+  statistics.usage.reportFailures++;
+  cb(extend(new Error(), response.body), response);
+};
+
+const processFailedReport = (error, response, t0, cb) => {
+  statistics.usage.reportFailures++;
+  errors.consecutiveReportFailures++;
+
+  const message = util.format(
+    'Failed reporting usage. Consecutive failures: %d',
+    errors.consecutiveReportFailures
+  );
+  registerError(message, error, undefined, 'report', t0);
+
+  cb(error ? error : new Error(message), response);
+};
+
+const processReportError = (error, response, t0, cb) => {
+  statistics.usage.reportFailures++;
+  errors.consecutiveReportFailures++;
+
+  const message = util.format('Failed reporting usage. ' +
+    'Consecutive failures: %d', errors.consecutiveReportFailures);
+  registerError(message, error, undefined, 'report', t0);
+
+  cb(error, response);
+};
+
+const reportUsage = (usage, token, cb = () => {}) => {
   const t0 = moment.now();
   brequest.post(':collector/v1/metering/collected/usage', {
     collector: uris().collector,
     headers: authHeader(token),
     body: usage
   }, (error, response) => {
-    if (!error && response) {
-      if (response.statusCode === 201) {
-        if (!response.headers || !response.headers.location) {
-          const message = util.format('No Location header found in ' +
-            'response %j for usage %j', response, usage);
-          edebug(message);
-          throw new Error(message);
-        }
-
-        debug('Successfully reported usage %j with headers %j',
-          usage, response.headers);
-        statistics.usage.reportSuccess++;
-        errors.noReportEverHappened = false;
-        errors.consecutiveFailures = 0;
-        perf.report('report', t0);
-
-        carryOver.write(usage, response, (error) => {
-          cb(error, response);
-        });
-        return;
-      }
-      if (response.statusCode === 409) {
-        debug('Conflicting usage %j. Response: %j', usage, response);
-        statistics.usage.reportConflict++;
-        perf.report('report', t0, undefined, undefined, undefined, 'rejected');
-        cb(error, response);
-        return;
-      }
-
-      statistics.usage.reportFailures++;
-      errors.consecutiveFailures++;
-      cb(error, response);
+    // Error or no response
+    if (error || !response) {
+      processReportError(error, response, t0, cb);
       return;
     }
-    statistics.usage.reportFailures++;
-    errors.consecutiveFailures++;
 
-    const message = util.format('Failed reporting usage. ' +
-      'Consecutive failures: %d', errors.consecutiveFailures);
-    registerError(message, error, undefined, 'report', t0);
+    // Business error
+    if (response.body && response.body.error) {
+      processBusinessErrorReport(response, usage, t0, cb);
+      return;
+    }
 
-    cb(error, response);
+    // Response
+    if (response.statusCode === 201)
+      processSuccessfulReport(response, usage, t0, cb);
+    else
+      processFailedReport(error, response, t0, cb);
   });
 };
 
@@ -464,7 +500,7 @@ const reportAppUsage = (cfToken, abacusToken, { failure, success }) => {
 
       if (usage && isElder(resource) && isRequested(resource)) {
         debug('Reporting usage event %j', usage);
-        reportUsage(usage, abacusToken, reportingConfig, (error, response) => {
+        reportUsage(usage, abacusToken, (error, response) => {
           if (!error && response && response.statusCode === 409) {
             statistics.usage.loopConflict++;
             perf.report('usage', t0, undefined, undefined,
@@ -582,32 +618,31 @@ const purgeCompensation = (cfToken, abacusToken, { failure, success }) => {
           const usage = buildAppUsage(resource, true);
           if (usage) {
             debug('Submitting STOP usage for app %s', guid);
-            reportUsage(usage, abacusToken, compensationConfig,
-              (error, response) => {
-                const responseCode = response ? response.statusCode : 'none';
+            reportUsage(usage, abacusToken,(error, response) => {
+              const responseCode = response ? response.statusCode : 'none';
 
-                if (!error && response && response.statusCode === 409) {
-                  statistics.compensation.usageConflict++;
-                  perf.report('compensation', t0, undefined, undefined,
-                    undefined, 'rejected');
-                  done();
-                  return;
-                }
-                if (error || responseCode !== 201) {
-                  statistics.compensation.usageFailure++;
-                  registerError('Error reporting compensating usage', error,
-                    response, 'compensation', t0);
-                  done(error, response);
-                  return;
-                }
-
-                cache.lastCompensatedGUID = guid;
-                cache.lastCompensatedTimestamp = resource.metadata.created_at;
-                compensationConfig.currentRetries = 0;
-                statistics.compensation.usageSuccess++;
-                perf.report('compensation', t0);
+              if (!error && response && response.statusCode === 409) {
+                statistics.compensation.usageConflict++;
+                perf.report('compensation', t0, undefined, undefined,
+                  undefined, 'rejected');
                 done();
-              });
+                return;
+              }
+              if (error || responseCode !== 201) {
+                statistics.compensation.usageFailure++;
+                registerError('Error reporting compensating usage', error,
+                  response, 'compensation', t0);
+                done(error, response);
+                return;
+              }
+
+              cache.lastCompensatedGUID = guid;
+              cache.lastCompensatedTimestamp = resource.metadata.created_at;
+              compensationConfig.currentRetries = 0;
+              statistics.compensation.usageSuccess++;
+              perf.report('compensation', t0);
+              done();
+            });
           }
           else {
             statistics.compensation.usageSkip++;

--- a/lib/cf/bridge/src/test/api-test.js
+++ b/lib/cf/bridge/src/test/api-test.js
@@ -298,6 +298,7 @@ describe('Admin API', () => {
                 missingToken: 0,
                 reportFailures: 0,
                 reportSuccess: 0,
+                reportBusinessError: 0,
                 reportConflict: 0,
                 loopFailures: 0,
                 loopSuccess: 0,
@@ -334,7 +335,7 @@ describe('Admin API', () => {
             errors: {
               missingToken: false,
               noReportEverHappened: true,
-              consecutiveFailures: 0,
+              consecutiveReportFailures: 0,
               lastError: '',
               lastErrorTimestamp: ''
             }

--- a/lib/cf/bridge/src/test/compensation-test.js
+++ b/lib/cf/bridge/src/test/compensation-test.js
@@ -734,7 +734,7 @@ describe('Purge compensation', () => {
 
         bridge.purgeCompensation(cfToken, abacusToken, {
           failure: (error, response) => {
-            expect(error).to.equal(null);
+            expect(error).to.not.equal(undefined);
             expect(response).to.deep.equal({ statusCode: 500, body: {} });
 
             expect(returnError).to.equal(true);
@@ -765,7 +765,7 @@ describe('Purge compensation', () => {
       it('retries', (done) => {
         bridge.purgeCompensation(cfToken, abacusToken, {
           failure: (error, response) => {
-            expect(error).to.equal(null);
+            expect(error).to.not.equal(undefined);
             expect(response).to.deep.equal({ statusCode: 500, body: {} });
 
             expect(returnError).to.equal(true);
@@ -834,7 +834,15 @@ describe('Purge compensation', () => {
             cb(null, { statusCode: 200, body: purgedAppUsage });
           }),
           post: spy((uri, opts, cb) => {
-            cb(null, { statusCode: 409, body: {} });
+            cb(null, {
+              statusCode: 409,
+              headers: { location: 'some location' },
+              body: {
+                error: 'conflict',
+                reason: 'Conflict! Do not retry',
+                noretry: true
+              }
+            });
           })
         });
         require.cache[require.resolve('abacus-request')].exports = reqmock;
@@ -845,7 +853,8 @@ describe('Purge compensation', () => {
       it('returns with success', (done) => {
         bridge.purgeCompensation(cfToken, abacusToken, {
           failure: (error, response) => {
-            done(new Error('Unexpected call to failure'));
+            done(new Error(util.format('Unexpected call of failure with ' +
+              'error %j and response %j', error, response)));
           },
           success: () => {
             done();
@@ -856,7 +865,8 @@ describe('Purge compensation', () => {
       it('increases conflict counter', (done) => {
         bridge.purgeCompensation(cfToken, abacusToken, {
           failure: (error, response) => {
-            done(new Error('Unexpected call to failure'));
+            done(new Error(util.format('Unexpected call of failure with ' +
+              'error %j and response %j', error, response)));
           },
           success: () => {
             expect(bridge.statistics.compensation.usageConflict).to.equal(1);
@@ -954,8 +964,8 @@ describe('Purge compensation', () => {
         post: spy((uri, opts, cb) => {
           cb(null, {
             statusCode: 201,
-            body: {},
-            headers: { location: 'some location' }
+            headers: { location: 'some location' },
+            body: {}
           });
         })
       });

--- a/lib/cf/bridge/src/test/report-usage-test.js
+++ b/lib/cf/bridge/src/test/report-usage-test.js
@@ -379,31 +379,41 @@ const tests = (secured) => {
         checkPostRequest(args[1], '35c4ff2f', 536870912, 1, 268435456, 2);
       });
 
+
       it('populates paging statistics', () => {
-        expect(bridge.statistics.paging.pageReadSuccess).to.equal(1);
-        expect(bridge.statistics.paging.pageReadFailures).to.equal(0);
-        expect(bridge.statistics.paging.pageProcessSuccess).to.equal(5);
-        expect(bridge.statistics.paging.pageProcessFailures).to.equal(0);
-        expect(bridge.statistics.paging.pageProcessEnd).to.equal(2);
+        expect(bridge.statistics.paging).to.deep.equal({
+          pageReadSuccess: 1,
+          pageReadFailures: 0,
+          pageProcessSuccess: 5,
+          pageProcessFailures: 0,
+          pageProcessEnd: 2,
+          missingToken: 0
+        });
       });
 
       it('populates usage statistics', () => {
-        expect(bridge.statistics.usage.reportFailures).to.equal(0);
-        expect(bridge.statistics.usage.reportSuccess).to.equal(2);
-        expect(bridge.statistics.usage.reportConflict).to.equal(0);
-        expect(bridge.statistics.usage.loopFailures).to.equal(0);
-        expect(bridge.statistics.usage.loopSuccess).to.equal(2);
-        expect(bridge.statistics.usage.loopConflict).to.equal(0);
-        expect(bridge.statistics.usage.loopSkip).to.equal(3);
+        expect(bridge.statistics.usage).to.deep.equal({
+          reportFailures: 0,
+          reportSuccess: 2,
+          reportBusinessError: 0,
+          reportConflict: 0,
+          loopFailures: 0,
+          loopSuccess: 2,
+          loopConflict: 0,
+          loopSkip: 3,
+          missingToken: 0
+        });
       });
 
       it('populates carry-over statistics', () => {
-        expect(bridge.statistics.carryOver.getSuccess).to.equal(2);
-        expect(bridge.statistics.carryOver.getFailure).to.equal(0);
-        expect(bridge.statistics.carryOver.removeSuccess).to.equal(0);
-        expect(bridge.statistics.carryOver.removeFailure).to.equal(0);
-        expect(bridge.statistics.carryOver.upsertSuccess).to.equal(2);
-        expect(bridge.statistics.carryOver.upsertFailure).to.equal(0);
+        expect(bridge.statistics.carryOver).to.deep.equal({
+          getSuccess: 2,
+          getFailure: 0,
+          removeSuccess: 0,
+          removeFailure: 0,
+          upsertSuccess: 2,
+          upsertFailure: 0
+        });
       });
     });
 
@@ -453,30 +463,39 @@ const tests = (secured) => {
         });
 
         it('populates paging statistics', () => {
-          expect(bridge.statistics.paging.pageReadSuccess).to.equal(1);
-          expect(bridge.statistics.paging.pageReadFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessSuccess).to.equal(1);
-          expect(bridge.statistics.paging.pageProcessFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessEnd).to.equal(1);
+          expect(bridge.statistics.paging).to.deep.equal({
+            pageReadSuccess: 1,
+            pageReadFailures: 0,
+            pageProcessSuccess: 1,
+            pageProcessFailures: 0,
+            pageProcessEnd: 1,
+            missingToken: 0
+          });
         });
 
         it('populates usage statistics', () => {
-          expect(bridge.statistics.usage.reportFailures).to.equal(0);
-          expect(bridge.statistics.usage.reportSuccess).to.equal(1);
-          expect(bridge.statistics.usage.reportConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopFailures).to.equal(0);
-          expect(bridge.statistics.usage.loopSuccess).to.equal(1);
-          expect(bridge.statistics.usage.loopConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopSkip).to.equal(0);
+          expect(bridge.statistics.usage).to.deep.equal({
+            reportFailures: 0,
+            reportSuccess: 1,
+            reportBusinessError: 0,
+            reportConflict: 0,
+            loopFailures: 0,
+            loopSuccess: 1,
+            loopConflict: 0,
+            loopSkip: 0,
+            missingToken: 0
+          });
         });
 
         it('populates carry-over statistics', () => {
-          expect(bridge.statistics.carryOver.getSuccess).to.equal(1);
-          expect(bridge.statistics.carryOver.getFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.removeSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.removeFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertSuccess).to.equal(1);
-          expect(bridge.statistics.carryOver.upsertFailure).to.equal(0);
+          expect(bridge.statistics.carryOver).to.deep.equal({
+            getSuccess: 1,
+            getFailure: 0,
+            removeSuccess: 0,
+            removeFailure: 0,
+            upsertSuccess: 1,
+            upsertFailure: 0
+          });
         });
       });
 
@@ -518,30 +537,39 @@ const tests = (secured) => {
         });
 
         it('populates paging statistics', () => {
-          expect(bridge.statistics.paging.pageReadSuccess).to.equal(1);
-          expect(bridge.statistics.paging.pageReadFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessSuccess).to.equal(1);
-          expect(bridge.statistics.paging.pageProcessFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessEnd).to.equal(1);
+          expect(bridge.statistics.paging).to.deep.equal({
+            pageReadSuccess: 1,
+            pageReadFailures: 0,
+            pageProcessSuccess: 1,
+            pageProcessFailures: 0,
+            pageProcessEnd: 1,
+            missingToken: 0
+          });
         });
 
         it('populates usage statistics', () => {
-          expect(bridge.statistics.usage.reportFailures).to.equal(0);
-          expect(bridge.statistics.usage.reportSuccess).to.equal(1);
-          expect(bridge.statistics.usage.reportConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopFailures).to.equal(0);
-          expect(bridge.statistics.usage.loopSuccess).to.equal(1);
-          expect(bridge.statistics.usage.loopConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopSkip).to.equal(0);
+          expect(bridge.statistics.usage).to.deep.equal({
+            reportFailures: 0,
+            reportSuccess: 1,
+            reportBusinessError: 0,
+            reportConflict: 0,
+            loopFailures: 0,
+            loopSuccess: 1,
+            loopConflict: 0,
+            loopSkip: 0,
+            missingToken: 0
+          });
         });
 
         it('populates carry-over statistics', () => {
-          expect(bridge.statistics.carryOver.getSuccess).to.equal(1);
-          expect(bridge.statistics.carryOver.getFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.removeSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.removeFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertSuccess).to.equal(1);
-          expect(bridge.statistics.carryOver.upsertFailure).to.equal(0);
+          expect(bridge.statistics.carryOver).to.deep.equal({
+            getSuccess: 1,
+            getFailure: 0,
+            removeSuccess: 0,
+            removeFailure: 0,
+            upsertSuccess: 1,
+            upsertFailure: 0
+          });
         });
       });
 
@@ -588,30 +616,39 @@ const tests = (secured) => {
         });
 
         it('populates paging statistics', () => {
-          expect(bridge.statistics.paging.pageReadSuccess).to.equal(1);
-          expect(bridge.statistics.paging.pageReadFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessSuccess).to.equal(1);
-          expect(bridge.statistics.paging.pageProcessFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessEnd).to.equal(1);
+          expect(bridge.statistics.paging).to.deep.equal({
+            pageReadSuccess: 1,
+            pageReadFailures: 0,
+            pageProcessSuccess: 1,
+            pageProcessFailures: 0,
+            pageProcessEnd: 1,
+            missingToken: 0
+          });
         });
 
         it('populates usage statistics', () => {
-          expect(bridge.statistics.usage.reportFailures).to.equal(0);
-          expect(bridge.statistics.usage.reportSuccess).to.equal(1);
-          expect(bridge.statistics.usage.reportConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopFailures).to.equal(0);
-          expect(bridge.statistics.usage.loopSuccess).to.equal(1);
-          expect(bridge.statistics.usage.loopConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopSkip).to.equal(0);
+          expect(bridge.statistics.usage).to.deep.equal({
+            reportFailures: 0,
+            reportSuccess: 1,
+            reportBusinessError: 0,
+            reportConflict: 0,
+            loopFailures: 0,
+            loopSuccess: 1,
+            loopConflict: 0,
+            loopSkip: 0,
+            missingToken: 0
+          });
         });
 
         it('populates carry-over statistics', () => {
-          expect(bridge.statistics.carryOver.getSuccess).to.equal(1);
-          expect(bridge.statistics.carryOver.getFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.removeSuccess).to.equal(1);
-          expect(bridge.statistics.carryOver.removeFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertFailure).to.equal(0);
+          expect(bridge.statistics.carryOver).to.deep.equal({
+            getSuccess: 1,
+            getFailure: 0,
+            removeSuccess: 1,
+            removeFailure: 0,
+            upsertSuccess: 0,
+            upsertFailure: 0
+          });
         });
       });
     });
@@ -745,30 +782,75 @@ const tests = (secured) => {
         });
 
         it('populates paging statistics', () => {
-          expect(bridge.statistics.paging.pageReadSuccess).to.equal(0);
-          expect(bridge.statistics.paging.pageReadFailures).to.equal(1);
-          expect(bridge.statistics.paging.pageProcessSuccess).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessEnd).to.equal(0);
+          expect(bridge.statistics.paging).to.deep.equal({
+            pageReadSuccess: 0,
+            pageReadFailures: 1,
+            pageProcessSuccess: 0,
+            pageProcessFailures: 0,
+            pageProcessEnd: 0,
+            missingToken: 0
+          });
         });
 
         it('populates usage statistics', () => {
-          expect(bridge.statistics.usage.reportFailures).to.equal(0);
-          expect(bridge.statistics.usage.reportSuccess).to.equal(0);
-          expect(bridge.statistics.usage.reportConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopFailures).to.equal(0);
-          expect(bridge.statistics.usage.loopSuccess).to.equal(0);
-          expect(bridge.statistics.usage.loopConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopSkip).to.equal(0);
+          expect(bridge.statistics.usage).to.deep.equal({
+            reportFailures: 0,
+            reportSuccess: 0,
+            reportBusinessError: 0,
+            reportConflict: 0,
+            loopFailures: 0,
+            loopSuccess: 0,
+            loopConflict: 0,
+            loopSkip: 0,
+            missingToken: 0
+          });
         });
 
-        it('populates carry-over statistics', () => {
-          expect(bridge.statistics.carryOver.getSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.getFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.removeSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.removeFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertFailure).to.equal(0);
+        it('does not change carry-over statistics', () => {
+          expect(bridge.statistics.carryOver).to.deep.equal({
+            getSuccess: 0,
+            getFailure: 0,
+            removeSuccess: 0,
+            removeFailure: 0,
+            upsertSuccess: 0,
+            upsertFailure: 0
+          });
+        });
+
+        it('populates paging statistics', () => {
+          expect(bridge.statistics.paging).to.deep.equal({
+            pageReadSuccess: 0,
+            pageReadFailures: 1,
+            pageProcessSuccess: 0,
+            pageProcessFailures: 0,
+            pageProcessEnd: 0,
+            missingToken: 0
+          });
+        });
+
+        it('populates usage statistics', () => {
+          expect(bridge.statistics.usage).to.deep.equal({
+            reportFailures: 0,
+            reportSuccess: 0,
+            reportBusinessError: 0,
+            reportConflict: 0,
+            loopFailures: 0,
+            loopSuccess: 0,
+            loopConflict: 0,
+            loopSkip: 0,
+            missingToken: 0
+          });
+        });
+
+        it('does not change carry-over statistics', () => {
+          expect(bridge.statistics.carryOver).to.deep.equal({
+            getSuccess: 0,
+            getFailure: 0,
+            removeSuccess: 0,
+            removeFailure: 0,
+            upsertSuccess: 0,
+            upsertFailure: 0
+          });
         });
       });
 
@@ -790,30 +872,39 @@ const tests = (secured) => {
         });
 
         it('populates paging statistics', () => {
-          expect(bridge.statistics.paging.pageReadSuccess).to.equal(0);
-          expect(bridge.statistics.paging.pageReadFailures).to.equal(1);
-          expect(bridge.statistics.paging.pageProcessSuccess).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessEnd).to.equal(0);
+          expect(bridge.statistics.paging).to.deep.equal({
+            pageReadSuccess: 0,
+            pageReadFailures: 1,
+            pageProcessSuccess: 0,
+            pageProcessFailures: 0,
+            pageProcessEnd: 0,
+            missingToken: 0
+          });
         });
 
         it('populates usage statistics', () => {
-          expect(bridge.statistics.usage.reportFailures).to.equal(0);
-          expect(bridge.statistics.usage.reportSuccess).to.equal(0);
-          expect(bridge.statistics.usage.reportConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopFailures).to.equal(0);
-          expect(bridge.statistics.usage.loopSuccess).to.equal(0);
-          expect(bridge.statistics.usage.loopConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopSkip).to.equal(0);
+          expect(bridge.statistics.usage).to.deep.equal({
+            reportFailures: 0,
+            reportSuccess: 0,
+            reportBusinessError: 0,
+            reportConflict: 0,
+            loopFailures: 0,
+            loopSuccess: 0,
+            loopConflict: 0,
+            loopSkip: 0,
+            missingToken: 0
+          });
         });
 
-        it('populates carry-over statistics', () => {
-          expect(bridge.statistics.carryOver.getSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.getFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.removeSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.removeFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertFailure).to.equal(0);
+        it('does not change carry-over statistics', () => {
+          expect(bridge.statistics.carryOver).to.deep.equal({
+            getSuccess: 0,
+            getFailure: 0,
+            removeSuccess: 0,
+            removeFailure: 0,
+            upsertSuccess: 0,
+            upsertFailure: 0
+          });
         });
       });
 
@@ -827,31 +918,39 @@ const tests = (secured) => {
         });
 
         it('populates paging statistics', () => {
-          expect(bridge.statistics.paging.missingToken).to.equal(1);
-          expect(bridge.statistics.paging.pageReadSuccess).to.equal(0);
-          expect(bridge.statistics.paging.pageReadFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessSuccess).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessEnd).to.equal(0);
+          expect(bridge.statistics.paging).to.deep.equal({
+            pageReadSuccess: 0,
+            pageReadFailures: 0,
+            pageProcessSuccess: 0,
+            pageProcessFailures: 0,
+            pageProcessEnd: 0,
+            missingToken: 1
+          });
         });
 
         it('populates usage statistics', () => {
-          expect(bridge.statistics.usage.reportFailures).to.equal(0);
-          expect(bridge.statistics.usage.reportSuccess).to.equal(0);
-          expect(bridge.statistics.usage.reportConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopFailures).to.equal(0);
-          expect(bridge.statistics.usage.loopSuccess).to.equal(0);
-          expect(bridge.statistics.usage.loopConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopSkip).to.equal(0);
+          expect(bridge.statistics.usage).to.deep.equal({
+            reportFailures: 0,
+            reportSuccess: 0,
+            reportBusinessError: 0,
+            reportConflict: 0,
+            loopFailures: 0,
+            loopSuccess: 0,
+            loopConflict: 0,
+            loopSkip: 0,
+            missingToken: 0
+          });
         });
 
-        it('populates carry-over statistics', () => {
-          expect(bridge.statistics.carryOver.getSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.getFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.removeSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.removeFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertFailure).to.equal(0);
+        it('does not change carry-over statistics', () => {
+          expect(bridge.statistics.carryOver).to.deep.equal({
+            getSuccess: 0,
+            getFailure: 0,
+            removeSuccess: 0,
+            removeFailure: 0,
+            upsertSuccess: 0,
+            upsertFailure: 0
+          });
         });
       });
     });
@@ -874,7 +973,10 @@ const tests = (secured) => {
           bridge = require('..');
           bridge.reportingConfig.minInterval = 5000;
           bridge.reportAppUsage(cfToken, abacusToken,
-            expectError(bridge, null, { statusCode: 500, body: {} }, done));
+            expectError(bridge,
+              'Failed reporting usage. Consecutive failures: 1',
+              { statusCode: 500, body: {} },
+              done));
         });
 
         it('increases the retry count', () => {
@@ -882,89 +984,333 @@ const tests = (secured) => {
         });
 
         it('populates paging statistics', () => {
-          expect(bridge.statistics.paging.pageReadSuccess).to.equal(0);
-          expect(bridge.statistics.paging.pageReadFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessSuccess).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessFailures).to.equal(1);
-          expect(bridge.statistics.paging.pageProcessEnd).to.equal(0);
+          expect(bridge.statistics.paging).to.deep.equal({
+            pageReadSuccess: 0,
+            pageReadFailures: 0,
+            pageProcessSuccess: 0,
+            pageProcessFailures: 1,
+            pageProcessEnd: 0,
+            missingToken: 0
+          });
         });
 
         it('populates usage statistics', () => {
-          expect(bridge.statistics.usage.reportFailures).to.equal(1);
-          expect(bridge.statistics.usage.reportSuccess).to.equal(0);
-          expect(bridge.statistics.usage.reportConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopFailures).to.equal(1);
-          expect(bridge.statistics.usage.loopSuccess).to.equal(0);
-          expect(bridge.statistics.usage.loopConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopSkip).to.equal(0);
+          expect(bridge.statistics.usage).to.deep.equal({
+            reportFailures: 1,
+            reportSuccess: 0,
+            reportBusinessError: 0,
+            reportConflict: 0,
+            loopFailures: 1,
+            loopSuccess: 0,
+            loopConflict: 0,
+            loopSkip: 0,
+            missingToken: 0
+          });
         });
 
-        it('populates carry-over statistics', () => {
-          expect(bridge.statistics.carryOver.getSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.getFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.removeSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.removeFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertFailure).to.equal(0);
+        it('does not change carry-over statistics', () => {
+          expect(bridge.statistics.carryOver).to.deep.equal({
+            getSuccess: 0,
+            getFailure: 0,
+            removeSuccess: 0,
+            removeFailure: 0,
+            upsertSuccess: 0,
+            upsertFailure: 0
+          });
         });
       });
 
-      context('on 409 response code', () => {
-        beforeEach((done) => {
-          // Mock the request module
-          const request = require('abacus-request');
-          reqmock = extend({}, request, {
-            get: spy((uri, opts, cb) => {
-              cb(null, { statusCode: 200, body: appUsagePageTwo });
-            }),
-            post: spy((uri, opts, cb) => {
-              cb(null, { statusCode: 409, body: {} });
-            })
+      context('on business error', () => {
+        context('on 409 response code', () => {
+          beforeEach((done) => {
+            // Mock the request module
+            const request = require('abacus-request');
+            reqmock = extend({}, request, {
+              get: spy((uri, opts, cb) => {
+                cb(null, { statusCode: 200, body: appUsagePageTwo });
+              }),
+              post: spy((uri, opts, cb) => {
+                cb(null, { statusCode: 409, body: {
+                  error: 'conflict',
+                  reason: 'Conflict? Please retry'
+                } });
+              })
+            });
+            require.cache[require.resolve('abacus-request')].exports = reqmock;
+
+            bridge = require('..');
+            bridge.reportingConfig.minInterval = 5000;
+            bridge.reportAppUsage(cfToken, abacusToken, {
+              failure: (error, response) => {
+                bridge.stopReporting();
+                done(new Error(util.format('Unexpected call of failure with ' +
+                  'error %j and response %j', error, response)));
+              },
+              success: () => {
+                bridge.stopReporting();
+                done();
+              }
+            });
           });
-          require.cache[require.resolve('abacus-request')].exports = reqmock;
 
-          bridge = require('..');
-          bridge.reportingConfig.minInterval = 5000;
-          bridge.reportAppUsage(cfToken, abacusToken, {
-            failure: () => {
-              done(new Error('Unexpected call of failure'));
-            },
-            success: () => {
-              bridge.stopReporting();
-              done();
-            }
+          it('populates paging statistics', () => {
+            expect(bridge.statistics.paging).to.deep.equal({
+              pageReadSuccess: 1,
+              pageReadFailures: 0,
+              pageProcessSuccess: 1,
+              pageProcessFailures: 0,
+              pageProcessEnd: 1,
+              missingToken: 0
+            });
+          });
+
+          it('populates usage statistics', () => {
+            expect(bridge.statistics.usage).to.deep.equal({
+              reportFailures: 0,
+              reportSuccess: 0,
+              reportBusinessError: 1,
+              reportConflict: 1,
+              loopFailures: 0,
+              loopSuccess: 0,
+              loopConflict: 1,
+              loopSkip: 0,
+              missingToken: 0
+            });
+          });
+
+          it('does not change carry-over statistics', () => {
+            expect(bridge.statistics.carryOver).to.deep.equal({
+              getSuccess: 0,
+              getFailure: 0,
+              removeSuccess: 0,
+              removeFailure: 0,
+              upsertSuccess: 0,
+              upsertFailure: 0
+            });
           });
         });
 
-        it('increases the conflict count', () => {
-          expect(bridge.statistics.usage.reportConflict).to.equal(1);
+        context('on 409 response code with noretry', () => {
+          beforeEach((done) => {
+            // Mock the request module
+            const request = require('abacus-request');
+            reqmock = extend({}, request, {
+              get: spy((uri, opts, cb) => {
+                cb(null, { statusCode: 200, body: appUsagePageTwo });
+              }),
+              post: spy((uri, opts, cb) => {
+                cb(null, { statusCode: 409, body: {
+                  error: 'conflict',
+                  reason: 'Conflict! Do not retry',
+                  noretry: true
+                } });
+              })
+            });
+            require.cache[require.resolve('abacus-request')].exports = reqmock;
+
+            bridge = require('..');
+            bridge.reportingConfig.minInterval = 5000;
+            bridge.reportAppUsage(cfToken, abacusToken, {
+              failure: (error, response) => {
+                bridge.stopReporting();
+                done(new Error(util.format('Unexpected call of failure with ' +
+                  'error %j and response %j', error, response)));
+              },
+              success: () => {
+                bridge.stopReporting();
+                done();
+              }
+            });
+          });
+
+          it('populates paging statistics', () => {
+            expect(bridge.statistics.paging).to.deep.equal({
+              pageReadSuccess: 1,
+              pageReadFailures: 0,
+              pageProcessSuccess: 1,
+              pageProcessFailures: 0,
+              pageProcessEnd: 1,
+              missingToken: 0
+            });
+          });
+
+          it('populates usage statistics', () => {
+            expect(bridge.statistics.usage).to.deep.equal({
+              reportFailures: 0,
+              reportSuccess: 0,
+              reportBusinessError: 1,
+              reportConflict: 1,
+              loopFailures: 0,
+              loopSuccess: 0,
+              loopConflict: 1,
+              loopSkip: 0,
+              missingToken: 0
+            });
+          });
+
+          it('does not change carry-over statistics', () => {
+            expect(bridge.statistics.carryOver).to.deep.equal({
+              getSuccess: 0,
+              getFailure: 0,
+              removeSuccess: 0,
+              removeFailure: 0,
+              upsertSuccess: 0,
+              upsertFailure: 0
+            });
+          });
         });
 
-        it('populates paging statistics', () => {
-          expect(bridge.statistics.paging.pageReadSuccess).to.equal(1);
-          expect(bridge.statistics.paging.pageReadFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessSuccess).to.equal(1);
-          expect(bridge.statistics.paging.pageProcessFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessEnd).to.equal(1);
+        context('on 201 response code', () => {
+          beforeEach((done) => {
+            const errorBody = {
+              error: 'emplannotfound',
+              reason: 'Metering plan for the metering plan id ' +
+              'complex-object-storage is not found'
+            };
+
+            // Mock the request module
+            const request = require('abacus-request');
+            reqmock = extend({}, request, {
+              get: spy((uri, opts, cb) => {
+                cb(null, { statusCode: 200, body: appUsagePageTwo });
+              }),
+              post: spy((uri, opts, cb) => {
+                cb(null, {
+                  statusCode: 201,
+                  headers: { location: 'some location' },
+                  body: errorBody
+                });
+              })
+            });
+            require.cache[require.resolve('abacus-request')].exports = reqmock;
+
+            bridge = require('..');
+            bridge.reportingConfig.minInterval = 5000;
+            bridge.reportAppUsage(cfToken, abacusToken, {
+              failure: (error, response) => {
+                expect(error).to.deep.equal(errorBody);
+                expect(response.statusCode).to.equal(201);
+
+                bridge.stopReporting();
+                done();
+              },
+              success: () => {
+                done(new Error('Unexpected call of success'));
+              }
+            });
+          });
+
+          it('populates paging statistics', () => {
+            expect(bridge.statistics.paging).to.deep.equal({
+              pageReadSuccess: 0,
+              pageReadFailures: 0,
+              pageProcessSuccess: 0,
+              pageProcessFailures: 1,
+              pageProcessEnd: 0,
+              missingToken: 0
+            });
+          });
+
+          it('populates usage statistics', () => {
+            expect(bridge.statistics.usage).to.deep.equal({
+              reportFailures: 1,
+              reportSuccess: 0,
+              reportBusinessError: 1,
+              reportConflict: 0,
+              loopFailures: 1,
+              loopSuccess: 0,
+              loopConflict: 0,
+              loopSkip: 0,
+              missingToken: 0
+            });
+          });
+
+          it('does not change carry-over statistics', () => {
+            expect(bridge.statistics.carryOver).to.deep.equal({
+              getSuccess: 0,
+              getFailure: 0,
+              removeSuccess: 0,
+              removeFailure: 0,
+              upsertSuccess: 0,
+              upsertFailure: 0
+            });
+          });
         });
 
-        it('populates usage statistics', () => {
-          expect(bridge.statistics.usage.reportFailures).to.equal(0);
-          expect(bridge.statistics.usage.reportSuccess).to.equal(0);
-          expect(bridge.statistics.usage.reportConflict).to.equal(1);
-          expect(bridge.statistics.usage.loopFailures).to.equal(0);
-          expect(bridge.statistics.usage.loopSuccess).to.equal(0);
-          expect(bridge.statistics.usage.loopConflict).to.equal(1);
-          expect(bridge.statistics.usage.loopSkip).to.equal(0);
-        });
+        context('on 500 response code with noretry', () => {
+          beforeEach((done) => {
+            const errorBody = {
+              error: 'internal',
+              reason: 'Network connectivity problem'
+            };
 
-        it('populates carry-over statistics', () => {
-          expect(bridge.statistics.carryOver.getSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.getFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.removeSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.removeFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertFailure).to.equal(0);
+            // Mock the request module
+            const request = require('abacus-request');
+            reqmock = extend({}, request, {
+              get: spy((uri, opts, cb) => {
+                cb(null, { statusCode: 200, body: appUsagePageTwo });
+              }),
+              post: spy((uri, opts, cb) => {
+                cb(null, {
+                  statusCode: 500,
+                  headers: { location: 'some location' },
+                  body: errorBody
+                });
+              })
+            });
+            require.cache[require.resolve('abacus-request')].exports = reqmock;
+
+            bridge = require('..');
+            bridge.reportingConfig.minInterval = 5000;
+            bridge.reportAppUsage(cfToken, abacusToken, {
+              failure: (error, response) => {
+                expect(error).to.deep.equal(errorBody);
+                expect(response.statusCode).to.equal(500);
+
+                bridge.stopReporting();
+                done();
+              },
+              success: () => {
+                done(new Error('Unexpected call of success'));
+              }
+            });
+          });
+
+          it('populates paging statistics', () => {
+            expect(bridge.statistics.paging).to.deep.equal({
+              pageReadSuccess: 0,
+              pageReadFailures: 0,
+              pageProcessSuccess: 0,
+              pageProcessFailures: 1,
+              pageProcessEnd: 0,
+              missingToken: 0
+            });
+          });
+
+          it('populates usage statistics', () => {
+            expect(bridge.statistics.usage).to.deep.equal({
+              reportFailures: 1,
+              reportSuccess: 0,
+              reportBusinessError: 1,
+              reportConflict: 0,
+              loopFailures: 1,
+              loopSuccess: 0,
+              loopConflict: 0,
+              loopSkip: 0,
+              missingToken: 0
+            });
+          });
+
+          it('does not change carry-over statistics', () => {
+            expect(bridge.statistics.carryOver).to.deep.equal({
+              getSuccess: 0,
+              getFailure: 0,
+              removeSuccess: 0,
+              removeFailure: 0,
+              upsertSuccess: 0,
+              upsertFailure: 0
+            });
+          });
         });
       });
 
@@ -993,30 +1339,39 @@ const tests = (secured) => {
         });
 
         it('populates paging statistics', () => {
-          expect(bridge.statistics.paging.pageReadSuccess).to.equal(0);
-          expect(bridge.statistics.paging.pageReadFailures).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessSuccess).to.equal(0);
-          expect(bridge.statistics.paging.pageProcessFailures).to.equal(1);
-          expect(bridge.statistics.paging.pageProcessEnd).to.equal(0);
+          expect(bridge.statistics.paging).to.deep.equal({
+            pageReadSuccess: 0,
+            pageReadFailures: 0,
+            pageProcessSuccess: 0,
+            pageProcessFailures: 1,
+            pageProcessEnd: 0,
+            missingToken: 0
+          });
         });
 
         it('populates usage statistics', () => {
-          expect(bridge.statistics.usage.reportFailures).to.equal(1);
-          expect(bridge.statistics.usage.reportSuccess).to.equal(0);
-          expect(bridge.statistics.usage.reportConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopFailures).to.equal(1);
-          expect(bridge.statistics.usage.loopSuccess).to.equal(0);
-          expect(bridge.statistics.usage.loopConflict).to.equal(0);
-          expect(bridge.statistics.usage.loopSkip).to.equal(0);
+          expect(bridge.statistics.usage).to.deep.equal({
+            reportFailures: 1,
+            reportSuccess: 0,
+            reportBusinessError: 0,
+            reportConflict: 0,
+            loopFailures: 1,
+            loopSuccess: 0,
+            loopConflict: 0,
+            loopSkip: 0,
+            missingToken: 0
+          });
         });
 
-        it('populates carry-over statistics', () => {
-          expect(bridge.statistics.carryOver.getSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.getFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.removeSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.removeFailure).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertSuccess).to.equal(0);
-          expect(bridge.statistics.carryOver.upsertFailure).to.equal(0);
+        it('does not change carry-over statistics', () => {
+          expect(bridge.statistics.carryOver).to.deep.equal({
+            getSuccess: 0,
+            getFailure: 0,
+            removeSuccess: 0,
+            removeFailure: 0,
+            upsertSuccess: 0,
+            upsertFailure: 0
+          });
         });
       });
 
@@ -1604,7 +1959,7 @@ const tests = (secured) => {
         require.cache[require.resolve('abacus-request')].exports = reqmock;
         bridge = require('..');
 
-        bridge.errors.consecutiveFailures = 5;
+        bridge.errors.consecutiveReportFailures = 5;
       });
 
       it('noReportEverHappened should be false', (done) => {
@@ -1624,10 +1979,10 @@ const tests = (secured) => {
       });
 
       it('consecutiveFailures should be 0', (done) => {
-        expect(bridge.errors.consecutiveFailures).to.equal(5);
+        expect(bridge.errors.consecutiveReportFailures).to.equal(5);
         bridge.reportAppUsage(cfToken, abacusToken, {
           success: () => {
-            expect(bridge.errors.consecutiveFailures).to.equal(0);
+            expect(bridge.errors.consecutiveReportFailures).to.equal(0);
             expect(bridge.errors.lastError).to.equal('');
             expect(bridge.errors.lastErrorTimestamp).to.equal('');
             done();
@@ -1659,7 +2014,7 @@ const tests = (secured) => {
       });
 
       it('should increment consecutiveFailures', (done) => {
-        const currentFailures = bridge.errors.consecutiveFailures;
+        const currentFailures = bridge.errors.consecutiveReportFailures;
         const startTime = moment.now();
 
         bridge.reportAppUsage(cfToken, abacusToken, {
@@ -1667,7 +2022,7 @@ const tests = (secured) => {
             done(new Error(util.format('Unexpected call of success')));
           },
           failure: () => {
-            expect(bridge.errors.consecutiveFailures)
+            expect(bridge.errors.consecutiveReportFailures)
               .to.equal(currentFailures + 1);
             expect(bridge.errors.lastError).to.equal('Error reporting usage; ' +
               'error: "Failed to post report"; response: {}');

--- a/lib/cf/renewer/src/index.js
+++ b/lib/cf/renewer/src/index.js
@@ -65,6 +65,7 @@ const statistics = {
     getSuccess: 0,
     reportFailures: 0,
     reportSuccess: 0,
+    reportBusinessError: 0,
     reportConflict: 0
   },
   carryOver: {
@@ -206,38 +207,88 @@ const resourceUsageSchemaProperties = map(
 const sanitizeUsageDoc = (doc) => pick(doc,
   resourceUsageSchemaProperties);
 
-const reportUsage = (usage, token, cb) => {
+const processSuccessfulReport = (response, usage, t0, cb) => {
+  if (!response.headers || !response.headers.location) {
+    const message = util.format('No Location header found in ' +
+      'response %j for usage %j', response, usage);
+    edebug(message);
+    throw new Error(message);
+  }
+
+  debug('Successfully reported usage %j with headers %j',
+    usage, response.headers);
+  statistics.usage.reportSuccess++;
+  errors.noReportEverHappened = false;
+  errors.consecutiveReportFailures = 0;
+  perf.report('report', t0);
+
+  cb(undefined, response);
+};
+
+const processBusinessErrorReport = (response, usage, t0, cb) => {
+  statistics.usage.reportBusinessError++;
+  debug('Business error for usage %j. Response: %j', usage, response);
+  perf.report('report', t0, undefined, undefined, undefined, 'rejected');
+
+  if (response.statusCode === 409) {
+    statistics.usage.reportConflict++;
+    errors.noReportEverHappened = false;
+    cb(undefined, response);
+    return;
+  }
+
+  statistics.usage.reportFailures++;
+  cb(extend(new Error(), response.body), response);
+};
+
+const processFailedReport = (error, response, t0, cb) => {
+  statistics.usage.reportFailures++;
+  errors.consecutiveReportFailures++;
+
+  const message = util.format(
+    'Failed reporting usage. Consecutive failures: %d',
+    errors.consecutiveReportFailures
+  );
+  registerError(message, error, undefined, 'report', t0);
+
+  cb(error ? error : new Error(message), response);
+};
+
+const processReportError = (error, response, t0, cb) => {
+  statistics.usage.reportFailures++;
+  errors.consecutiveReportFailures++;
+
+  const message = util.format('Failed reporting usage. ' +
+    'Consecutive failures: %d', errors.consecutiveReportFailures);
+  registerError(message, error, undefined, 'report', t0);
+
+  cb(error, response);
+};
+
+const reportUsage = (usage, token, cb = () => {}) => {
   const t0 = moment.now();
   reliableRequest.post(':collector/v1/metering/collected/usage', {
     collector: uris().collector,
     headers: authHeader(token),
     body: usage
   }, (error, response) => {
-    if (!error && response) {
-      if (response.statusCode === 201) {
-        debug('Successfully reported usage %j with headers %j',
-          usage, response.headers);
-        statistics.usage.reportSuccess++;
-        errors.consecutiveReportFailures = 0;
-        errors.noReportEverHappened = false;
-        perf.report('report', t0);
-        cb(undefined, response);
-        return;
-      }
-      if (response.statusCode === 409) {
-        debug('Conflicting usage %j. Response: %j', usage, response);
-        statistics.usage.reportConflict++;
-        errors.noReportEverHappened = false;
-        perf.report('report', t0, undefined, undefined, undefined, 'rejected');
-        cb(undefined, response);
-        return;
-      }
+    // Error or no response
+    if (error || !response) {
+      processReportError(error, response, t0, cb);
+      return;
     }
-    statistics.usage.reportFailures++;
-    errors.consecutiveReportFailures++;
-    registerError(util.format('Failed reporting usage: %j', usage),
-      error, response, 'report', t0);
-    cb(error ? error : new Error('Failed reporting usage'), response);
+
+    // Business error
+    if (response.body && response.body.error) {
+      processBusinessErrorReport(response, usage, t0, cb);
+      return;
+    }
+
+    // Response
+    if (response.statusCode === 201)
+      processSuccessfulReport(response, usage, t0, cb);
+    else
+      processFailedReport(error, response, t0, cb);
   });
 };
 

--- a/lib/cf/renewer/src/test/api-test.js
+++ b/lib/cf/renewer/src/test/api-test.js
@@ -160,6 +160,7 @@ describe('Admin API', () => {
                 getFailures: 0,
                 reportFailures: 0,
                 reportSuccess: 0,
+                reportBusinessError: 0,
                 reportConflict: 0
               },
               carryOver: {

--- a/lib/cf/renewer/src/test/carry-over-test.js
+++ b/lib/cf/renewer/src/test/carry-over-test.js
@@ -153,7 +153,11 @@ const tests = (secured) => {
           cb(undefined, { statusCode: 200, body: appUsage });
         }),
         post: spy((uri, opts, cb) => {
-          cb(undefined, { statusCode: 201, body: {} });
+          cb(undefined, {
+            statusCode: 201,
+            headers: { location: 'some location' },
+            body: {}
+          });
         })
       });
       require.cache[require.resolve('abacus-request')].exports = reqmock;
@@ -202,7 +206,11 @@ const tests = (secured) => {
           });
         }),
         post: spy((uri, opts, cb) => {
-          cb(undefined, { statusCode: 201, body: {} });
+          cb(undefined, {
+            statusCode: 201,
+            headers: { location: 'some location' },
+            body: {}
+          });
         })
       });
       require.cache[require.resolve('abacus-request')].exports = reqmock;

--- a/lib/cf/renewer/src/test/report-usage-test.js
+++ b/lib/cf/renewer/src/test/report-usage-test.js
@@ -164,7 +164,11 @@ const tests = (secured) => {
     return extend({}, usage, { organization_id: guid });
   };
 
-  const getResponse = (code, body) => ({ statusCode: code, body: body });
+  const getResponse = (code, headers, body = {}) => ({
+    statusCode: code,
+    headers: headers,
+    body: body
+  });
 
   context('with usage in db', () => {
 
@@ -177,7 +181,11 @@ const tests = (secured) => {
             cb(undefined, { statusCode: 200, body: appUsage });
           }),
           post: spy((uri, opts, cb) => {
-            cb(null, { statusCode: 201, body: {} });
+            cb(null, {
+              statusCode: 201,
+              headers: { location: 'some location' },
+              body: {}
+            });
           })
         });
         require.cache[require.resolve('abacus-request')].exports = reqmock;
@@ -242,10 +250,10 @@ const tests = (secured) => {
         reqmock = extend({}, request, {
           get: spy((uri, opts, cb) => {
             cb(opts.usage_id === collectorIdToError ? 'error' : undefined,
-              getResponse(200, appUsage));
+              getResponse(200, {}, appUsage));
           }),
           post: spy((uri, opts, cb) => {
-            cb(undefined, getResponse(201, {}));
+            cb(undefined, getResponse(201, { location: 'some location' }));
           })
         });
         require.cache[require.resolve('abacus-request')].exports = reqmock;
@@ -272,8 +280,12 @@ const tests = (secured) => {
                 collector_id: collectorIdToError
               });
               expect(error.error).to.equal('error');
-              expect(error.response).to.deep.equal(getResponse(200, appUsage));
-              expect(response).to.deep.equal(getResponse(200, appUsage));
+              expect(error.response).to.deep.equal(
+                getResponse(200, {}, appUsage)
+              );
+              expect(response).to.deep.equal(
+                getResponse(200, {}, appUsage)
+              );
               done();
             },
             success: () => {
@@ -335,8 +347,12 @@ const tests = (secured) => {
                 collector_id: collectorIdToError
               });
               expect(error.error).to.equal('error');
-              expect(error.response).to.deep.equal(getResponse(200, appUsage));
-              expect(response).to.deep.equal(getResponse(200, appUsage));
+              expect(error.response).to.deep.equal(
+                getResponse(200, {}, appUsage)
+              );
+              expect(response).to.deep.equal(
+                getResponse(200, {}, appUsage)
+              );
               done();
             },
             success: () => {
@@ -437,13 +453,11 @@ const tests = (secured) => {
             cb(undefined,
               opts.usage_id === collectorIdToError ?
                 getResponse(errorResponseCode, {}) :
-                getResponse(200, appUsage));
+                getResponse(200, {}, appUsage));
           }),
           post: spy((uri, opts, cb) => {
-            cb(undefined, {
-              statusCode: 201,
-              body: changeOrgId(appUsage, opts.usage_id)
-            });
+            cb(undefined, getResponse(201,{ location: 'some location' },
+              changeOrgId(appUsage, opts.usage_id)));
           })
         });
         require.cache[require.resolve('abacus-request')].exports = reqmock;
@@ -631,7 +645,7 @@ const tests = (secured) => {
     });
 
     context('on error during reporting', () => {
-      const mockedResponse = { statusCode: 201, body: {} };
+      const mockedResponse = getResponse(201, { location: 'some location' });
 
       let numPostRequestToError;
       let renewer;
@@ -832,10 +846,10 @@ const tests = (secured) => {
     });
 
     context('on bad response during reporting', () => {
-      const getResponse = (code) => ({ statusCode: code });
       const startTime = moment.now();
 
       let errorResponseCode;
+      let errorResponseBody;
       let numPostRequestToError;
       let renewer;
 
@@ -851,9 +865,9 @@ const tests = (secured) => {
             });
           }),
           post: spy((uri, opts, cb) => {
-            cb(undefined,
-              ++numPostRequests === numPostRequestToError ?
-              getResponse(errorResponseCode) : getResponse(201));
+            cb(undefined, ++numPostRequests === numPostRequestToError ?
+              getResponse(errorResponseCode, {}, errorResponseBody) :
+              getResponse(201, { location: 'some location' }));
           })
         });
         require.cache[require.resolve('abacus-request')].exports = reqmock;
@@ -882,11 +896,9 @@ const tests = (secured) => {
               expect(error.op).to.equal('start report');
               expect(error.doc).not.to.equal(undefined);
               expect(error.error).not.to.equal(undefined);
-              expect(error.response).to.deep.equal(
-                getResponse(errorResponseCode)
-              );
+              expect(error.response).to.deep.equal(response);
               expect(response).to.deep.equal(
-                getResponse(errorResponseCode)
+                getResponse(errorResponseCode, {}, errorResponseBody)
               );
               done();
             },
@@ -946,11 +958,9 @@ const tests = (secured) => {
               expect(error.op).to.equal('start report');
               expect(error.doc).not.to.equal(undefined);
               expect(error.error).not.to.equal(undefined);
-              expect(error.response).to.deep.equal(
-                getResponse(errorResponseCode)
-              );
+              expect(error.response).to.deep.equal(response);
               expect(response).to.deep.equal(
-                getResponse(errorResponseCode)
+                getResponse(errorResponseCode, {}, errorResponseBody)
               );
               done();
             },
@@ -999,55 +1009,261 @@ const tests = (secured) => {
         });
       });
 
-      context('when 409 is returned', () => {
-        beforeEach((done) => {
-          numPostRequestToError = 2;
-          errorResponseCode = 409;
+      context('on business error', () => {
+        context('on 409 response code', () => {
+          beforeEach((done) => {
+            numPostRequestToError = 2;
+            errorResponseCode = 409;
+            errorResponseBody = {
+              error: 'conflict',
+              reason: 'Conflict. Please retry'
+            };
 
-          renewer = require('..');
-          renewer.renewUsage(systemToken, {
-            failure: (error, response) => {
-              renewer.stopRenewer();
-              done(new Error(util.format('Unexpected call of failure with ' +
-                'error %j and response %j', error, response)));
-            },
-            success: () => {
-              renewer.stopRenewer();
-              done();
-            }
+            renewer = require('..');
+            renewer.renewUsage(systemToken, {
+              failure: (error, response) => {
+                renewer.stopRenewer();
+                done(new Error(util.format('Unexpected call of failure with ' +
+                  'error %j and response %j', error, response)));
+              },
+              success: () => {
+                renewer.stopRenewer();
+                done();
+              }
+            });
+          });
+
+          it('gets the real usage from the COLLECTOR', () => {
+            const args = reqmock.get.args;
+            expect(args.length).to.equal(2);
+            checkGetRequest(args[0], '1');
+            checkGetRequest(args[1], '2');
+          });
+
+          it('reports refreshed usage to COLLECTOR', () => {
+            const args = reqmock.post.args;
+            expect(args.length).to.equal(2);
+            checkPostRequest(args[0],
+              changeOrgId(generateUsage(appUsage, 0, 'previous'), '1'));
+            checkPostRequest(args[1],
+              changeOrgId(generateUsage(appUsage, 0, 'previous'), '2'));
+          });
+
+          it('counts the outcome', () => {
+            expect(renewer.statistics.usage).to.deep.equal({
+              getSuccess: 2,
+              getFailures: 0,
+              reportSuccess: 1,
+              reportBusinessError: 1,
+              reportConflict: 1,
+              reportFailures: 0,
+              missingToken: 0
+            });
+          });
+
+          it('raises correct reporting errors', () => {
+            expect(renewer.errors.noGetEverHappened).to.equal(false);
+            expect(renewer.errors.noReportEverHappened).to.equal(false);
+
+            expect(renewer.errors.consecutiveGetFailures).to.equal(0);
+            expect(renewer.errors.consecutiveReportFailures).to.equal(0);
           });
         });
 
-        it('gets the real usage from the COLLECTOR', () => {
-          const args = reqmock.get.args;
-          expect(args.length).to.equal(2);
-          checkGetRequest(args[0], '1');
-          checkGetRequest(args[1], '2');
+        context('on 409 response code with noretry', () => {
+          beforeEach((done) => {
+            numPostRequestToError = 2;
+            errorResponseCode = 409;
+            errorResponseBody = {
+              error: 'conflict',
+              reason: 'Conflict! Do not retry',
+              noretry: true
+            };
+
+            renewer = require('..');
+            renewer.renewUsage(systemToken, {
+              failure: (error, response) => {
+                renewer.stopRenewer();
+                done(new Error(util.format('Unexpected call of failure with ' +
+                  'error %j and response %j', error, response)));
+              },
+              success: () => {
+                renewer.stopRenewer();
+                done();
+              }
+            });
+          });
+
+          it('gets the real usage from the COLLECTOR', () => {
+            const args = reqmock.get.args;
+            expect(args.length).to.equal(2);
+            checkGetRequest(args[0], '1');
+            checkGetRequest(args[1], '2');
+          });
+
+          it('reports refreshed usage to COLLECTOR', () => {
+            const args = reqmock.post.args;
+            expect(args.length).to.equal(2);
+            checkPostRequest(args[0],
+              changeOrgId(generateUsage(appUsage, 0, 'previous'), '1'));
+            checkPostRequest(args[1],
+              changeOrgId(generateUsage(appUsage, 0, 'previous'), '2'));
+          });
+
+          it('counts the outcome', () => {
+            expect(renewer.statistics.usage).to.deep.equal({
+              getSuccess: 2,
+              getFailures: 0,
+              reportSuccess: 1,
+              reportBusinessError: 1,
+              reportConflict: 1,
+              reportFailures: 0,
+              missingToken: 0
+            });
+          });
+
+          it('raises correct reporting errors', () => {
+            expect(renewer.errors.noGetEverHappened).to.equal(false);
+            expect(renewer.errors.noReportEverHappened).to.equal(false);
+
+            expect(renewer.errors.consecutiveGetFailures).to.equal(0);
+            expect(renewer.errors.consecutiveReportFailures).to.equal(0);
+          });
         });
 
-        it('reports refreshed usage to COLLECTOR', () => {
-          const args = reqmock.post.args;
-          expect(args.length).to.equal(2);
-          checkPostRequest(args[0],
-            changeOrgId(generateUsage(appUsage, 0, 'previous'), '1'));
-          checkPostRequest(args[1],
-            changeOrgId(generateUsage(appUsage, 0, 'previous'), '2'));
+        context('on 201 response code', () => {
+          beforeEach((done) => {
+            numPostRequestToError = 2;
+            errorResponseCode = 201;
+            errorResponseBody = {
+              error: 'emplannotfound',
+              reason: 'Metering plan for the metering plan id ' +
+              'complex-object-storage is not found'
+            };
+
+            renewer = require('..');
+            renewer.renewUsage(systemToken, {
+              failure: (error, response) => {
+                expect(error.op).to.equal('start report');
+                expect(error.doc).not.to.equal(undefined);
+                expect(error.error).not.to.equal(undefined);
+                expect(error.response).to.deep.equal(response);
+                expect(response).to.deep.equal(
+                  getResponse(errorResponseCode, {}, errorResponseBody)
+                );
+
+                renewer.stopRenewer();
+                done();
+              },
+              success: () => {
+                renewer.stopRenewer();
+                done(new Error('Unexpected call of success'));
+              }
+            });
+          });
+
+          it('gets the real usage from the COLLECTOR', () => {
+            const args = reqmock.get.args;
+            expect(args.length).to.equal(2);
+            checkGetRequest(args[0], '1');
+            checkGetRequest(args[1], '2');
+          });
+
+          it('reports refreshed usage to COLLECTOR', () => {
+            const args = reqmock.post.args;
+            expect(args.length).to.equal(2);
+            checkPostRequest(args[0],
+              changeOrgId(generateUsage(appUsage, 0, 'previous'), '1'));
+            checkPostRequest(args[1],
+              changeOrgId(generateUsage(appUsage, 0, 'previous'), '2'));
+          });
+
+          it('counts the outcome', () => {
+            expect(renewer.statistics.usage).to.deep.equal({
+              getSuccess: 2,
+              getFailures: 0,
+              reportSuccess: 1,
+              reportBusinessError: 1,
+              reportConflict: 0,
+              reportFailures: 1,
+              missingToken: 0
+            });
+          });
+
+          it('raises correct reporting errors', () => {
+            expect(renewer.errors.noGetEverHappened).to.equal(false);
+            expect(renewer.errors.noReportEverHappened).to.equal(false);
+
+            expect(renewer.errors.consecutiveGetFailures).to.equal(0);
+            expect(renewer.errors.consecutiveReportFailures).to.equal(0);
+          });
         });
 
-        it('counts the outcome', () => {
-          expect(renewer.statistics.usage.getSuccess).to.equal(2);
-          expect(renewer.statistics.usage.getFailures).to.equal(0);
-          expect(renewer.statistics.usage.reportSuccess).to.equal(1);
-          expect(renewer.statistics.usage.reportConflict).to.equal(1);
-          expect(renewer.statistics.usage.reportFailures).to.equal(0);
-        });
+        context('on 500 response code', () => {
+          beforeEach((done) => {
+            numPostRequestToError = 2;
+            errorResponseCode = 500;
+            errorResponseBody = {
+              error: 'internal',
+              reason: 'Network connectivity problem'
+            };
 
-        it('raises correct reporting errors', () => {
-          expect(renewer.errors.noGetEverHappened).to.equal(false);
-          expect(renewer.errors.noReportEverHappened).to.equal(false);
+            renewer = require('..');
+            renewer.renewUsage(systemToken, {
+              failure: (error, response) => {
+                expect(error.op).to.equal('start report');
+                expect(error.doc).not.to.equal(undefined);
+                expect(error.error).not.to.equal(undefined);
+                expect(error.response).to.deep.equal(response);
+                expect(response).to.deep.equal(
+                  getResponse(errorResponseCode, {}, errorResponseBody)
+                );
 
-          expect(renewer.errors.consecutiveGetFailures).to.equal(0);
-          expect(renewer.errors.consecutiveReportFailures).to.equal(0);
+                renewer.stopRenewer();
+                done();
+              },
+              success: () => {
+                renewer.stopRenewer();
+                done(new Error('Unexpected call of success'));
+              }
+            });
+          });
+
+          it('gets the real usage from the COLLECTOR', () => {
+            const args = reqmock.get.args;
+            expect(args.length).to.equal(2);
+            checkGetRequest(args[0], '1');
+            checkGetRequest(args[1], '2');
+          });
+
+          it('reports refreshed usage to COLLECTOR', () => {
+            const args = reqmock.post.args;
+            expect(args.length).to.equal(2);
+            checkPostRequest(args[0],
+              changeOrgId(generateUsage(appUsage, 0, 'previous'), '1'));
+            checkPostRequest(args[1],
+              changeOrgId(generateUsage(appUsage, 0, 'previous'), '2'));
+          });
+
+          it('counts the outcome', () => {
+            expect(renewer.statistics.usage).to.deep.equal({
+              getSuccess: 2,
+              getFailures: 0,
+              reportSuccess: 1,
+              reportBusinessError: 1,
+              reportConflict: 0,
+              reportFailures: 1,
+              missingToken: 0
+            });
+          });
+
+          it('raises correct reporting errors', () => {
+            expect(renewer.errors.noGetEverHappened).to.equal(false);
+            expect(renewer.errors.noReportEverHappened).to.equal(false);
+
+            expect(renewer.errors.consecutiveGetFailures).to.equal(0);
+            expect(renewer.errors.consecutiveReportFailures).to.equal(0);
+          });
         });
       });
 
@@ -1106,7 +1322,11 @@ const tests = (secured) => {
             cb(undefined, { statusCode: 200, body: appUsage });
           }),
           post: spy((uri, opts, cb) => {
-            cb(null, { statusCode: 201, body: {} });
+            cb(null, {
+              statusCode: 201,
+              headers: { location: 'some location' },
+              body: {}
+            });
           })
         });
         require.cache[require.resolve('abacus-request')].exports = reqmock;
@@ -1151,7 +1371,11 @@ const tests = (secured) => {
           cb(undefined, { statusCode: 200, body: appUsage });
         }),
         post: spy((uri, opts, cb) => {
-          cb(null, { statusCode: 201, body: {} });
+          cb(null, {
+            statusCode: 201,
+            headers: { location: 'some location' },
+            body: {}
+          });
         })
       });
       require.cache[require.resolve('abacus-request')].exports = reqmock;
@@ -1210,7 +1434,11 @@ const tests = (secured) => {
           cb(undefined, { statusCode: 200, body: appUsage });
         }),
         post: spy((uri, opts, cb) => {
-          cb(null, { statusCode: 201, body: {} });
+          cb(null, {
+            statusCode: 201,
+            headers: { location: 'some location' },
+            body: {}
+          });
         })
       });
       require.cache[require.resolve('abacus-request')].exports = reqmock;

--- a/lib/cf/renewer/src/test/retry-usage-test.js
+++ b/lib/cf/renewer/src/test/retry-usage-test.js
@@ -96,7 +96,11 @@ const tests = (secured) => {
     return extend({}, usage, { organization_id: 'us-south:' + guid });
   };
 
-  const okPostResponse = { statusCode: 201, body: {} };
+  const okPostResponse = {
+    statusCode: 201,
+    headers: { location: 'some location' },
+    body: {}
+  };
 
   beforeEach(() => {
     deleteModules();
@@ -199,6 +203,7 @@ const tests = (secured) => {
         getSuccess: 3,
         getFailures: 0,
         reportSuccess: 2,
+        reportBusinessError: 0,
         reportConflict: 0,
         reportFailures: 1
       });
@@ -248,6 +253,7 @@ const tests = (secured) => {
         getSuccess: 2,
         getFailures: 0,
         reportSuccess: 1,
+        reportBusinessError: 0,
         reportConflict: 0,
         reportFailures: 1
       });
@@ -314,6 +320,7 @@ const tests = (secured) => {
               getFailures: 0,
               getSuccess: 6,
               reportSuccess: 4,
+              reportBusinessError: 0,
               reportConflict: 0,
               reportFailures: 2
             });


### PR DESCRIPTION
When Bridge receives 201 response code it does not check for business error and continues submitting events. We should instead check for business error and fail. The failure would trigger the bridge retry mechanism.