### PR TITLE
Fix restartAppsWithRetry logic

### DIFF
--- a/etc/concourse/scripts/common-functions
+++ b/etc/concourse/scripts/common-functions
@@ -22,10 +22,12 @@ function restartApps {
 }
 
 function restartAppsWithRetry {
+  set +e
   retries=$RESTART_RETRIES
   if [[ -z "$retries" ]]; then
     retries=5
   elif [[ $retries -eq 0 ]]; then
+    set -e
     return
   fi
 
@@ -38,6 +40,7 @@ function restartAppsWithRetry {
     restartApps
 
     if [[ $? -eq 0 ]]; then
+      set -e
       return
     fi
   done


### PR DESCRIPTION
Currently the restartAppsWithRetry function in /etc/concourse/scripts/common-functions does not set back the -e flag if there are no applications to restart.