### PR TITLE
Fix mongo and couch connection pooling issues

### DIFF
--- a/lib/utils/couchclient/src/index.js
+++ b/lib/utils/couchclient/src/index.js
@@ -10,6 +10,7 @@ const memdown = require('memdown');
 const moment = require('abacus-moment');
 const perf = require('abacus-perf');
 const url = require('url');
+const lock = require('abacus-lock');
 
 // Configure needed PouchDB functionality
 const PouchDB = require('pouchdb');
@@ -435,63 +436,54 @@ const couchclient = (part, uri, cons) => {
   });
 
   // Pool of memoized db partition handles
-  // Warning: partitions is a mutable variable, but that's the point of
-  // memoization anyway
-  let partitions = [];
+  let partitions = {};
 
-  const poolPartitionDB = (u, db, dbKey) => {
-    // do not pool in-memory DBs
-    if (findWhere([db.dbconsOptions], inMemoryOpt)) {
-      debug('DB handle for %s will not be pooled', puri(u));
-      return;
-    }
-
-    // Warning: mutating variable partitions
-    // Memoize the db handle with both the read mode and the
-    // requested read/write mode
-    partitions[[u, 'read'].join('-')] = db;
-    partitions[dbKey] = db;
-  };
-
-  const createDBHandle = (p, rw, cb) => {
-    const u = dbopt.uri(p);
-    debug('Using db %s in %s mode', puri(u), rw);
-
-    // Return memoized db partition handle or get and memoize a new one
-    // from the given db constructor. DB handles are keyed by db uri and
-    // read/write operating mode
-    const dbKey = [u, rw].join('-');
-    if (partitions[dbKey])
-      return cb(null, partitions[dbKey]);
-
-    debug('Constructing db handle for db %s in %s mode', puri(u), rw);
-    return dbopt.cons(u, {
-      // Skip db setup in read mode, as we don't need the db to be
-      // created if it doesn't exist
-      skip_setup: rw === 'read'
-    }, (err, db) => {
-      if(err) {
-        cb(null, errdb('dbcons-err-' + u, err));
-        return;
-      }
-      poolPartitionDB(u, db, dbKey);
-
-      cb(null, db);
-    });
-  };
-
+  // Get pooled db partition handle(s)
   const pool = (p, rw, cb) => {
-    // Convert db partition to a db name
-    if(Array.isArray(p[0])) {
-      transform.map(p, (v, i, p, mapCb) => {
-        createDBHandle(v, rw, mapCb);
-      }, (err, res) => {
-        cb(err, res);
-      });
-      return;
-    }
 
-    createDBHandle(p, rw, cb);
+    // Get a pooled db partition handle for a single partition
+    const pooldb = (p, rw, cb) => {
+      const u = dbopt.uri(p);
+      debug('Using db %s in %s mode', puri(u), rw);
+
+      // Return a memoized db partition handle or get and memoize a new one
+      // from the given db constructor. DB handles are keyed by db uri and
+      // read/write operating mode
+      const dbkey = [u, rw].join('-');
+      lock(dbkey, (err, unlock) => {
+        if (partitions[dbkey])
+          return unlock(cb(null, partitions[dbkey]));
+
+        const options = {
+          // Skip db setup in read mode, as we don't need the db to be
+          // created if it doesn't exist
+          skip_setup: rw === 'read'
+        };
+        debug('Constructing db handle for db %s in %s mode', puri(u), rw);
+        return dbopt.cons(u, options, (err, db) => {
+          if (err)
+            return unlock(cb(null, errdb('dbcons-err-' + u, err)));
+
+          // Do not pool in-memory DBs
+          if (findWhere([db.dbconsOptions], inMemoryOpt)) {
+            debug('In-memory db handle for db %s not pooled', puri(u));
+            return unlock(cb(null, db));
+          }
+
+          // Memoize the db handle with both the read mode and the
+          // requested read/write mode
+          partitions[[u, 'read'].join('-')] = db;
+          partitions[dbkey] = db;
+
+          return unlock(cb(null, db));
+        });
+      });
+    };
+
+    if(Array.isArray(p[0]))
+      transform.map(p, (v, i, p, mcb) => pooldb(v, rw, mcb), cb);
+    else
+      pooldb(p, rw, cb);
   };
 
   return {

--- a/lib/utils/mongoclient/src/index.js
+++ b/lib/utils/mongoclient/src/index.js
@@ -11,6 +11,7 @@ const perf = require('abacus-perf');
 const mongoDB = require('mongodb').MongoClient;
 const url = require('url');
 const moment = require('abacus-moment');
+const lock = require('abacus-lock');
 
 const defaults = _.defaults;
 const each = _.each;
@@ -516,66 +517,39 @@ const mongoclient = (part, uri, cons) => {
   });
 
   // Pool of memoized db partition handles
