### PR TITLE
Configure DB aliases and use multiple mongo DBs

### DIFF
--- a/etc/concourse/deploy-pipeline-vars.yml
+++ b/etc/concourse/deploy-pipeline-vars.yml
@@ -48,9 +48,35 @@ purge-app-usage-events: false
 # Note: Not used if create-db-service is false, but still required
 db-service-name: service-name
 
-# DB service plan
+# DB service instances
 # Note: Not used if create-db-service is false, but still required
-db-plan-name: plan-name
+db-service-instances:
+  - name: service-instance-name
+    plan: plan-name
+
+# Collector DB alias, used to identify DB service instances that belong to the collector group
+# Note: Not used if bind-db-service is false, but still required
+db-collector: db-collector
+
+# Meter DB alias, used to identify DB service instances that belong to the meter group
+# Note: Not used if bind-db-service is false, but still required
+db-meter: db-meter
+
+# Accumlator DB alias, used to identify DB service instances that belong to the accumulator group
+# Note: Not used if bind-db-service is false, but still required
+db-accumulator: db-accumulator
+
+# Aggregator DB alias, used to identify DB service instances that belong to the aggregator group
+# Note: Not used if bind-db-service is false, but still required
+db-aggregator: db-aggregator
+
+# Bridge DB alias, used to identify DB service instances that belong to the bridge / renewer group
+# Note: Not used if bind-db-service is false, but still required
+db-bridge: db-bridge
+
+# Plugins DB alias, used to identify DB service instances that belong to the plugins group
+# Note: Not used if bind-db-service is false, but still required
+db-plugins: db-plugins
 
 # Enable the service plan. Change this to "true" if the plan is paid for instance
 # Note: Not used if create-db-service is false, but still required

--- a/etc/concourse/deploy-pipeline.yml
+++ b/etc/concourse/deploy-pipeline.yml
@@ -39,7 +39,13 @@ jobs:
             CF_DOMAIN: {{cf-domain}}
             CREATE_DB_SERVICE: {{create-db-service}}
             DB_SERVICE_NAME: {{db-service-name}}
-            DB_PLAN_NAME: {{db-plan-name}}
+            DB_SERVICE_INSTANCES: {{db-service-instances}}
+            DB_COLLECTOR: {{db-collector}}
+            DB_METER: {{db-meter}}
+            DB_ACCUMULATOR: {{db-accumulator}}
+            DB_AGGREGATOR: {{db-aggregator}}
+            DB_BRIDGE: {{db-bridge}}
+            DB_PLUGINS: {{db-plugins}}
             ENABLE_SERVICE_ACCESS: {{enable-service-access}}
             UAA_ADMIN: {{uaa-admin}}
             UAA_SECRET: {{uaa-secret}}

--- a/etc/concourse/scripts/cf-deploy-infra
+++ b/etc/concourse/scripts/cf-deploy-infra
@@ -2,18 +2,11 @@
 
 set -e -x
 
-SCRIPT_DIR="${BASH_SOURCE%/*}"
-
 echo "Environment:"
 env | sort
 
 SCRIPT_DIR="${BASH_SOURCE%/*}"
 source $SCRIPT_DIR/common-functions
-
-#
-# Get platform info
-#
-unamestr=`uname`
 
 if [ "$SKIP_SSL_VALIDATION" == "true" ]; then
   skip='--skip-ssl-validation'
@@ -26,8 +19,8 @@ cf api $skip "https://api.$CF_API"
 echo "" | cf login $skip -u "$CF_ADMIN_USER" -p "$CF_ADMIN_PASSWORD"
 
 echo "Recreating organization and space ..."
-cf create-quota "$CF_ORG" -m 80g -i 4g -r 80 -s 2 --allow-paid-service-plans
-cf update-quota "$CF_ORG" -m 80g -i 4g -r 80 -s 2 --allow-paid-service-plans
+cf create-quota "$CF_ORG" -m 80g -i 4g -r 80 -s 10 --allow-paid-service-plans
+cf update-quota "$CF_ORG" -m 80g -i 4g -r 80 -s 10 --allow-paid-service-plans
 cf create-org "$CF_ORG" -q "$CF_ORG"
 cf create-space "$CF_SPACE" -o "$CF_ORG"
 if [ "$ENABLE_SERVICE_ACCESS" == "true" ]; then
@@ -48,33 +41,13 @@ echo "Logging to $CF_API as abacus user ..."
 cf login $skip -a "https://api.$CF_API" -u "$CF_USER" -p "$CF_PASSWORD" -o "$CF_ORG" -s "$CF_SPACE"
 
 if [ "$CREATE_DB_SERVICE" == "true" ]; then
