### PR TITLE
Fail when creating or updating a service failed

### DIFF
--- a/etc/concourse/scripts/common-functions
+++ b/etc/concourse/scripts/common-functions
@@ -60,16 +60,18 @@ function waitForServices {
 }
 
 function createOrUpdateService {
-  set +e
+  set +e # Disable error checks
   cf service $1
-  if [ "$?" == "1" ]; then
+  return_code=$?
+  set -e # Enable error checks
+  
+  if [ "$return_code" == "1" ]; then
     echo "Creating new DB service instance $1 with plan $2 ..."
     cf create-service "$DB_SERVICE_NAME" $2 $1
   else
     echo "Updating DB service instance $1 with plan $2 ..."
     cf update-service $1 -p $2
   fi
-  set -e
 }
 
 function bindService {


### PR DESCRIPTION
In createOrUpdateService error checks where completely turned off. However this should only be the case for the check of the existance of the service via the "cf service" command. Otherwise errors during "cf create-service" or "cf update-service" go unnoticed. 
Even when these commands trigger an asynchronous action the return code is 0, which allows error checks to be enabled during the execution of these commands.