-  // Warning: partitions is a mutable variable, but that's the point of
-  // memoization anyway
-  let partitions = [];
+  let partitions = {};
+
+  // Get pooled db partition handle(s)
   const pool = (p, rw, cb) => {
-    // Convert db partition to a db name
-    if(Array.isArray(p[0]))
-      return transform.map(p, (v, i, p, mcb) => {
-        const u = dbopt.uri(v);
-        debug('Using db %s in %s mode', puri(u), rw);
 
-        // Return memoized db partition handle or get and memoize a new one
-        // from the given db constructor. DB handles are keyed by db uri and
-        // read/write operating mode
-        const dbk = [u, rw].join('-');
-        if (partitions[dbk])
-          return mcb(null, partitions[dbk]);
+    // Get a pooled db partition handle for a single partition
+    const pooldb = (p, cb) => {
+      const u = dbopt.uri(p);
+      debug('Using db %s', puri(u));
 
-        debug('Constructing db handle for db %s in %s mode', puri(u), rw);
+      // Return a memoized db partition handle or get and memoize a new one
+      // from the given db constructor
+      lock(u, (err, unlock) => {
+        if (partitions[u])
+          return unlock(cb(null, partitions[u]));
+
+        debug('Constructing db handle for db %s', puri(u));
         return dbopt.cons(u, {}, (err, db) => {
-          if(err) {
-            mcb(null, errdb('dbcons-err-' + u, err));
-            return;
-          }
+          if (err)
+            return unlock(cb(null, errdb('dbcons-err-' + u, err)));
 
-          // Warning: mutating variable partitions
-          // Memoize the db handle with both the read mode and the
-          // requested read/write mode
-          partitions[[u, 'read'].join('-')] = db;
-          partitions[dbk] = db;
+          // Memoize the db handle
+          partitions[u] = db;
 
-          mcb(null, db);
+          return unlock(cb(null, db));
         });
-      }, (err, res) => {
-        cb(err, res);
       });
-    const u = dbopt.uri(p);
-    debug('Using db %s in %s mode', puri(u), rw);
-
-    // Return memoized db partition handle or get and memoize a new one
-    // from the given db constructor. DB handles are keyed by db uri and
-    // read/write operating mode
-    const dbk = [u, rw].join('-');
-    if (partitions[dbk])
-      return cb(null, partitions[dbk]);
-
-    debug('Constructing db handle for db %s in %s mode', puri(u), rw);
-    return dbopt.cons(u, {}, (err, db) => {
-      if(err) {
-        cb(null, errdb('dbcons-err-' + u, err));
-        return;
-      }
-
-      // Warning: mutating variable partitions
-      // Memoize the db handle with both the read mode and the
-      // requested read/write mode
-      partitions[[u, 'read'].join('-')] = db;
-      partitions[dbk] = db;
-
-      cb(null, db);
-    });
+    };
+  
+    if(Array.isArray(p[0]))
+      transform.map(p, (v, i, p, mcb) => pooldb(v, mcb), cb);
+    else
+      pooldb(p, cb);
   };
 
   return {

--- a/lib/utils/mongoclient/src/test/test.js
+++ b/lib/utils/mongoclient/src/test/test.js
@@ -2094,7 +2094,7 @@ describe('abacus-mongoclient', () => {
       dbclient.dburi(dbserver(), 'abacus-mongoclient-test-document-order')));
 
     const time = 1455005971858;
-    const numberOfDocuments = 100;
+    const numberOfDocuments = 1000;
     const getKey = (counter) => {
       return dbclient.kturi('document' + counter, time + counter);
     };


### PR DESCRIPTION
Connection pooling in both couch and mongo clients was broken when multiple parallel operations (e.g. during a batch op) attempted to get the same connection from an initially empty pool. Instead of creating just one connection per partition and then caching and reusing it, as many connections were created as there were parallel operations started, even for the same partition. This resulted in crashing mongo during the execution of unit tests in some cases due to reaching the max number of connections.

This issue is now fixed by adding locking to ensure that the initial creation of each connection happens only once. In addition, the code in both clients is refactored to remove code duplication in the `pool` function, to comply with existing naming conventions, and to ensure that the similarity between both clients is preserved as much as possible. For mongo, pooling by read / write mode is removed as it doesn't seem to be needed.