-  echo "Creating new DB service instance ..."
-  cf create-service "$DB_SERVICE_NAME" "$DB_PLAN_NAME" db
-  until cf service db | grep -q 'Status: \(create\|update\) succeeded\|Status: \(create\|update\) failed\|Service instance .* not found'
-  do
-    sleep 3s
-  done
-  service_creation_status=$(cf service db)
-  if grep -q 'Status: \(create\|update\) succeeded' <<< $service_creation_status ; then
-    echo "DB creation finished successfully."
-  else
-    echo "DB creation failed!"
-    exit 1
-  fi
-
-  echo "Updating DB service instance ..."
-  cf update-service db -p "$DB_PLAN_NAME"
-  until cf service db | grep -q 'Status: \(create\|update\) succeeded\|Status: \(create\|update\) failed\|Service instance .* not found'
-  do
-    sleep 3s
-  done
-  service_creation_status=$(cf service db)
-  if grep -q 'Status: \(create\|update\) succeeded' <<< $service_creation_status ; then
-    echo "DB update finished successfully."
-  else
-    echo "DB update failed!"
-    exit 1
-  fi
+  echo "Creating or updating DB service instances ..."
+  instances=($DB_SERVICE_INSTANCES)
+  for instance in "${instances[@]}"; do
+    args=(${instance//:/ })
+    createOrUpdateService ${args[0]} ${args[1]} &
+  done;
+  waitForServices ${#instances[@]}
 else
   echo "Using DB URL provided in abacus-config !"
 fi

--- a/etc/concourse/scripts/cf-deploy-stage
+++ b/etc/concourse/scripts/cf-deploy-stage
@@ -5,48 +5,14 @@ set -e -x
 echo "Environment:"
 env | sort
 
-#
-# Get platform info
-#
-unamestr=`uname`
-
-function mapRoutes {
-  if [ -z "$1" ]; then
-     echo "Cannot map app without a name !"
-     exit 1
-  fi
-  if [ -z "$2" ]; then
-    echo "Unknown number of instances !"
-    exit 1
-  fi
-
-  local APP_NAME=$1
-  local INSTANCES=$(expr $2 - 1)
-
-  set +e # Disable error checks
-  cf app ${ABACUS_PREFIX}abacus-usage-collector
-  single_app=$?
-  set -e # Enable error checks
-
-  if [ $single_app = 0 ]; then
-    echo "Found single $APP_NAME instance. Will not map route !!!"
-  else
-    echo "Mapping $2 (0-$INSTANCES) instances of $APP_NAME in $CF_DOMAIN domain ..."
-    for i in `seq 0 $INSTANCES`;
-    do
-      cf map-route "$APP_NAME-$i" $CF_DOMAIN --hostname "$APP_NAME"
-    done
-  fi
-}
-
 SCRIPT_DIR="${BASH_SOURCE%/*}"
 source $SCRIPT_DIR/common-functions
 
-echo "Logging to $CF_API ..."
 if [ "$SKIP_SSL_VALIDATION" == "true" ]; then
   skip='--skip-ssl-validation'
 fi
 
+echo "Logging to $CF_API ..."
 cf login -a https://api.$CF_API -u $CF_USER -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE $skip
 
 echo "Pushing $ABACUS_PROFILE Abacus installation ..."
@@ -58,13 +24,14 @@ echo "Mapping routes ..."
 mapRoutes ${ABACUS_PREFIX}abacus-usage-collector 6
 mapRoutes ${ABACUS_PREFIX}abacus-usage-reporting 6
 
-getApps
-
 if [ "$BIND_DB_SERVICE" == "true" ]; then
   echo "Binding services ..."
-  if [[ "$unamestr" == 'Linux' ]]; then
-    echo ${APPS[@]} | xargs -n1 | xargs -P 5 -i cf bind-service {} db
-  else
-    echo ${APPS[@]} | xargs -n1 | xargs -P 5 -n 1 -J {} cf bind-service {} db
-  fi
+  getApps
+  bindService abacus-usage-collector $DB_COLLECTOR
+  bindService abacus-usage-meter $DB_METER
+  bindService abacus-usage-accumulator $DB_ACCUMULATOR
+  bindService abacus-usage-aggregator $DB_AGGREGATOR
+  bindService abacus-usage-reporting $DB_AGGREGATOR,$DB_ACCUMULATOR
+  bindService abacus-cf-bridge,abacus-cf-renewer $DB_BRIDGE
+  bindService abacus-provisioning-plugin,abacus-account-plugin $DB_PLUGINS
 fi

--- a/etc/concourse/scripts/common-functions
+++ b/etc/concourse/scripts/common-functions
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 APPS=()
 
 function getApps {
@@ -39,4 +41,74 @@ function restartAppsWithRetry {
       return
     fi
   done
+}
+
+function waitForServices {
+  echo "Waiting for DB creation or update ..."
+  until [ "$(cf services | grep '\(create\|update\) succeeded\|\(create\|update\) failed' | wc -l)" == "$1" ]; do
+    sleep 3s
+  done
+  if [ "$(cf services | grep '\(create\|update\) succeeded' | wc -l)" == "$1" ]; then
+    echo "DB creation or update finished successfully."
+  else
+    echo "DB creation or update failed!"
+    exit 1
+  fi
+}
+
+function createOrUpdateService {
+  set +e
+  cf service $1
+  if [ "$?" == "1" ]; then
+    echo "Creating new DB service instance $1 with plan $2 ..."
+    cf create-service "$DB_SERVICE_NAME" $2 $1
+  else
+    echo "Updating DB service instance $1 with plan $2 ..."
+    cf update-service $1 -p $2
+  fi
+  set -e
+}
+
+function bindService {
+  instances=($DB_SERVICE_INSTANCES)
+  for dbalias in $(echo $2 | sed "s/,/ /g" | xargs -n1 | sort -u | xargs); do
+    for app_prefix in $(echo $1 | sed "s/,/ /g" | xargs -n1 | sort -u | xargs); do
+      for instance in "${instances[@]}"; do
+        instance_name=${instance%:*}
+        for app in "${APPS[@]}"; do
+          if [[ $instance_name == $dbalias* && $app == $app_prefix* ]]; then
+            cf bind-service $app $instance_name
+          fi
+        done
+      done
+    done
+  done
+}
+
+function mapRoutes {
+  if [ -z "$1" ]; then
+     echo "Cannot map app without a name !"
+     exit 1
+  fi
+  if [ -z "$2" ]; then
+    echo "Unknown number of instances !"
+    exit 1
+  fi
+
+  local APP_NAME=$1
+  local INSTANCES=$(expr $2 - 1)
+
+  set +e # Disable error checks
+  cf app $APP_NAME
+  single_app=$?
+  set -e # Enable error checks
+
+  if [ $single_app = 0 ]; then
+    echo "Found single $APP_NAME instance. Will not map route !!!"
+  else
+    echo "Mapping $2 (0-$INSTANCES) instances of $APP_NAME in $CF_DOMAIN domain ..."
+    for i in `seq 0 $INSTANCES`; do
+      cf map-route "$APP_NAME-$i" $CF_DOMAIN --hostname "$APP_NAME"
+    done
+  fi
 }

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -65,16 +65,23 @@ const secured = () => process.env.SECURED === 'true' ? true : false;
 // OAuth bearer access token with Abacus system access scopes
 let systemToken;
 
+const dbaliasAggregator = process.env.DBALIAS_AGGREGATOR || 'db';
+const dbaliasAccumulator = process.env.DBALIAS_ACCUMULATOR || 'db';
+
 // Resolve service URIs
 const uris = urienv({
   account: 9881,
-  auth_server: 9882
+  auth_server: 9882,
+  [dbaliasAggregator]: 5984,
+  [dbaliasAccumulator]: 5984
 });
 
 // Configure rated usage db
-const aggregatordb = dataflow.db('abacus-aggregator-aggregated-usage');
+const aggregatordb = dataflow.db('abacus-aggregator-aggregated-usage',
+  undefined, uris[dbaliasAggregator]);
 // Configure accumulated usage db
-const accumulatordb = dataflow.db('abacus-accumulator-accumulated-usage');
+const accumulatordb = dataflow.db('abacus-accumulator-accumulated-usage',
+  undefined, uris[dbaliasAccumulator]);
 
 // Time dimensions
 const dimensions = ['s', 'm', 'h', 'D', 'M'];

--- a/lib/cf/bridge/src/index.js
+++ b/lib/cf/bridge/src/index.js
@@ -27,10 +27,12 @@ const edebug = require('abacus-debug')('e-abacus-cf-bridge');
 // Create an express router
 const routes = router();
 
+const dbalias = process.env.DBALIAS || 'db';
+
 // Resolve service URIs
 const uris = memoize(() => urienv({
   auth_server: 9882,
-  db         : 5984
+  [dbalias]  : 5984
 }));
 
 // Use secure routes or not
@@ -48,7 +50,8 @@ const cfAdminToken = oauth.cache(uris().auth_server,
 
 // DB for storing the last processed app and app-usage GUIDs
 const db = throttle(retry(breaker(batch(
-  dbclient(partition.singleton, dbclient.dburi(uris().db, 'abacus-cf-bridge'))
+  dbclient(partition.singleton, dbclient.dburi(uris()[dbalias],
+    'abacus-cf-bridge'))
 ))));
 
 const minIntervalTime = parseInt(process.env.MIN_INTERVAL_TIME) || 5000;

--- a/lib/cf/renewer/src/index.js
+++ b/lib/cf/renewer/src/index.js
@@ -43,11 +43,13 @@ const edebug = require('abacus-debug')('e-abacus-cf-renewer');
 // Create an express router
 const routes = router();
 
+const dbalias = process.env.DBALIAS || 'db';
+
 // Resolve service URIs
 const uris = memoize(() => urienv({
   auth_server : 9882,
   collector   : 9080,
-  db          : 5984,
+  [dbalias]   : 5984,
   provisioning: 9880
 }));
 

--- a/lib/plugins/eureka/src/index.js
+++ b/lib/plugins/eureka/src/index.js
@@ -24,14 +24,16 @@ const debug = require('abacus-debug')('abacus-eureka-plugin');
 // Secure the routes or not
 const secured = () => process.env.SECURED === 'true' ? true : false;
 
+const dbalias = process.env.DBALIAS || 'db';
+
 const uris = urienv({
-  db: 5984
+  [dbalias]: 5984
 });
 
 // Configure app instance db
 const db = yieldable(retry(breaker(batch(
   dbclient(partition.singleton,
-  dbclient.dburi(uris.db, 'abacus-app-instances'))))));
+  dbclient.dburi(uris[dbalias], 'abacus-app-instances'))))));
 
 // Create an express router
 const routes = router();

