### PR TITLE
Fix collector and bridge dependencies

### DIFF
--- a/lib/cf/bridge/package.json
+++ b/lib/cf/bridge/package.json
@@ -47,6 +47,7 @@
     "abacus-perf": "file:../../utils/perf",
     "abacus-report": "file:../../utils/report",
     "abacus-retry": "file:../../utils/retry",
+    "abacus-request": "file:../../utils/request",
     "abacus-router": "file:../../utils/router",
     "abacus-throttle": "file:../../utils/throttle",
     "abacus-urienv": "file:../../utils/urienv",
@@ -60,8 +61,7 @@
     "abacus-cfpush": "file:../../../tools/cfpush",
     "abacus-eslint": "file:../../../tools/eslint",
     "abacus-mocha": "file:../../../tools/mocha",
-    "abacus-publish": "file:../../../tools/publish",
-    "abacus-request": "file:../../utils/request"
+    "abacus-publish": "file:../../../tools/publish"
   },
   "engines": {
     "node": ">=6.10.0",

--- a/lib/metering/collector/package.json
+++ b/lib/metering/collector/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "abacus-batch": "file:../../utils/batch",
     "abacus-breaker": "file:../../utils/breaker",
+    "abacus-cluster": "file:../../utils/cluster",
     "abacus-oauth": "file:../../utils/oauth",
     "abacus-dataflow": "file:../../utils/dataflow",
     "abacus-debug": "file:../../utils/debug",
@@ -57,7 +58,6 @@
   "devDependencies": {
     "abacus-cfpack": "file:../../../tools/cfpack",
     "abacus-cfpush": "file:../../../tools/cfpush",
-    "abacus-cluster": "file:../../utils/cluster",
     "abacus-eslint": "file:../../../tools/eslint",
     "abacus-mocha": "file:../../../tools/mocha",
     "abacus-publish": "file:../../../tools/publish"


### PR DESCRIPTION
Move abacus-request from bridge and abacus-cluster from collector to dependecies instead of devDependencies since they cannot get built without them.