### PR TITLE
Extend oauth to work with custom endpoint

### DIFF
--- a/lib/plugins/authserver/src/index.js
+++ b/lib/plugins/authserver/src/index.js
@@ -35,7 +35,7 @@ routes.get('/v2/info', function *(req) {
 });
 
 // Retrieve OAuth bearer access token
-routes.get('/oauth/token', function *(req) {
+routes.post('/oauth/token', function *(req) {
   debug('Get OAuth bearer access token');
 
   // Default OAuth bearer access token

--- a/lib/plugins/authserver/src/test/test.js
+++ b/lib/plugins/authserver/src/test/test.js
@@ -67,7 +67,7 @@ describe('abacus-account-plugin', () => {
 
         // Get OAuth bearer access token with scopes using client credentials
         debug('Fetching new token...');
-        request.get('http://localhost::p/oauth/token?' +
+        request.post('http://localhost::p/oauth/token?' +
           'grant_type=client_credentials&scope=' +
           encodeURIComponent('test.scope.write test.scope.read'), {
             p: server.address().port

--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -4,6 +4,7 @@
 
 const _ = require('underscore');
 const jwt = require('jsonwebtoken');
+const lru = require('abacus-lrucache');
 const request = require('abacus-request');
 const retry = require('abacus-retry');
 
@@ -18,45 +19,58 @@ const edebug = require('abacus-debug')('e-abacus-oauth');
 const get = retry(request.get);
 const post = retry(request.post);
 
+const tokenEndpoints = lru({
+  max: 1000,
+  maxAge: 1000 * 60 * 60 // 1 hour
+});
+
 // Retrieve token endpoint from an authorization server
 const tokenEndpoint = (apiHostName, cb) => {
   debug('Retrieving token endpoint information from authorization server, %o',
     apiHostName);
 
-  get(apiHostName + '/v2/info', (err, val) => {
-    if (err) {
-      debug('Error getting oauth server information, %o', err);
-      cb(err);
-      return;
-    }
+  const cachedEndpoint = tokenEndpoints.get(apiHostName);
+  if (cachedEndpoint) {
+    debug('Retrieved token endpoint %o from cache', cachedEndpoint);
+    cb(undefined, cachedEndpoint);
+  }
+  else
+    get(apiHostName + '/v2/info', (err, val) => {
+      if (err) {
+        debug('Error getting oauth server information, %o', err);
+        cb(err);
+        return;
+      }
 
-    if (val.statusCode >= 400) {
-      debug('%s - %s - has returned an error - response %d' +
-        (val.body ? ' %o' : '%s'), val.request.method,
-        val.request.path, val.statusCode,
-        val.body || '');
-      cb(new Error('Unable to get oauth server information'));
-      return;
-    }
+      if (val.statusCode >= 400) {
+        debug('%s - %s - has returned an error - response %d' +
+          (val.body ? ' %o' : '%s'), val.request.method,
+          val.request.path, val.statusCode,
+          val.body || '');
+        cb(new Error('Unable to get oauth server information'));
+        return;
+      }
 
-    debug('Retrieved token endpoint %o', val.body.token_endpoint);
+      debug('Retrieved token endpoint %o from authorization server',
+        val.body.token_endpoint);
 
-    // Return endpoint host
-    if (val.body && val.body.token_endpoint)
-      cb(undefined, val.body.token_endpoint);
-    else
-      cb(new Error('Unable to get token endpoint from oauth server'));
-  });
+      // Return endpoint host
+      if (val.body && val.body.token_endpoint) {
+        tokenEndpoints.set(apiHostName, val.body.token_endpoint);
+        cb(undefined, val.body.token_endpoint);
+      }
+      else
+        cb(new Error('Unable to get token endpoint from oauth server'));
+    });
 };
 
 // Retrieve token from the endpoint using client credentials
 // OAuth trusted client flow.
-const newToken = (endpoint, method, path, clientId, secret, scopes, cb) => {
+const newToken = (endpoint, path, clientId, secret, scopes, cb) => {
   debug('Retrieving token from endpoint %o with client %s and scopes %s',
     endpoint, clientId, scopes);
 
-  const call = method === 'GET' ? get : method === 'POST' ? post : undefined;
-  call(`${endpoint}/${path}?grant_type=client_credentials` +
+  post(`${endpoint}/${path}?grant_type=client_credentials` +
     (scopes ? '&scope=' + encodeURIComponent(scopes) : ''), {
       headers: {
         authorization: 'Basic ' + new Buffer(clientId + ':' + secret)
@@ -225,8 +239,8 @@ const authorize = (auth, expectedScope) => {
   debug('Authorized request with scope %o', scopeToCheck);
 };
 
-const cache = (authServer, id, secret, scopes, method = 'GET',
-  path = 'oauth/token', isAuthServer = true) => {
+const cache = (authServer, id, secret, scopes, path = 'oauth/token',
+  isAuthServer = true) => {
   // Store OAuth bearer access token for reuse
   let token;
 
@@ -266,7 +280,7 @@ const cache = (authServer, id, secret, scopes, method = 'GET',
       debug('Getting OAuth bearer access token from endpoint %s for ' +
         'client %s and scopes %s', endpoint, id, scopes);
 
-      newToken(endpoint, method, path, id, secret, scopes, (err, t) => {
+      newToken(endpoint, path, id, secret, scopes, (err, t) => {
         if (err) {
           error(err);
           return;
@@ -338,7 +352,7 @@ const getBearerToken = (authServer, id, secret, scopes, cb) => {
     }
 
     // Get token endpoint from OAuth token endpoint
-    newToken(endpoint, 'GET', 'oauth/token', id, secret, scopes, (err, t) => {
+    newToken(endpoint, 'oauth/token', id, secret, scopes, (err, t) => {
       if (err) {
         edebug('Error getting OAuth bearer access token, %o', err);
         debug('Error getting OAuth bearer access token, %o', err);

--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -16,49 +16,48 @@ const debug = require('abacus-debug')('abacus-oauth');
 const edebug = require('abacus-debug')('e-abacus-oauth');
 
 const get = retry(request.get);
+const post = retry(request.post);
 
 // Retrieve token endpoint from an authorization server
 const tokenEndpoint = (apiHostName, cb) => {
   debug('Retrieving token endpoint information from authorization server, %o',
     apiHostName);
 
-  get(apiHostName + '/v2/info',
-    (err, val) => {
-      if (err) {
-        debug('Error getting oauth server information, %o', err);
-        cb(err);
-        return;
-      }
-
-      if (val.statusCode >= 400) {
-        debug('%s - %s - has returned an error - response %d' +
-          (val.body ? ' %o' : '%s'), val.request.method,
-          val.request.path, val.statusCode,
-          val.body || '');
-        cb(new Error('Unable to get oauth server information'));
-        return;
-      }
-
-      debug('Retrieved token endpoint %o', val.body.token_endpoint);
-
-      // Return endpoint host
-      if (val.body && val.body.token_endpoint)
-        cb(undefined, val.body.token_endpoint);
-      else
-        cb(new Error('Unable to get token endpoint from oauth server'));
+  get(apiHostName + '/v2/info', (err, val) => {
+    if (err) {
+      debug('Error getting oauth server information, %o', err);
+      cb(err);
+      return;
     }
-  );
+
+    if (val.statusCode >= 400) {
+      debug('%s - %s - has returned an error - response %d' +
+        (val.body ? ' %o' : '%s'), val.request.method,
+        val.request.path, val.statusCode,
+        val.body || '');
+      cb(new Error('Unable to get oauth server information'));
+      return;
+    }
+
+    debug('Retrieved token endpoint %o', val.body.token_endpoint);
+
+    // Return endpoint host
+    if (val.body && val.body.token_endpoint)
+      cb(undefined, val.body.token_endpoint);
+    else
+      cb(new Error('Unable to get token endpoint from oauth server'));
+  });
 };
 
 // Retrieve token from the endpoint using client credentials
 // OAuth trusted client flow.
-const newToken = (tokenEndpoint, clientId, secret, scopes, cb) => {
+const newToken = (endpoint, method, path, clientId, secret, scopes, cb) => {
   debug('Retrieving token from endpoint %o with client %s and scopes %s',
-    tokenEndpoint, clientId, scopes);
+    endpoint, clientId, scopes);
 
-  get(`${tokenEndpoint}/oauth/token?grant_type=client_credentials` +
-    (scopes ? '&scope=' + encodeURIComponent(scopes) : ''),
-    {
+  const call = method === 'GET' ? get : method === 'POST' ? post : undefined;
+  call(`${endpoint}/${path}?grant_type=client_credentials` +
+    (scopes ? '&scope=' + encodeURIComponent(scopes) : ''), {
       headers: {
         authorization: 'Basic ' + new Buffer(clientId + ':' + secret)
           .toString('base64')
@@ -226,7 +225,8 @@ const authorize = (auth, expectedScope) => {
   debug('Authorized request with scope %o', scopeToCheck);
 };
 
-const cache = (authServer, id, secret, scopes) => {
+const cache = (authServer, id, secret, scopes, method = 'GET',
+  path = 'oauth/token', isAuthServer = true) => {
   // Store OAuth bearer access token for reuse
   let token;
 
@@ -262,32 +262,40 @@ const cache = (authServer, id, secret, scopes) => {
       done(err);
     };
 
-    // Get OAuth bearer access token
-    const get = () => {
+    const getToken = (endpoint) => {
       debug('Getting OAuth bearer access token from endpoint %s for ' +
-        'client %s and scopes %s', authServer, id, scopes);
-      // Get token endpoint from OAuth server
-      tokenEndpoint(authServer, (err, endpoint) => {
+        'client %s and scopes %s', endpoint, id, scopes);
+
+      newToken(endpoint, method, path, id, secret, scopes, (err, t) => {
         if (err) {
           error(err);
           return;
         }
 
-        // Get token from the OAuth token endpoint
-        newToken(endpoint, id, secret, scopes, (err, t) => {
+        debug('Got OAuth bearer access token');
+        token = t;
+        // Convert token expiration period from seconds to milliseconds
+        // Without conversion, the token will refresh every 2 minutes
+        refresh(Math.max(token.expires_in * 1000 - 120000, 120000));
+        done();
+      });
+    };
+
+    // Get OAuth bearer access token
+    const get = () => {
+      // Get token from the OAuth token endpoint
+      if (isAuthServer)
+        // Get token endpoint from OAuth server
+        tokenEndpoint(authServer, (err, endpoint) => {
           if (err) {
             error(err);
             return;
           }
 
-          debug('Got OAuth bearer access token');
-          token = t;
-          // Convert token expiration period from seconds to milliseconds
-          // Without conversion, the token will refresh every 2 minutes
-          refresh(Math.max(token.expires_in * 1000 - 120000, 120000));
-          done();
+          getToken(endpoint);
         });
-      });
+      else
+        getToken(authServer);
     };
 
     // start to get OAuth bearer access token
@@ -330,7 +338,7 @@ const getBearerToken = (authServer, id, secret, scopes, cb) => {
     }
 
     // Get token endpoint from OAuth token endpoint
-    newToken(endpoint, id, secret, scopes, (err, t) => {
+    newToken(endpoint, 'GET', 'oauth/token', id, secret, scopes, (err, t) => {
       if (err) {
         edebug('Error getting OAuth bearer access token, %o', err);
         debug('Error getting OAuth bearer access token, %o', err);

--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -32,7 +32,7 @@ const tokenEndpoint = (apiHostName, cb) => {
   const cachedEndpoint = tokenEndpoints.get(apiHostName);
   if (cachedEndpoint) {
     debug('Retrieved token endpoint %o from cache', cachedEndpoint);
-    cb(undefined, cachedEndpoint);
+    setImmediate(() => cb(undefined, cachedEndpoint));
   }
   else
     get(apiHostName + '/v2/info', (err, val) => {

--- a/lib/utils/oauth/src/test/test.js
+++ b/lib/utils/oauth/src/test/test.js
@@ -300,7 +300,8 @@ describe('abacus-oauth', () => {
     }
   });
 
-  const checkTokens = (invalidToken, validToken, done) => {
+  const checkTokens = (invalidToken, validToken, callsCount, expectedCallsCount,
+    done) => {
     invalidToken.start((err) => {
       expect(err).to.deep.equal(new Error('Unable to get OAuth token'));
       expect(invalidToken()).to.equal(undefined);
@@ -322,6 +323,10 @@ describe('abacus-oauth', () => {
         // restore the clock
         clock.restore();
 
+        // Check calls to the authorization server endpoint
+        if (callsCount)
+          expect(callsCount()).to.equal(expectedCallsCount);
+
         done();
       });
     });
@@ -332,13 +337,15 @@ describe('abacus-oauth', () => {
     const app = express();
 
     // Add auth server REST endpoints
+    let callsCount = 0;
     app.get('/v2/info', (req, res) => {
+      callsCount++;
       res.send({
         token_endpoint: [req.protocol, '://', req.headers.host].join('')
       });
     });
 
-    app.get('/oauth/token', (req, res) => {
+    app.post('/oauth/token', (req, res) => {
       if (req.query.scope === 'invalid') {
         res.status(400).end();
         return;
@@ -357,7 +364,7 @@ describe('abacus-oauth', () => {
     const validToken = oauth.cache('http://localhost:' +
       server.address().port, 'valid', 'secret', 'scopes');
 
-    checkTokens(invalidToken, validToken, done);
+    checkTokens(invalidToken, validToken, () => callsCount, 1, done);
   });
 
   it('get OAuth bearer access token using cache directly', (done) => {
@@ -379,13 +386,13 @@ describe('abacus-oauth', () => {
     // Unable to get a token from auth server's token endpoint
     const invalidToken = oauth.cache('http://localhost:' +
       server.address().port, 'valid', 'secret', 'invalid',
-      'POST', 'oauth2/api/v1/token', false);
+      'oauth2/api/v1/token', false);
 
     const validToken = oauth.cache('http://localhost:' +
       server.address().port, 'valid', 'secret', 'scopes',
-      'POST', 'oauth2/api/v1/token', false);
+      'oauth2/api/v1/token', false);
 
-    checkTokens(invalidToken, validToken, done);
+    checkTokens(invalidToken, validToken, undefined, undefined, done);
   });
 
   it('authorization server responds with errors', (done) => {
@@ -409,7 +416,7 @@ describe('abacus-oauth', () => {
         res.status(500).end();
     });
 
-    app.get('/oauth/token', (req, res) => {
+    app.post('/oauth/token', (req, res) => {
       res.status(500).end();
     });
 
@@ -475,7 +482,7 @@ describe('abacus-oauth', () => {
       });
     });
 
-    app.get('/oauth/token', (req, res) => {
+    app.post('/oauth/token', (req, res) => {
       if (req.query.scope === 'invalid') {
         res.status(400).end();
         return;
@@ -523,7 +530,7 @@ describe('abacus-oauth', () => {
         res.send({ token_endpoint: [req.protocol, '://',
           req.headers.host].join('') });
       });
-      api.get('/oauth/token', (req, res) => {
+      api.post('/oauth/token', (req, res) => {
         if (typeof oauthTokenResponse === 'number')
           res.sendStatus(oauthTokenResponse);
         else

--- a/lib/utils/oauth/src/test/test.js
+++ b/lib/utils/oauth/src/test/test.js
@@ -300,6 +300,33 @@ describe('abacus-oauth', () => {
     }
   });
 
+  const checkTokens = (invalidToken, validToken, done) => {
+    invalidToken.start((err) => {
+      expect(err).to.deep.equal(new Error('Unable to get OAuth token'));
+      expect(invalidToken()).to.equal(undefined);
+
+      // Now try a valid token and let it expire and refresh the token
+
+      // Setup a fake time
+      const clock = sinon.useFakeTimers(moment.now(),
+        'Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval');
+
+      validToken.start((err) => {
+        expect(err).to.equal(undefined);
+        expect(validToken()).to.equal('Bearer AAA');
+
+        // Let the token be refreshed
+        clock.tick(1000 * 3600 * 2 + 1);
+        expect(validToken()).to.equal('Bearer AAA');
+
+        // restore the clock
+        clock.restore();
+
+        done();
+      });
+    });
+  };
+
   it('get OAuth bearer access token using cache', (done) => {
     // Create a test Express application
     const app = express();
@@ -324,36 +351,41 @@ describe('abacus-oauth', () => {
     const server = app.listen(0);
 
     // Unable to get a token from auth server's token endpoint
-    const invalidtoken = oauth.cache('http://localhost:' +
+    const invalidToken = oauth.cache('http://localhost:' +
       server.address().port, 'valid', 'secret', 'invalid');
 
-    invalidtoken.start((err) => {
-      expect(err).to.deep.equal(new Error('Unable to get OAUTH token'));
-      expect(invalidtoken()).to.equal(undefined);
+    const validToken = oauth.cache('http://localhost:' +
+      server.address().port, 'valid', 'secret', 'scopes');
 
-      // Now try a valid token and let it expire and refresh the token
+    checkTokens(invalidToken, validToken, done);
+  });
 
-      // Setup a fake time
-      const clock = sinon.useFakeTimers(moment.now(),
-      'Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval');
+  it('get OAuth bearer access token using cache directly', (done) => {
+    // Create a test Express application
+    const app = express();
 
-      const validToken = oauth.cache('http://localhost:' +
-        server.address().port, 'valid', 'secret', 'scopes');
+    app.post('/oauth2/api/v1/token', (req, res) => {
+      if (req.query.scope === 'invalid') {
+        res.status(400).end();
+        return;
+      }
 
-      validToken.start((err) => {
-        expect(err).to.equal(undefined);
-        expect(validToken()).to.equal('Bearer AAA');
-
-        // Let the token be refreshed
-        clock.tick(1000 * 3600 * 2 + 1);
-        expect(validToken()).to.equal('Bearer AAA');
-
-        // restore the clock
-        clock.restore();
-
-        done();
-      });
+      res.send({ access_token: 'AAA', token_type: 'bearer', expires_in: 1 });
     });
+
+    // Listen on an ephemeral port
+    const server = app.listen(0);
+
+    // Unable to get a token from auth server's token endpoint
+    const invalidToken = oauth.cache('http://localhost:' +
+      server.address().port, 'valid', 'secret', 'invalid',
+      'POST', 'oauth2/api/v1/token', false);
+
+    const validToken = oauth.cache('http://localhost:' +
+      server.address().port, 'valid', 'secret', 'scopes',
+      'POST', 'oauth2/api/v1/token', false);
+
+    checkTokens(invalidToken, validToken, done);
   });
 
   it('authorization server responds with errors', (done) => {

--- a/test/cf/multiple-apps/src/test/test.js
+++ b/test/cf/multiple-apps/src/test/test.js
@@ -182,7 +182,7 @@ describe('abacus-cf multiple-apps-test with oAuth', () => {
         token_endpoint: 'http://localhost:' + serverPort
       });
     });
-    routes.get('/oauth/token', (request, response) => {
+    routes.post('/oauth/token', (request, response) => {
       oAuthDebug('Requested oAuth token with %j', request.query);
       const scope = request.query.scope;
       const containerToken = scope && scope.indexOf('container') > 0;

--- a/test/cf/purge/src/test/purge-test.js
+++ b/test/cf/purge/src/test/purge-test.js
@@ -199,7 +199,7 @@ const test = (secured) => {
         token_endpoint: 'http://localhost:' + serverPort
       });
     });
-    routes.get('/oauth/token', (request, response) => {
+    routes.post('/oauth/token', (request, response) => {
       oAuthDebug('Requested oAuth token with %j', request.query);
       const scope = request.query.scope;
       const containerToken = scope && scope.indexOf('container') > 0;

--- a/test/cf/renewer/src/test/irrelevant-usage-test.js
+++ b/test/cf/renewer/src/test/irrelevant-usage-test.js
@@ -183,7 +183,7 @@ const test = (secured) => {
         token_endpoint: 'http://localhost:' + serverPort
       });
     });
-    routes.get('/oauth/token', (request, response) => {
+    routes.post('/oauth/token', (request, response) => {
       oAuthDebug('Requested oAuth token with %j', request.query);
       const scope = request.query.scope;
       const containerToken = scope && scope.indexOf('container') > 0;

--- a/test/cf/single-app/src/test/accuracy-test.js
+++ b/test/cf/single-app/src/test/accuracy-test.js
@@ -185,7 +185,7 @@ describe('abacus-cf-single-app-accuracy-itest', () => {
         token_endpoint: 'http://localhost:' + serverPort
       });
     });
-    routes.get('/oauth/token', (request, response) => {
+    routes.post('/oauth/token', (request, response) => {
       oAuthDebug('Requested oAuth token with %j', request.query);
       const scope = request.query.scope;
       const containerToken = scope && scope.indexOf('container') > 0;

--- a/test/cf/single-app/src/test/bridge-test.js
+++ b/test/cf/single-app/src/test/bridge-test.js
@@ -201,7 +201,7 @@ describe('abacus-cf-single-app-bridge-itest without oAuth', () => {
         token_endpoint: 'http://localhost:' + serverPort
       });
     });
-    routes.get('/oauth/token', (request, response) => {
+    routes.post('/oauth/token', (request, response) => {
       oAuthDebug('Requested oAuth token with %j', request.query);
       const scope = request.query.scope;
       const containerToken = scope && scope.indexOf('container') > 0;

--- a/test/cf/single-app/src/test/renewer-test.js
+++ b/test/cf/single-app/src/test/renewer-test.js
@@ -185,7 +185,7 @@ describe('abacus-cf-single-app-renewer-itest without oAuth', () => {
         token_endpoint: 'http://localhost:' + serverPort
       });
     });
-    routes.get('/oauth/token', (request, response) => {
+    routes.post('/oauth/token', (request, response) => {
       oAuthDebug('Requested oAuth token with %j', request.query);
       const scope = request.query.scope;
       const containerToken = scope && scope.indexOf('container') > 0;

--- a/test/cf/slack-window/src/test/bridge-test.js
+++ b/test/cf/slack-window/src/test/bridge-test.js
@@ -199,7 +199,7 @@ const test = (secured) => {
         token_endpoint: 'http://localhost:' + serverPort
       });
     });
-    routes.get('/oauth/token', (request, response) => {
+    routes.post('/oauth/token', (request, response) => {
       oAuthDebug('Requested oAuth token with %j', request.query);
       const scope = request.query.scope;
       const containerToken = scope && scope.indexOf('container') > 0;

--- a/test/cf/slack-window/src/test/renewer-test.js
+++ b/test/cf/slack-window/src/test/renewer-test.js
@@ -181,7 +181,7 @@ const test = (secured) => {
         token_endpoint: 'http://localhost:' + serverPort
       });
     });
-    routes.get('/oauth/token', (request, response) => {
+    routes.post('/oauth/token', (request, response) => {
       oAuthDebug('Requested oAuth token with %j', request.query);
       const scope = request.query.scope;
       const containerToken = scope && scope.indexOf('container') > 0;

--- a/test/cf/timeshift/src/test/renewer-test.js
+++ b/test/cf/timeshift/src/test/renewer-test.js
@@ -394,7 +394,7 @@ runWithPersistentDB('abacus-cf-renewer time shift', () => {
         token_endpoint: 'http://localhost:' + serverPort
       });
     });
-    routes.get('/oauth/token', (request, response) => {
+    routes.post('/oauth/token', (request, response) => {
       oAuthDebug('Requested oAuth token with %j', request.query);
       const scope = request.query.scope;
       const containerToken = scope && scope.indexOf('container') > 0;


### PR DESCRIPTION
1. Extend OAuth to work with custom endpoint and token path
2. Use "POST" method when making access token requests according to [RFC6749](https://tools.ietf.org/html/rfc6749#section-3.2)
3. Cache the token endpoint retrieved from CF API

Signed-off-by: Stoyan Rachev <stoyanr@gmail.com>