--- a/lib/plugins/provisioning/src/index.js
+++ b/lib/plugins/provisioning/src/index.js
@@ -41,24 +41,26 @@ const debug = require('abacus-debug')('abacus-provisioning-plugin');
 // Secure the routes or not
 const secured = () => process.env.SECURED === 'true' ? true : false;
 
+const dbalias = process.env.DBALIAS || 'db';
+
 const uris = urienv({
-  db: 5984
+  [dbalias]: 5984
 });
 
 // Configure rating plan db
 const ratingdb = yieldable(retry(breaker(batch(
   dbclient(partition.singleton,
-    dbclient.dburi(uris.db, 'abacus-rating-plans'))))));
+    dbclient.dburi(uris[dbalias], 'abacus-rating-plans'))))));
 
 // Configure pricing plan db
 const pricingdb = yieldable(retry(breaker(batch(
   dbclient(partition.singleton,
-    dbclient.dburi(uris.db, 'abacus-pricing-plans'))))));
+    dbclient.dburi(uris[dbalias], 'abacus-pricing-plans'))))));
 
 // Configure metering plan db
 const meteringdb = yieldable(retry(breaker(batch(
   dbclient(partition.singleton,
-    dbclient.dburi(uris.db, 'abacus-metering-plans'))))));
+    dbclient.dburi(uris[dbalias], 'abacus-metering-plans'))))));
 
 // Create an express router
 const routes = router();

--- a/lib/utils/carryover/src/index.js
+++ b/lib/utils/carryover/src/index.js
@@ -20,11 +20,13 @@ const urienv = require('abacus-urienv');
 // Setup debug log
 const debug = require('abacus-debug')('abacus-carryover');
 
+const dbalias = process.env.DBALIAS || 'db';
+
 // Resolve service URIs
 const uris = memoize(() => urienv({
   api        : 80,
   collector  : 9080,
-  db         : 5984
+  [dbalias]  : 5984
 }));
 
 // Partitioning function that can be used for range queries
@@ -33,7 +35,7 @@ const checkKeyPart = partition.partitioner(partition.bucket,
 
 // Carry-over DB user to transfer usage to the next month
 const carryOverDB = throttle(retry(breaker(batch(
-  dbclient(checkKeyPart, dbclient.dburi(uris().db, 'abacus-carry-over'))
+  dbclient(checkKeyPart, dbclient.dburi(uris()[dbalias], 'abacus-carry-over'))
 ))));
 
 const buildKey = (usage) => dbclient.tkuri(

--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -68,9 +68,11 @@ const debug = require('abacus-debug')('abacus-dataflow');
 const edebug = require('abacus-debug')('e-abacus-dataflow');
 const odebug = require('abacus-debug')('o-abacus-dataflow');
 
+const dbalias = process.env.DBALIAS || 'db';
+
 // Resolve service URIs
 const uris = memoize(() => urienv({
-  db: 5984
+  [dbalias]: 5984
 }));
 
 const forward = (n) => partition.createForwardFn(n, 4000);
@@ -472,9 +474,13 @@ const dbname = (key, def) => {
 };
 
 // Return a db
-const db = (dbname, dbh, dburi) => !dbname ? undefined :
-  yieldable(throttle(retry(breaker(batch(
-    (dbh || dbhandle)(dburi || uris().db, dbname), 20, 100, dbcsize)))));
+const db = (dbname, dbh, dburi) => {
+  debug('Getting db for name %s and uri %s', dbname, dburi || uris()[dbalias]);
+  return !dbname ? undefined :
+    yieldable(throttle(retry(breaker(batch(
+      (dbh || dbhandle)(dburi || uris()[dbalias], dbname), 20, 100, 
+        dbcsize)))));
+};
 
 // Return a function that will convert a (bucket, period, op) to a list of
 // (partition, epoch) pairs. This version of the forward function is used
@@ -503,7 +509,7 @@ const edbhandle = (dbserver, name) => dbclient(
 // Return an errordb
 const errordb = (dbname, dbh) => !dbname ? undefined :
   yieldable(throttle(retry(breaker(batch(
-    (dbh || edbhandle)(uris().db, dbname), 20, 100, dbcsize)))));
+    (dbh || edbhandle)(uris()[dbalias], dbname), 20, 100, dbcsize)))));
 
 // Error list time limit (1 month)
 const errorTimeLimit = 2629746000;
@@ -1193,7 +1199,7 @@ const idbhandle = (dbserver, name) => dbclient(
 // Return a db to use when replaying docs
 const replaydb = (dbname, dbh) => !dbname ? undefined :
   yieldable(throttle(retry(breaker(batch(
-    (dbh || idbhandle)(uris().db, dbname))))));
+    (dbh || idbhandle)(uris()[dbalias], dbname))))));
 
 // Replay the last input docs that don't have any corresponding inputs.
 // This is typically used when restarting a flow after an error.

--- a/lib/utils/mongoclient/src/index.js
+++ b/lib/utils/mongoclient/src/index.js
@@ -13,6 +13,7 @@ const url = require('url');
 const moment = require('abacus-moment');
 const lock = require('abacus-lock');
 
+const contains = _.contains;
 const defaults = _.defaults;
 const each = _.each;
 const extend = _.extend;
@@ -104,19 +105,154 @@ const key = (uri) => {
   return undefined;
 };
 
