### PR TITLE
Fix restartAppsWithRetry logic

### DIFF
--- a/etc/concourse/scripts/cf-acceptance-test
+++ b/etc/concourse/scripts/cf-acceptance-test
@@ -41,7 +41,6 @@ pushd $abacus_dir
   echo "Deploying Abacus ..."
   npm run cfstage default
 
-  set +e
   echo "Start all apps in $CF_ORG/$CF_SPACE ..."
   getApps
   echo ${APPS[@]} | xargs -n1 | xargs -P 5 -i cf start {}

--- a/etc/concourse/scripts/cf-deploy-stage
+++ b/etc/concourse/scripts/cf-deploy-stage
@@ -18,11 +18,14 @@ cf login -a https://api.$CF_SYS_DOMAIN -u $CF_USER -p $CF_PASSWORD -o $CF_ORG -s
 echo "Pushing $ABACUS_PROFILE Abacus installation ..."
 pushd built-project
   npm run cfstage -- $ABACUS_PROFILE
-popd
 
-echo "Mapping routes ..."
-mapRoutes ${ABACUS_PREFIX}abacus-usage-collector 6
-mapRoutes ${ABACUS_PREFIX}abacus-usage-reporting 6
+  echo "Mapping routes ..."
+  collectorApps=$(node_modules/abacus-etc/apprc lib/metering/collector/.apprc $ABACUS_PROFILE APPS)
+  mapRoutes ${ABACUS_PREFIX}abacus-usage-collector $collectorApps
+
+  reportingApps=$(node_modules/abacus-etc/apprc lib/aggregation/reporting/.apprc $ABACUS_PROFILE APPS)
+  mapRoutes ${ABACUS_PREFIX}abacus-usage-reporting $reportingApps
+popd
 
 if [ "$BIND_DB_SERVICE" == "true" ]; then
   echo "Binding services ..."

--- a/etc/concourse/scripts/common-functions
+++ b/etc/concourse/scripts/common-functions
@@ -22,10 +22,12 @@ function restartApps {
 }
 
 function restartAppsWithRetry {
+  set +e
   retries=$RESTART_RETRIES
   if [[ -z "$retries" ]]; then
     retries=5
   elif [[ $retries -eq 0 ]]; then
+    set -e
     return
   fi
 
@@ -38,6 +40,7 @@ function restartAppsWithRetry {
     restartApps
 
     if [[ $? -eq 0 ]]; then
+      set -e
       return
     fi
   done


### PR DESCRIPTION
Currently the restartAppsWithRetry function in /etc/concourse/scripts/common-functions does not set back the -e flag if there are no applications to restart. 