### PR TITLE
Move authorization before searching db in Reporting

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -2195,7 +2195,7 @@ The _resource instance usage summary report_ API can be used to retrieve aggrega
 ### Method: get
 _HTTP request_:
 ```
-GET /v1/metering/organizations/:organization_id/resource_instances/:resource_instance_id/consumers/:consumer_id/plans/:plan_id/metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/pricing_plans/:pricing_plan_id/t/:t/aggregated/usage/:time
+GET /v1/metering/organizations/:organization_id/spaces/:space_id/resource_id/:resource_id/resource_instances/:resource_instance_id/consumers/:consumer_id/plans/:plan_id/metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/pricing_plans/:pricing_plan_id/t/:t/aggregated/usage/:time
 ```
 
 _Description_: Retrieves a usage report document containing a summary of the aggregated Cloud resource usage incurred by the specified resource instance within an organization and the specific set of plans at the specified time.

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -542,8 +542,9 @@ const orgsUsage = function *(orgids, time, auth) {
 
 // Return the usage for a resource instance for a particular plan in a given
 // organization, consumer, time period
-const resourceInstanceUsage = function *(orgid, spaceid, resid, conid, planid,
-  mplanid, rplanid, pplanid, t, time, auth) {
+const resourceInstanceUsage = function *(orgid, spaceid, resourceInstanceId,
+  consumerId, planid, meteringPlanId, ratingPlanId, pricingPlanId,
+  timeBasedKeySegment, time, auth) {
   // Forward authorization header field to account to authorize
   const o = auth ? { headers: { authorization: auth } } : {};
 
@@ -563,13 +564,18 @@ const resourceInstanceUsage = function *(orgid, spaceid, resid, conid, planid,
     throw res;
   }
 
-  const id = ['k', orgid, resid, conid, planid, mplanid, rplanid, pplanid, 't',
-    t].join('/');
+  const id = ['k', orgid, resourceInstanceId, consumerId, planid,
+    meteringPlanId, ratingPlanId, pricingPlanId,
+    't', timeBasedKeySegment].join('/');
+
+
+  debug('Adiii %s', id);
 
   const doc = yield accumulatordb.get(id);
 
   if(!doc) {
-    debug('No resource instance usage found for %s on %s', resid, time);
+    debug('No resource instance usage found for %s on %s',
+      resourceInstanceId, time);
 
     // Return an empty usage report if no usage was found
     return {};
@@ -751,14 +757,14 @@ const runQuery = function *(query) {
 };
 
 // Return OAuth system scopes needed to retrieve org usage
-const sysScopes = (doc) => secured() ? {
+const sysScopes = () => secured() ? {
   system: ['abacus.usage.read']
 } : undefined;
 
 // Return OAuth resource or system scopes needed to retrieve resource instance
 // usage
-const scopes = (doc) => secured() ? {
-  resource: [['abacus.usage', doc.resource_id, 'read'].join('.')],
+const scopes = (resourceId) => secured() ? {
+  resource: [['abacus.usage', resourceId, 'read'].join('.')],
   system: ['abacus.usage.read']
 } : undefined;
 
@@ -767,13 +773,13 @@ const retrieveUsage = function *(req) {
   debug('Retrieving rated usage for organization %s on %s',
     req.params.organization_id, req.params.time);
 
+  if (secured())
+    oauth.authorize(req.headers && req.headers.authorization, sysScopes());
+
   // Retrieve and return the rated usage for the given org and time
   const doc = yield orgUsage(req.params.organization_id,
     req.params.time ? parseInt(req.params.time) : undefined,
     req.headers && req.headers.authorization);
-
-  if (secured())
-    oauth.authorize(req.headers && req.headers.authorization, sysScopes(doc));
 
   return {
     body: omit(dbclient.undbify(doc),
@@ -784,11 +790,15 @@ const retrieveUsage = function *(req) {
 };
 
 // Retrieve a usage report summary for a resource instance given the
-// org, resource instance, consumer, plan, metering plan,
-// rating plan, pricing plan, time
+// org, space, resource instance, consumer, plan, metering plan,
+// rating plan, pricing plan, t, time
 const retrieveResourceInstanceUsage = function *(req) {
   debug('Retrieving rated usage for resource instance %s on %s',
     req.params.resource_instance_id, req.params.time);
+
+  if (secured())
+    oauth.authorize(req.headers && req.headers.authorization,
+      scopes(req.params.resource_id));
 
   const doc = yield resourceInstanceUsage(req.params.organization_id,
     req.params.space_id, req.params.resource_instance_id,
@@ -796,9 +806,6 @@ const retrieveResourceInstanceUsage = function *(req) {
     req.params.rating_plan_id, req.params.pricing_plan_id, req.params.t,
     req.params.time ? parseInt(req.params.time) : undefined,
     req.headers && req.headers.authorization);
-
-  if (secured())
-    oauth.authorize(req.headers && req.headers.authorization, scopes(doc));
 
   return {
     body: omit(dbclient.undbify(doc),
@@ -820,9 +827,10 @@ routes.get(
 
 routes.get(
   '/v1/metering/organizations/:organization_id/spaces/:space_id/' +
-  'resource_instances/:resource_instance_id/consumers/:consumer_id/plans/' +
-  ':plan_id/metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/' +
-  'pricing_plans/:pricing_plan_id/t/:t/aggregated/usage/:time',
+  'resource_id/:resource_id/resource_instances/:resource_instance_id/' +
+  'consumers/:consumer_id/plans/:plan_id/metering_plans/:metering_plan_id/' +
+  'rating_plans/:rating_plan_id/pricing_plans/:pricing_plan_id/' +
+  't/:t/aggregated/usage/:time',
   throttle(retrieveResourceInstanceUsage));
 
 // Retrieve a usage summary using a GraphQL query
@@ -830,6 +838,9 @@ routes.get(
   '/v1/metering/aggregated/usage/graph/:query', throttle(function *(req) {
     debug(
       'Retrieving rated usage using graphql query %s', req.params.query);
+
+    if (secured())
+      oauth.authorize(req.headers && req.headers.authorization, sysScopes());
 
     const q = req.headers && req.headers.authorization ?
       req.params.query.replace(/(.*)\((.*)/,
@@ -852,9 +863,6 @@ routes.get(
           nobreaker: true
         });
     }
-
-    if (secured())
-      oauth.authorize(req.headers && req.headers.authorization, sysScopes(doc));
 
     return {
       body: omit(dbclient.undbify(doc.data),

--- a/lib/aggregation/reporting/src/test/test.js
+++ b/lib/aggregation/reporting/src/test/test.js
@@ -17,6 +17,8 @@ const extend = _.extend;
 
 const brequest = batch(request);
 
+const testResourceId = 'test-resource-id';
+
 /* eslint quotes: 1 */
 
 // Configure test db URL prefix
@@ -167,7 +169,7 @@ const ratedConsumerTemplate = (orgid, start, end, plan, a, p,
       end: end,
       processed: processed,
       resources: [{
-        resource_id: 'test-resource',
+        resource_id: testResourceId,
         aggregated_usage: a,
         plans: p
       }]
@@ -181,7 +183,7 @@ const consumerReferenceTemplate = (orgid, sid, plan, processed, conid) => ({
 const buildSpaceUsage = (a, p, c) => [{
   space_id: sid,
   resources: [{
-    resource_id: 'test-resource',
+    resource_id: testResourceId,
     aggregated_usage: a,
     plans: p
   }],
@@ -189,7 +191,7 @@ const buildSpaceUsage = (a, p, c) => [{
 }];
 
 const buildResourceUsage = (a, p) => [{
-  resource_id: 'test-resource',
+  resource_id: testResourceId,
   aggregated_usage: a,
   plans: p
 }];
@@ -202,7 +204,7 @@ const ratedTemplate = (id, orgid, start, end, processed, a, p, c) => ({
   consumer_id: 'cid',
   start: start,
   end: end,
-  resource_id: 'test-resource',
+  resource_id: testResourceId,
   plan_id: 'basic/test-metering-plan/' +
     'test-rating-plan/test-pricing-basic',
   pricing_country: 'USA',
@@ -225,7 +227,7 @@ const consumerReportTemplate = (plan, a, p, planWindow) => ({
   consumer_id: cid(plan),
   windows: planWindow,
   resources: [{
-    resource_id: 'test-resource',
+    resource_id: testResourceId,
     windows: planWindow,
     aggregated_usage: a,
     plans: p
@@ -236,7 +238,7 @@ const spaceReportTemplate = (tw, au, plans, consumers) => [{
   space_id: sid,
   windows: tw,
   resources: [{
-    resource_id: 'test-resource',
+    resource_id: testResourceId,
     windows: tw,
     aggregated_usage: au,
     plans: plans
@@ -253,7 +255,7 @@ const reportTemplate = (id, tw, au, plans, consumers) => ({
   processed: 1420502500000,
   windows: tw,
   resources: [{
-    resource_id: 'test-resource',
+    resource_id: testResourceId,
     windows: tw,
     aggregated_usage: au,
     plans: plans
@@ -280,7 +282,7 @@ const accumulatedTemplate = (oid, acc) => extend(planTemplate(), {
   id: accid(oid, rid),
   organization_id: oid,
   space_id: sid,
-  resource_id: 'test-resource',
+  resource_id: testResourceId,
   consumer_id: 'UNKNOWN',
   resource_instance_id: rid,
   start: 1446415200000,
@@ -484,7 +486,7 @@ describe('abacus-usage-report', () => {
           windows: buildWindow(undefined, undefined, undefined, undefined,
             undefined, 607.05852),
           resources: [{
-            resource_id: 'test-resource',
+            resource_id: testResourceId,
             aggregated_usage: buildAggregatedUsage(undefined, undefined,
               undefined, undefined, undefined, 11, 11, 585, undefined,
               undefined, 0.05852, undefined, undefined, true)
@@ -538,7 +540,7 @@ describe('abacus-usage-report', () => {
           windows: buildWindow(undefined, undefined, undefined, undefined,
             undefined, 607.05852),
           resources: [{
-            resource_id: 'test-resource',
+            resource_id: testResourceId,
             aggregated_usage: buildAggregatedUsage(undefined, undefined,
               undefined, undefined, undefined, 11, 11, 585, undefined,
               undefined, 0.05852, undefined, undefined, true)
@@ -629,7 +631,7 @@ describe('abacus-usage-report', () => {
         resource_instance_id: rid,
         resources: [
           {
-            resource_id: 'test-resource',
+            resource_id: testResourceId,
             plans: [
               {
                 plan_id: 'basic/test-metering-plan/' +
@@ -800,7 +802,7 @@ describe('abacus-usage-report', () => {
             space_id: '582018c9-e396-4f59-9945-b1bd579a819b',
             resources: [
               {
-                resource_id: 'test-resource',
+                resource_id: testResourceId,
                 plans: [
                   {
                     plan_id: 'basic/test-metering-plan/' +
@@ -985,7 +987,7 @@ describe('abacus-usage-report', () => {
             space_id: 'c228ecc8-15eb-446f-a4e6-a2d05a729b98',
             resources: [
               {
-                resource_id: 'test-resource',
+                resource_id: testResourceId,
                 plans: [
                   {
                     plan_id: 'basic/test-metering-plan/' +
@@ -1170,7 +1172,7 @@ describe('abacus-usage-report', () => {
             space_id: '69d4d85b-03f7-436e-b293-94d1803b42bf',
             resources: [
               {
-                resource_id: 'test-resource',
+                resource_id: testResourceId,
                 plans: [
                   {
                     plan_id: 'basic/test-metering-plan/' +
@@ -1339,7 +1341,7 @@ describe('abacus-usage-report', () => {
             space_id: '4ef2f706-f2ae-4be5-a18c-40a969cf8fb6',
             resources: [
               {
-                resource_id: 'test-resource',
+                resource_id: testResourceId,
                 plans: [
                   {
                     plan_id: 'basic/test-metering-plan/' +
@@ -1522,7 +1524,7 @@ describe('abacus-usage-report', () => {
             space_id: 'eac5125c-74ff-4984-9ba6-2eea7158490f',
             resources: [
               {
-                resource_id: 'test-resource',
+                resource_id: testResourceId,
                 plans: [
                   {
                     plan_id: 'basic/test-metering-plan/' +
@@ -1680,7 +1682,7 @@ describe('abacus-usage-report', () => {
         end: 1448457443000,
         resources: [
           {
-            resource_id: 'test-resource',
+            resource_id: testResourceId,
             plans: [
               {
                 plan_id: 'basic/test-metering-plan/' +
@@ -1871,7 +1873,7 @@ describe('abacus-usage-report', () => {
         end: 1448457443000,
         resources: [
           {
-            resource_id: 'test-resource',
+            resource_id: testResourceId,
             plans: [
               {
                 plan_id: 'basic/test-metering-plan/' +
@@ -2061,7 +2063,7 @@ describe('abacus-usage-report', () => {
         end: 1448457443000,
         resources: [
           {
-            resource_id: 'test-resource',
+            resource_id: testResourceId,
             plans: [
               {
                 plan_id: 'basic/test-metering-plan/' +
@@ -2219,7 +2221,7 @@ describe('abacus-usage-report', () => {
         end: 1448457443000,
         resources: [
           {
-            resource_id: 'test-resource',
+            resource_id: testResourceId,
             plans: [
               {
                 plan_id: 'basic/test-metering-plan/' +
@@ -2403,7 +2405,7 @@ describe('abacus-usage-report', () => {
         consumer_id: 'UNKNOWN',
         resources: [
           {
-            resource_id: 'test-resource',
+            resource_id: testResourceId,
             plans: [
               {
                 plan_id: 'basic/test-metering-plan/' +
@@ -2755,7 +2757,6 @@ describe('abacus-usage-report', () => {
       const accumulated = accumulatedTemplate(oid, buildAccumulatedUsage(
         { current: 1 }, { current: 1 }, { current: 100 }, 1, 0.03, 15,
         undefined, true, undefined));
-
       storeAccumulatedUsage(accumulated, done);
     });
 
@@ -2772,7 +2773,7 @@ describe('abacus-usage-report', () => {
           end: 1446415200000,
           processed: 1446418800000,
           start: 1446415200000,
-          resource_id: 'test-resource',
+          resource_id: testResourceId,
           space_id: sid,
           organization_id: oid,
           consumer_id: 'UNKNOWN',
@@ -2796,12 +2797,14 @@ describe('abacus-usage-report', () => {
         // Get the accumulated usage
         request.get(
           'http://localhost::p/v1/metering/organizations/:organization_id/' +
-          'spaces/:space_id/resource_instances/:resource_instance_id/' +
-          'consumers/:consumer_id/plans/:plan_id/metering_plans/' +
-          ':metering_plan_id/rating_plans/:rating_plan_id/' +
+          'spaces/:space_id/resource_id/:resource_id/' +
+          'resource_instances/:resource_instance_id/' +
+          'consumers/:consumer_id/plans/:plan_id/' +
+          'metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/' +
           'pricing_plans/:pricing_plan_id/t/:t/aggregated/usage/:time', {
             p: server.address().port,
             organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf27',
+            resource_id: testResourceId,
             resource_instance_id: '0b39fa70-a65f-4183-bae8-385633ca5c87',
             consumer_id: 'UNKNOWN',
             plan_id: 'basic',
@@ -2895,7 +2898,7 @@ describe('abacus-usage-report', () => {
           'test-pricing-basic/t/0001456185600000',
         organization_id: 'org',
         space_id: 'spa',
-        resource_id: 'test-resource',
+        resource_id: testResourceId,
         consumer_id: 'con',
         resource_instance_id: 'ins',
         plan_id: 'basic',
@@ -3014,6 +3017,7 @@ const orgUsagePath =
 
 const resInstanceUsagePath =
   '/v1/metering/organizations/:organization_id/spaces/:space_id/' +
+  'resource_id/:resource_id/' +
   'resource_instances/:resource_instance_id/consumers/:consumer_id/plans/' +
   ':plan_id/metering_plans/:metering_plan_id/rating_plans/:rating_plan_id/' +
   'pricing_plans/:pricing_plan_id/t/:t/aggregated/usage/:time';
@@ -3032,6 +3036,7 @@ const resInstanceUsageParams = {
   organization_id: oid2,
   space_id: sid,
   resource_instance_id: rid,
+  resource_id: testResourceId,
   consumer_id: 'UNKNOWN',
   plan_id: 'basic',
   metering_plan_id: 'test-metering-plan',
@@ -3169,7 +3174,7 @@ describe('abacus-usage-report-auth', () => {
 
   context('with a valid token that has a correct resource scope', () => {
     const signedToken = jwt.sign(extend(tokenPayload,
-      { scope: ['abacus.usage.test-resource.read'] }),
+      { scope: [`abacus.usage.${testResourceId}.read`] }),
       tokenSecret, { expiresIn: 43200 });
     const headers = {
       headers: {


### PR DESCRIPTION
fixes #545
[delivers #140227121]

In order to check the authorization scope before we start searching the db and avoid DOS attacks against Abacus using an invalid token we are adding one additional parameter to Resource instance usage summary report - resource_id