+// Get server partitioning mode, either 'collection' or 'db' depending on
+// whether the server uri contains a database or not
+const getPartitioningMode = (server) => {
+  // Remove uri schema and trailing '/'
+  const removeSchema = () => {
+    const i = server.indexOf('://');
+    const schema = i !== -1 ? server.substring(0, i) : undefined;
+    const uri = schema ? server.substring(schema.length + 3) : server;
+    return uri[uri.length - 1] === '/' ? uri.substring(0, uri.length - 1) : uri;
+  };
+
+  // Return 'collection' if the resulting uri still contains '/', otherwise 'db'
+  return removeSchema().includes('/') ? 'collection' : 'db';
+};
+
+// List all partitions on the specified server
+// Depending on the partition mode, return either all databases
+// or all collections in a database
+const listPartitions = (server, db, cb) => {
+  if (getPartitioningMode(server) === 'db') {
+    // List all databases on the server
+    debug('Listing databases on %s', server);
+    db.admin().listDatabases((err, dbs) => {
+      if (err) {
+        edebug('Failed to list databases on %s because of %o', server, err);
+        return cb(err);
+      }
+      
+      // Return all database names
+      return cb(null, map(dbs.databases, (d) => d.name));
+    });
+  }
+  else {
+    // List all collections on the server
+    debug('Listing collections on %s', server);
+    db.listCollections().toArray((err, collections) => {
+      if (err) {
+        edebug('Failed to list collections on %s because of %o', server, err);
+        return cb(err);
+      }
+
+      // Return all collection names
+      return cb(null, map(collections, (c) => c.name));
+    });
+  }
+};
+
+// Find a server that already contains the specified partition
+const findServer = (servers, partition, cb) => {
+  debug('Looking for partition %s on all servers', partition);
+
+  // Filter all servers that already contain the specified partition
+  const options = dbOpts();
+  transform.filter(servers, (server, i, servers, cb) => {
+    // Connect to the server
+    debug('Connecting to %s with options %o', server, options);
+    mongoDB.connect(server, options, (err, db) => {
+      if (err) {
+        edebug('Failed to connect to %s because of %o', server, err);
+        return cb(err);
+      }
+
+      // List all partitions on the server
+      return listPartitions(server, db, (err, partitions) => {
+        if (err) {
+          db.close();
+          return cb(err);
+        }
+
+        // Return true if the list of partitions contains the partition
+        db.close();
+        return cb(null, contains(partitions, partition));
+      });
+    });
+  }, (err, servers) => {
+    if (err)
+      return cb(err);
+
+    // Return the first server or undefined if no servers were found
+    const server = servers.length > 0 ? servers[0] : undefined;
+    if(server)
+      debug('Partition %s found on server %s', partition, server);
+    else
+      debug('Partition %s not found on any server', partition);
+    return cb(null, server);
+  });
+};
+
+// Memoized partition servers
+const partitionServers = {};
+
+// Get a server for the specified partition
+// If it already exists on any of the servers, that server is returned
+// Otherwise, a server is assigned based on the partition index
+const getServer = (partition, servers, p, cb) => {
+  // If a single server, return it
+  if (servers.length === 1)
+    return cb(null, servers[0]);
+
+  return lock(partition, (err, unlock) => {
+    // Return a memoized partition server
+    if (partitionServers[partition])
+      return unlock(cb(null, partitionServers[partition]));
+
+    // Find a server that already contains the partition
+    return findServer(servers, partition, (err, found) => {
+      if (err)
+        return unlock(cb(err));
+
+      // Use the found server, or assign one if not found
+      const server = found ? found : servers[p[0] % servers.length];
+      partitionServers[partition] = server;
+      return unlock(cb(null, server));
+    });
+  });
+};
+
 // Return a db uri naming function configured with a db uri name prefix
 const dburi = (server, name) => {
-  if(!server)
-    return (p) => [name, p.join('-')].join('-');
+  if (!server)
+    return (p, cb) => cb(null, [name, p.join('-')].join('-'));
 
-  const queryOpts = url.parse(server).search;
-  const srv = queryOpts ? server.replace(queryOpts, '') : server;
-  const path = /:name/.test(srv) ? request.route(srv, {
-    name: name
-  }) : [srv, name].join('/');
+  // Compose a db uri from a server uri, name, and partition infos
+  const cdburi = (server, p, cb) => {
+    const queryOpts = url.parse(server).search;
+    const srv = queryOpts ? server.replace(queryOpts, '') : server;
+    const path = /:name/.test(srv) ? request.route(srv, {
+      name: name
+    }) : [srv, name].join('/');
 
-  return (p) => queryOpts ? [path, p.join('-')].join('-') + queryOpts :
-    [path, p.join('-')].join('-');
+    cb(null, queryOpts ? [path, p.join('-')].join('-') + queryOpts : 
+       [path, p.join('-')].join('-'));
+  };
+
+  // If there are multiple servers, first get a server for the partition
+  // and then compose the db uri from that server
+  if(Array.isArray(server))
+    return (p, cb) => {
+      const partition = [name, p.join('-')].join('-');
+      debug('Getting server for partition %s', partition);
+      getServer(partition, server, p, (err, server) => {
+        if (err)
+          return cb(err);
+        return cdburi(server, p, cb);
+      });
+    };
+  
+  return (p, cb) => cdburi(server, p, cb);
 };
 
 // Convert a URI to a printable URI, with the optional user and password
@@ -153,6 +289,7 @@ const dbOpts = (opt) => {
 
 // Construct a db handle for a db uri
 const dbcons = (uri, opt, cb) => {
+  debug('Constructing db handle for uri %s', uri);
   const url = /:/.test(uri) ? uri : 'mongodb://localhost:27017/' + uri;
   const driverUrl = removeCollectionFromUrl(url);
 
@@ -212,7 +349,7 @@ const errdb = (name, err) => ({
 // Return the db handle of the partition to use for a given key and time
 const dbpartition = (k, t, rw, part, pool, cb) => {
   part(k, t, rw, (err, p) => err ?
-    cb(null, errdb(dburi('err')([k, t ]), err)) : pool(p, rw, cb));
+    dburi('err')([k, t], (e, u) => cb(null, errdb(u, err))) : pool(p, rw, cb));
 };
 
 // Run a single db operation on a doc, using the given partition and db pool
@@ -524,24 +661,28 @@ const mongoclient = (part, uri, cons) => {
 
     // Get a pooled db partition handle for a single partition
     const pooldb = (p, cb) => {
-      const u = dbopt.uri(p);
-      debug('Using db %s', puri(u));
+      debug('Getting db uri for partition %o', p);
+      dbopt.uri(p, (err, u) => {
+        if(err)
+          return cb(err);
+        debug('Using db %s', puri(u));
 
-      // Return a memoized db partition handle or get and memoize a new one
-      // from the given db constructor
-      lock(u, (err, unlock) => {
-        if (partitions[u])
-          return unlock(cb(null, partitions[u]));
+        // Return a memoized db partition handle or get and memoize a new one
+        // from the given db constructor
+        return lock(u, (err, unlock) => {
+          if (partitions[u])
+            return unlock(cb(null, partitions[u]));
 
-        debug('Constructing db handle for db %s', puri(u));
-        return dbopt.cons(u, {}, (err, db) => {
-          if (err)
-            return unlock(cb(null, errdb('dbcons-err-' + u, err)));
+          debug('Constructing db handle for db %s', puri(u));
+          return dbopt.cons(u, {}, (err, db) => {
+            if (err)
+              return unlock(cb(null, errdb('dbcons-err-' + u, err)));
 
-          // Memoize the db handle
-          partitions[u] = db;
+            // Memoize the db handle
+            partitions[u] = db;
 
-          return unlock(cb(null, db));
+            return unlock(cb(null, db));
+          });
         });
       });
     };
@@ -868,7 +1009,7 @@ const mongoclient = (part, uri, cons) => {
 };
 
 // Drop databases that match the given regex.
-const drop = (server = 'mongodb://localhost:27017', regex, cb) => {
+const dropOne = (server = 'mongodb://localhost:27017', regex, cb) => {
   if(/:/.test(server)) {
     // Only do this on localhost or 127.0.0.1 for now as that's only for
     // running our tests
@@ -916,6 +1057,12 @@ const drop = (server = 'mongodb://localhost:27017', regex, cb) => {
   }
   else
     cb();
+};
+
+const drop = (server = 'mongodb://localhost:27017', regex, cb) => {
+  const servers = Array.isArray(server) ? server : 
+    server.includes('|') ? server.split('|') : [server];
+  transform.map(servers, (server, i, l, cb) => dropOne(server, regex, cb), cb);
 };
 
 // Export our public functions

--- a/lib/utils/mongoclient/src/test/test.js
+++ b/lib/utils/mongoclient/src/test/test.js
@@ -8,16 +8,33 @@ const sample = _.sample;
 const flatten = _.flatten;
 const map = _.map;
 const range = _.range;
+const extend = _.extend;
 
 const partition = require('abacus-partition');
 const batch = require('abacus-batch');
 const moment = require('abacus-moment');
-const dbclient = require('..');
+const mongodb = require('mongodb');
 
 /* eslint handle-callback-err: 0 */
 
-const dbserver = () => process.env.DB;
+const dbserver = () => {
+  const value = process.env.DB;
+  return value && value.includes('|') ? value.split('|') : value;
+};
+
 const debug = require('abacus-debug')('abacus-mongoclient-test');
+
+// Spy the MongoDB client
+const mongoDB = mongodb.MongoClient;
+let mongoConnectSpy = spy(mongoDB, 'connect');
+const mongodbmock = extend({}, mongodb, {
+  MongoClient: extend({}, mongoDB, {
+    connect: (server, options, cb) => mongoConnectSpy(server, options, cb)
+  })
+});
+require.cache[require.resolve('mongodb')].exports = mongodbmock;
+
+const dbclient = require('..');
 
 describe('abacus-mongoclient', () => {
   const helloKey = dbclient.kturi('Hello', moment.utc(
@@ -44,9 +61,23 @@ describe('abacus-mongoclient', () => {
     dbclient.drop(dbserver(), /^abacus-mongoclient-/, done);
   });
 
+  beforeEach(() => {
+    mongoConnectSpy.reset();
+  });
+
   afterEach(() => {
     delete process.env.DB_OPTS;
   });
+
+  const cbfnspy = (count, connectCount, done) => {
+    let cbs = 0;
+    return () => {
+      if(++cbs === count) {
+        expect(mongoConnectSpy.callCount).to.equal(connectCount);
+        done();
+      }
+    };
+  };
 
   it('distributes db operations over several db partitions', (done) => {
 
@@ -803,8 +834,11 @@ describe('abacus-mongoclient', () => {
     };
 
     const uriOnly = (done) => {
-      const db = dbclient(undefined, () => {
-        return dbserver() || 'mongodb://localhost:27017';
+      const db = dbclient(undefined, (p, cb) => {
+        let server = dbserver();
+        if(Array.isArray(server))
+          server = server.length > 0 ? server[0] : undefined;
+        cb(null, server || 'mongodb://localhost:27017');
       });
       expect(db).to.not.equal(undefined);
       read(db, done);
@@ -1714,28 +1748,34 @@ describe('abacus-mongoclient', () => {
         putlist(db, () => getrange(db, done)))))))));
   });
 
-  it('preserves URI options when constructing DB URIs', () => {
+  it('preserves URI options when constructing DB URIs', (done) => {
+    const cb = cbfnspy(8, 0, done);
+
     const serverNameFunc = dbclient.dburi('mongodb://localhost:1234' +
       '?ssl=true', 'ssl-test');
-    expect(serverNameFunc(['1'])).to.equal('mongodb://localhost:1234/' +
-      'ssl-test-1?ssl=true');
-    expect(serverNameFunc(['1', '23'])).to.equal('mongodb://localhost:1234/'
-      + 'ssl-test-1-23?ssl=true');
+    serverNameFunc(['1'], (err, u) =>
+      cb(expect(u).to.equal('mongodb://localhost:1234/ssl-test-1?ssl=true')));
+    serverNameFunc(['1', '23'], (err, u) => 
+      cb(expect(u).to.equal(
+        'mongodb://localhost:1234/ssl-test-1-23?ssl=true')));
 
     const serverFunc = dbclient.dburi('mongodb://localhost:1234?ssl=true');
-    expect(serverFunc(['1'])).to.equal('mongodb://localhost:1234/' +
-      '-1?ssl=true');
-    expect(serverFunc(['1', '23'])).to.equal('mongodb://localhost:1234/' +
-      '-1-23?ssl=true');
+    serverFunc(['1'], (err, u) =>
+      cb(expect(u).to.equal('mongodb://localhost:1234/-1?ssl=true')));
+    serverFunc(['1', '23'], (err, u) =>
+      cb(expect(u).to.equal('mongodb://localhost:1234/-1-23?ssl=true')));
 
     const nameFunc = dbclient.dburi(undefined, 'dbname');
-    expect(nameFunc(['1'])).to.equal('dbname-1');
-    expect(nameFunc(['1', '23'])).to.equal('dbname-1-23');
+    nameFunc(['1'], (err, u) =>
+      cb(expect(u).to.equal('dbname-1')));
+    nameFunc(['1', '23'], (err, u) =>
+      cb(expect(u).to.equal('dbname-1-23')));
 
     const noSchemaFunc = dbclient.dburi('localhost:2345?ssl=true', 'dbname');
-    expect(noSchemaFunc(['1'])).to.equal('localhost:2345/dbname-1?ssl=true');
-    expect(noSchemaFunc(['1', '23'])).to.equal('localhost:2345/dbname-1-23?' +
-      'ssl=true');
+    noSchemaFunc(['1'], (err, u) =>
+      cb(expect(u).to.equal('localhost:2345/dbname-1?ssl=true')));
+    noSchemaFunc(['1', '23'], (err, u) =>
+      cb(expect(u).to.equal('localhost:2345/dbname-1-23?ssl=true')));
   });
 
   it('reads custom Mongo options from environment', (done) => {
@@ -1766,40 +1806,137 @@ describe('abacus-mongoclient', () => {
     debug('custom Mongo opts: db get finished');
   });
 
-  it('generates URI without collection', () => {
-    const replicaSet = '127.0.0.1:1234,localhost:3456,localhost:5678';
+  it('generates URI without collection', (done) => {
+    const rs = '127.0.0.1:1234,localhost:3456,localhost:5678';
 
-    const serverNameFunc = dbclient.dburi('mongodb://' + replicaSet +
+    const cb = cbfnspy(10, 0, done);
+
+    const serverNameFunc = dbclient.dburi('mongodb://' + rs +
       '?ssl=true', 'ssl-test');
-    expect(serverNameFunc(['1'])).to.equal('mongodb://' + replicaSet +
-      '/ssl-test-1?ssl=true');
-    expect(serverNameFunc(['1', '23'])).to.equal('mongodb://' + replicaSet +
-      '/ssl-test-1-23?ssl=true');
+    serverNameFunc(['1'], (err, u) =>
+      cb(expect(u).to.equal('mongodb://' + rs + '/ssl-test-1?ssl=true')));
+    serverNameFunc(['1', '23'], (err, u) =>
+      cb(expect(u).to.equal('mongodb://' + rs + '/ssl-test-1-23?ssl=true')));
 
-    const serverFunc = dbclient.dburi('mongodb://' + replicaSet + '?ssl=true');
-    expect(serverFunc(['1'])).to.equal('mongodb://' + replicaSet +
-      '/-1?ssl=true');
-    expect(serverFunc(['1', '23'])).to.equal('mongodb://' + replicaSet +
-      '/-1-23?ssl=true');
+    const serverFunc = dbclient.dburi('mongodb://' + rs + '?ssl=true');
+    serverFunc(['1'], (err, u) =>
+      cb(expect(u).to.equal('mongodb://' + rs + '/-1?ssl=true')));
+    serverFunc(['1', '23'], (err, u) =>
+      cb(expect(u).to.equal('mongodb://' + rs + '/-1-23?ssl=true')));
 
-    const noSchemaFunc = dbclient.dburi(replicaSet + '?ssl=true', 'dbname');
-    expect(noSchemaFunc(['1'])).to.equal(replicaSet + '/dbname-1?ssl=true');
-    expect(noSchemaFunc(['1', '23'])).to.equal(replicaSet + '/dbname-1-23' +
-      '?ssl=true');
+    const noSchemaFunc = dbclient.dburi(rs + '?ssl=true', 'dbname');
+    noSchemaFunc(['1'], (err, u) =>
+      cb(expect(u).to.equal(rs + '/dbname-1?ssl=true')));
+    noSchemaFunc(['1', '23'], (err, u) =>
+      cb(expect(u).to.equal(rs + '/dbname-1-23?ssl=true')));
 
-    const replicaSetFunc = dbclient.dburi('mongodb://' + replicaSet +
-      '?replicaSet=foo&ssl=true', 'dbname');
-    expect(replicaSetFunc(['1'])).to.equal('mongodb://' + replicaSet +
-      '/dbname-1?replicaSet=foo&ssl=true');
-    expect(replicaSetFunc(['1', '23'])).to.equal('mongodb://' + replicaSet +
-      '/dbname-1-23?replicaSet=foo&ssl=true');
+    const replicaSetFunc = dbclient.dburi('mongodb://' + rs +
+      '?rs=foo&ssl=true', 'dbname');
+    replicaSetFunc(['1'], (err, u) =>
+      cb(expect(u).to.equal('mongodb://' + rs + '/dbname-1?rs=foo&ssl=true')));
+    replicaSetFunc(['1', '23'], (err, u) =>
+      cb(expect(u).to.equal('mongodb://' + rs +
+      '/dbname-1-23?rs=foo&ssl=true')));
 
-    const replicaSetCollectionFunc = dbclient.dburi('mongodb://' + replicaSet +
-      '?replicaSet=foo&ssl=true', 'dbname/collection');
-    expect(replicaSetCollectionFunc(['1'])).to.equal('mongodb://' + replicaSet +
-      '/dbname/collection-1?replicaSet=foo&ssl=true');
-    expect(replicaSetCollectionFunc(['1', '23'])).to.equal('mongodb://' +
-      replicaSet + '/dbname/collection-1-23?replicaSet=foo&ssl=true');
+    const replicaSetCollectionFunc = dbclient.dburi('mongodb://' + rs +
+      '?rs=foo&ssl=true', 'dbname/collection');
+    replicaSetCollectionFunc(['1'], (err, u) =>
+      cb(expect(u).to.equal('mongodb://' + rs +
+      '/dbname/collection-1?rs=foo&ssl=true')));
+    replicaSetCollectionFunc(['1', '23'], (err, u) =>
+      cb(expect(u).to.equal('mongodb://' +
+      rs + '/dbname/collection-1-23?rs=foo&ssl=true')));
+  });
+
+  it('with many servers, returns the correct server', (done) => {
+    const cb = cbfnspy(4, 8, done);
+
+    const multiServerFunc = dbclient.dburi([
+      'mongodb://localhost:27017/abacus-mongoclient-0',
+      'mongodb://localhost:27017/abacus-mongoclient-1'], 'abacus');
+    multiServerFunc(['0', '201703'], (err, u) =>
+      cb(expect(u).to.equal(
+        'mongodb://localhost:27017/abacus-mongoclient-0/abacus-0-201703')));
+    multiServerFunc(['1', '201703'], (err, u) =>
+      cb(expect(u).to.equal(
+        'mongodb://localhost:27017/abacus-mongoclient-1/abacus-1-201703')));
+    multiServerFunc(['2', '201703'], (err, u) =>
+      cb(expect(u).to.equal(
+        'mongodb://localhost:27017/abacus-mongoclient-0/abacus-2-201703')));
+    multiServerFunc(['3', '201703'], (err, u) =>
+      cb(expect(u).to.equal(
+        'mongodb://localhost:27017/abacus-mongoclient-1/abacus-3-201703')));
+  });
+
+  it('with one server, returns this server', (done) => {
+    const cb = cbfnspy(2, 0, done);
+
+    const singleServerFunc = dbclient.dburi([
+      'mongodb://localhost:27017/abacus-mongoclient-0'], 'abacus');
+    singleServerFunc(['4', '201703'], (err, u) =>
+      cb(expect(u).to.equal(
+        'mongodb://localhost:27017/abacus-mongoclient-0/abacus-4-201703')));
+    singleServerFunc(['5', '201703'], (err, u) =>
+      cb(expect(u).to.equal(
+        'mongodb://localhost:27017/abacus-mongoclient-0/abacus-5-201703')));
+  });
+
+  it('with many servers, memoizes the correct server', (done) => {
+    const cb = cbfnspy(4, 2, done);
+
+    const multiServerFunc = dbclient.dburi([
+      'mongodb://localhost:27017/abacus-mongoclient-0',
+      'mongodb://localhost:27017/abacus-mongoclient-1'], 'abacus');
+    multiServerFunc(['6', '201703'], (err, u) =>
+      cb(expect(u).to.equal(
+        'mongodb://localhost:27017/abacus-mongoclient-0/abacus-6-201703')));
+    multiServerFunc(['6', '201703'], (err, u) =>
+      cb(expect(u).to.equal(
+        'mongodb://localhost:27017/abacus-mongoclient-0/abacus-6-201703')));
+    multiServerFunc(['6', '201703'], (err, u) =>
+      cb(expect(u).to.equal(
+        'mongodb://localhost:27017/abacus-mongoclient-0/abacus-6-201703')));
+    multiServerFunc(['6', '201703'], (err, u) =>
+      cb(expect(u).to.equal(
+        'mongodb://localhost:27017/abacus-mongoclient-0/abacus-6-201703')));
+  });
+
+  it('if the partition exits, returns the correct server', (done) => {
+    const db = dbclient(undefined, dbclient.dburi(
+      'mongodb://localhost:27017/abacus-mongoclient-1', 'abacus'));
+
+    // Put a document to create the partition
+    db.put({
+      id: helloKey,
+      value: 'Hello'
+    }, (err, doc) => {
+      expect(err).to.equal(null);
+
+      const multiServerFunc = dbclient.dburi([
+        'mongodb://localhost:27017/abacus-mongoclient-0',
+        'mongodb://localhost:27017/abacus-mongoclient-1'], 'abacus');
+      multiServerFunc(['0', '201411'], (err, u) => {
+        expect(u).to.equal(
+          'mongodb://localhost:27017/abacus-mongoclient-1/abacus-0-201411');
+        expect(mongoConnectSpy.callCount).to.equal(3);
+        done();
+      });
+    });
+  });
+
+  it('on connection error, propagates the error', (done) => {
+    const original = mongoConnectSpy;
+    mongoConnectSpy = spy((server, options, cb) => {
+      cb('connection error');
+    });
+    const multiServerFunc = dbclient.dburi([
+      'mongodb://localhost:27017/abacus-mongoclient-0',
+      'mongodb://localhost:27017/abacus-mongoclient-1'], 'abacus');
+    multiServerFunc(['7', '201703'], (err, u) => {
+      expect(err).to.equal('connection error');
+      mongoConnectSpy = original;
+      done();
+    });
   });
 
   it('removes collection from URL', () => {

--- a/lib/utils/notify/src/index.js
+++ b/lib/utils/notify/src/index.js
@@ -20,9 +20,11 @@ const memoize = _.memoize;
 // Setup the debug
 const debug = require('abacus-debug')('abacus-notify');
 
+const dbalias = process.env.DBALIAS || 'db';
+
 // Resolve service URIs
 const uris = memoize(() => urienv({
-  db: 5984
+  [dbalias]: 5984
 }), () => process.env.DB || '');
 
 // Return a function that will convert a (bucket, period, op) to a list of
@@ -75,7 +77,7 @@ const dbcsize = (name, args) => {
 // Return a db
 const db = (dbname, dbh) => !dbname ? undefined :
   yieldable(throttle(retry(breaker(batch(
-    (dbh || dbhandle)(uris().db, dbname), 20, 100, dbcsize)))));
+    (dbh || dbhandle)(uris()[dbalias], dbname), 20, 100, dbcsize)))));
 
 // Takes a list of urls and does a POST request on everyone one asynchronously
 const notify = (l, cb) => {

--- a/lib/utils/urienv/src/index.js
+++ b/lib/utils/urienv/src/index.js
@@ -25,18 +25,21 @@ const defport = () => process.browser ?
   window.location.port : process.env.PORT ? process.env.PORT : 9080;
 
 // Convert an alias to a value found in an environment variable
-const env = (alias) => process.env[alias.replace('-', '_').toUpperCase()];
+const env = (alias) => {
+  const value = process.env[alias.replace('-', '_').toUpperCase()];
+  return value && value.includes('|') ? value.split('|') : value;
+};
 
-// Compute URL in a hosted Cloud platform environment, using the
+// Compute URLs in a hosted Cloud platform environment, using the
 // bound service instance URIs.
-const serviceInstanceURI = (alias) => {
-  const serviceURI = vcapenv.serviceInstanceCredentials(alias, 'uri');
-  if (/:/.test(serviceURI)) {
-    debug('Resolved %s to service instance URI %s', alias, serviceURI);
-    return serviceURI;
+const serviceInstanceURIs = (alias) => {
+  const serviceURIs = vcapenv.serviceInstancesCredentials(alias, 'uri');
+  if (serviceURIs.every((serviceURI) => /:/.test(serviceURI))) {
+    debug('Resolved %s to service instance URIs %o', alias, serviceURIs);
+    return serviceURIs;
   }
 
-  return undefined;
+  return [];
 };
 
 // Compute the URL of an app in a hosted Cloud platform environment, using
@@ -45,12 +48,16 @@ const hosted = (alias, uris) => {
   // Search for service instance
   if(vcapenv.services()) {
     debug('Searching in service instances %j', vcapenv.services());
-    const serviceURI = serviceInstanceURI(alias);
-    if (serviceURI) return serviceURI;
+    const serviceURIs = serviceInstanceURIs(alias);
+    if (serviceURIs && serviceURIs.length > 0) return serviceURIs;
   }
 
   // Use the app environment
   const resolved = env(alias) || alias;
+  if(Array.isArray(resolved) && resolved.every((r) => /:/.test(r))) {
+    debug('Resolved env alias %s to URIs %o', alias, resolved);
+    return resolved;
+  }
   if(/:/.test(resolved)) {
     debug('Resolved env alias %s to URI %s', alias, resolved);
     return resolved;
@@ -65,10 +72,21 @@ const hosted = (alias, uris) => {
 
 // Compute the URL of an app in a local environment, using a default protocol,
 // host and the given port.
+/* eslint complexity: 0 */
 const local = (alias, def) => {
   // Use the app environment or the provided default
   const resolved = env(alias) || def;
   if(resolved) {
+    if(Array.isArray(resolved)) {
+      if (resolved.every((r) => /^[0-9]+$/.test(r))) {
+        const target = resolved.map((r) => 
+          defprotocol() + '//' + defhost() + ':' + r);
+        debug('Resolved alias %s to ports %o', alias, target);
+        return target;
+      }
+      debug('Resolved alias %s to URIs %o', alias, resolved);
+      return resolved;
+    }
     if(/^[0-9]+$/.test(resolved)) {
       const target = defprotocol() + '//' + defhost() + ':' + resolved;
       debug('Resolved alias %s to port %s', alias, target);

--- a/lib/utils/urienv/src/test/test.js
+++ b/lib/utils/urienv/src/test/test.js
@@ -21,6 +21,17 @@ describe('abacus-urienv', () => {
       expect(uris.ghi).to.equal('http://localhost:9082');
     });
 
+    it('resolves URIs to localhost with multiple ports', () => {
+      // Return empty VCAP env like when running on localhost
+      vcapenv.app = stub().returns({});
+
+      const uris = urienv.resolve({
+        def: [9080, 9081]
+      });
+      expect(uris.def).to.deep.equal(['http://localhost:9080',
+        'http://localhost:9081']);
+    });
+
     it('resolves URIs from browser location', () => {
       process.browser = true;
       global.window = {
@@ -57,6 +68,27 @@ describe('abacus-urienv', () => {
 
       it('resolves URIs from environment', () => {
         expect(uris.mno).to.equal(envURI);
+      });
+    });
+
+    context('when environment contains the alias as a list', () => {
+      const envURI = 'https://xyz.net:9084|https://xyz.net:9085';
+      let uris;
+
+      beforeEach(() => {
+        process.env.MNO = envURI;
+        uris = urienv.resolve({
+          mno: 9084
+        });
+      });
+
+      afterEach(() => {
+        delete process.env.MNO;
+      });
+
+      it('resolves URIs from environment', () => {
+        expect(uris.mno).to.deep.equal(['https://xyz.net:9084',
+          'https://xyz.net:9085']);
       });
     });
   });
@@ -120,12 +152,41 @@ describe('abacus-urienv', () => {
       });
     });
 
-    context('when service instance is bound', () => {
+    context('when environment contains the alias as a list', () => {
+      const envURI = 'https://xyz.net:9084|https://xyz.net:9085';
+      let uris;
+
+      beforeEach(() => {
+        process.env.MNO = envURI;
+
+        // Return VCAP env like when running in a Cloud Foundry app instance
+        vcapenv.app = stub().returns({
+          application_uris: ['test.ng.bluemix.net',
+            'test.mybluemix.net'
+          ]
+        });
+
+        uris = urienv.resolve({
+          mno: 9084
+        });
+      });
+
+      afterEach(() => {
+        delete process.env.MNO;
+      });
+
+      it('resolves URIs from environment', () => {
+        expect(uris.mno).to.deep.equal(['https://xyz.net:9084',
+          'https://xyz.net:9085']);
+      });
+    });
+
+    context('when a single service instances is bound', () => {
       const dbURI = 'postgres://user:pwd@babar.elephantsql.com:5432/seilbmbd';
       const services = {
         elephantsql: [
           {
-            name: 'elephantsql',
+            name: 'elephantsql-1',
             label: 'elephantsql',
             plan: 'turtle',
             credentials: {
@@ -139,6 +200,8 @@ describe('abacus-urienv', () => {
       beforeEach(() => {
         // Return VCAP env like when running with service instances
         process.env.VCAP_SERVICES = JSON.stringify(services);
+
+        process.env.ELEPHANTSQL = 'postgres://babar.elephantsql.com:5432';
 
         // Return VCAP env like when running in a Cloud Foundry app instance
         vcapenv.app = stub().returns({
@@ -155,14 +218,58 @@ describe('abacus-urienv', () => {
 
       afterEach(() => {
         delete process.env.VCAP_SERVICES;
+        delete process.env.ELEPHANTSQL;
       });
 
       it('resolves URIs from service instance URI first', () => {
-        expect(uris.elephantsql).to.equal(dbURI);
+        expect(uris.elephantsql).to.deep.equal([dbURI]);
       });
 
       it('resolves URIs to the first application URI', () => {
         expect(uris.abc).to.equal('https://abc.ng.bluemix.net');
+      });
+    });
+
+    context('when multiple service instances are bound', () => {
+      const dbURI0 = 'postgres://user:pwd@babar.elephantsql.com:5432/seilbmbd0';
+      const dbURI1 = 'postgres://user:pwd@babar.elephantsql.com:5432/seilbmbd1';
+      const services = {
+        elephantsql: [
+          {
+            name: 'elephantsql-1',
+            label: 'elephantsql',
+            plan: 'turtle',
+            credentials: {
+              uri: dbURI1
+            }
+          },
+          {
+            name: 'elephantsql-0',
+            label: 'elephantsql',
+            plan: 'turtle',
+            credentials: {
+              uri: dbURI0
+            }
+          }
+        ]
+      };
+      let uris;
+
+      beforeEach(() => {
+        // Return VCAP env like when running with service instances
+        process.env.VCAP_SERVICES = JSON.stringify(services);
+
+        uris = urienv.resolve({
+          elephantsql: 9081
+        });
+      });
+
+      afterEach(() => {
+        delete process.env.VCAP_SERVICES;
+      });
+
+      it('resolves URIs from all service instances', () => {
+        expect(uris.elephantsql).to.deep.equal([dbURI0, dbURI1]);
       });
     });
   });

--- a/lib/utils/vcapenv/src/index.js
+++ b/lib/utils/vcapenv/src/index.js
@@ -7,7 +7,8 @@ const _ = require('underscore');
 const path = require('path');
 
 const memoize = _.memoize;
-const findWhere = _.findWhere;
+const filter = _.filter;
+const reduce = _.reduce;
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-vcapenv');
@@ -75,23 +76,19 @@ const services = memoize(() => {
   return process.env.VCAP_SERVICES || '';
 });
 
-// Return a VCAP service instance
-const serviceInstance = (serviceInstanceName) => {
-  const serviceList = services() || {};
-
-  for(const serviceName in serviceList) {
-    const foundInstance = findWhere(serviceList[serviceName],
-      { name: serviceInstanceName });
-    if (foundInstance) return foundInstance;
-  }
-
-  return undefined;
+// Return VCAP service instances
+const serviceInstances = (serviceInstanceName) => {
+  const foundInstances = reduce(services() || {}, (accum, services) =>
+    accum.concat(filter(services,
+      (svc) => svc.name.match(new RegExp(serviceInstanceName + '.*')))), []);
+  foundInstances.sort((a, b) => a.name.localeCompare(b.name));
+  return foundInstances;
 };
 
-// Return the credentials configured for a VCAP service instance
-const serviceInstanceCredentials = (serviceInstanceName, key) => {
-  const foundInstance = serviceInstance(serviceInstanceName);
-  return foundInstance ? foundInstance.credentials[key] : undefined;
+// Return the credentials configured for VCAP service instances
+const serviceInstancesCredentials = (serviceInstanceName, key) => {
+  const foundInstances = serviceInstances(serviceInstanceName);
+  return foundInstances.map((foundInstance) => foundInstance.credentials[key]);
 };
 
 // Returns an Express middleware that reports the app instance id and index
@@ -124,7 +121,7 @@ module.exports.iaddress = iaddress;
 module.exports.iports = iports;
 module.exports.iport = iport;
 module.exports.services = services;
-module.exports.serviceInstance = serviceInstance;
-module.exports.serviceInstanceCredentials = serviceInstanceCredentials;
+module.exports.serviceInstances = serviceInstances;
+module.exports.serviceInstancesCredentials = serviceInstancesCredentials;
 module.exports.headers = headers;
 

--- a/lib/utils/vcapenv/src/test/test.js
+++ b/lib/utils/vcapenv/src/test/test.js
@@ -75,15 +75,15 @@ describe('abacus-vcapenv', () => {
 
     it('returns undefined if no service instances are present', () => {
       // Expect the service instances to be parsed from VCAP_SERVICES
-      expect(vcapenv.serviceInstance('rediscloud-1')).to.eql(undefined);
-      expect(vcapenv.serviceInstance('unknown')).to.eql(undefined);
+      expect(vcapenv.serviceInstances('rediscloud-1')).to.deep.equal([]);
+      expect(vcapenv.serviceInstances('unknown')).to.deep.equal([]);
     });
 
     it('returns a default empty service instance key', () => {
-      expect(vcapenv.serviceInstanceCredentials('rediscloud-1', 'host')).
-        to.equal(undefined);
-      expect(vcapenv.serviceInstanceCredentials('unknown', 'host')).
-        to.equal(undefined);
+      expect(vcapenv.serviceInstancesCredentials('rediscloud-1', 'host')).
+        to.deep.equal([]);
+      expect(vcapenv.serviceInstancesCredentials('unknown', 'host')).
+        to.deep.equal([]);
     });
 
     it('returns a default empty VCAP_SERVICES env var', () => {
@@ -91,7 +91,7 @@ describe('abacus-vcapenv', () => {
     });
   });
 
-  context('when service instance is bound', () => {
+  context('when a single service instance is bound', () => {
     const serviceInstance = {
       name: 'rediscloud-1',
       label: 'rediscloud',
@@ -113,7 +113,7 @@ describe('abacus-vcapenv', () => {
       process.env.VCAP_SERVICES = JSON.stringify(services);
 
       // Expect the service info to be parsed from VCAP_SERVICES
-      expect(vcapenv.services()).to.eql(services);
+      expect(vcapenv.services()).to.deep.equal(services);
     });
 
     it('returns the service instance', () => {
@@ -121,7 +121,8 @@ describe('abacus-vcapenv', () => {
       process.env.VCAP_SERVICES = JSON.stringify(services);
 
       // Expect the service instances to be parsed from VCAP_SERVICES
-      expect(vcapenv.serviceInstance('rediscloud-1')).to.eql(serviceInstance);
+      expect(vcapenv.serviceInstances('rediscloud-1')).
+        to.deep.equal([serviceInstance]);
     });
 
     it('returns undefined if service instance is unknown', () => {
@@ -129,17 +130,73 @@ describe('abacus-vcapenv', () => {
       process.env.VCAP_SERVICES = JSON.stringify(services);
 
       // Expect the service instances to be parsed from VCAP_SERVICES
-      expect(vcapenv.serviceInstance('unknown')).to.eql(undefined);
+      expect(vcapenv.serviceInstances('unknown')).to.deep.equal([]);
     });
-
 
     it('returns a service instance key', () => {
       // Set VCAP_SERVICES env variable like when running on Cloud Foundry
       process.env.VCAP_SERVICES = JSON.stringify(services);
 
       // Expect the credentials key to be parsed from VCAP_SERVICES
-      expect(vcapenv.serviceInstanceCredentials('rediscloud-1', 'host')).
-        to.equal(serviceInstance.credentials.host);
+      expect(vcapenv.serviceInstancesCredentials('rediscloud-1', 'host')).
+        to.deep.equal([serviceInstance.credentials.host]);
+    });
+  });
+
+  context('when multiple service instances are bound', () => {
+    const serviceInstance0 = {
+      name: 'rediscloud-0',
+      label: 'rediscloud',
+      plan: '20mb',
+      credentials: {
+        port: '6378',
+        host: 'pub-redis-6378.us-east-1-2.3.ec2.redislabs.com',
+        password: '1M5zd3QfWi9nUyya'
+      }
+    };
+    const serviceInstance1 = {
+      name: 'rediscloud-1',
+      label: 'rediscloud',
+      plan: '20mb',
+      credentials: {
+        port: '6379',
+        host: 'pub-redis-6379.us-east-1-2.3.ec2.redislabs.com',
+        password: '1M5zd3QfWi9nUyya'
+      }
+    };
+    const services = {
+      rediscloud: [
+        serviceInstance1,
+        serviceInstance0
+      ]
+    };
+
+    it('returns the correct service instance', () => {
+      // Set VCAP_SERVICES env variable like when running on Cloud Foundry
+      process.env.VCAP_SERVICES = JSON.stringify(services);
+
+      // Expect the service instances to be parsed from VCAP_SERVICES
+      expect(vcapenv.serviceInstances('rediscloud-1')).
+        to.deep.equal([serviceInstance1]);
+    });
+
+    it('returns all matching service instances, sorted by name', () => {
+      // Set VCAP_SERVICES env variable like when running on Cloud Foundry
+      process.env.VCAP_SERVICES = JSON.stringify(services);
+
+      // Expect the service instances to be parsed from VCAP_SERVICES
+      expect(vcapenv.serviceInstances('rediscloud')).
+        to.deep.equal([serviceInstance0, serviceInstance1]);
+    });
+
+    it('returns all matching service instances keys', () => {
+      // Set VCAP_SERVICES env variable like when running on Cloud Foundry
+      process.env.VCAP_SERVICES = JSON.stringify(services);
+
+      // Expect the credentials key to be parsed from VCAP_SERVICES
+      expect(vcapenv.serviceInstancesCredentials('rediscloud', 'host')).
+        to.deep.equal([serviceInstance0.credentials.host,
+          serviceInstance1.credentials.host]);
     });
   });
 


### PR DESCRIPTION
Makes possible splitting Abacus data across multiple database instances, using the following approaches:
* Use a separate database instance per group of applications. 
* Use more than one database instance for all applications and distribute the database partitions across these database instances. 

Signed-off-by: Martin Aleksandrov <martin.aleksandrov@sap.com>