### PR TITLE
Fix 'eventTime' timestamp to prevent conflict error 409 (conflict) 

### DIFF
--- a/lib/cf/bridge/src/index.js
+++ b/lib/cf/bridge/src/index.js
@@ -270,7 +270,7 @@ const modifyUsage = (usage, event) => {
   return usage;
 };
 
-const buildAppUsage = (event, stopped = false) => {
+const buildAppUsage = (event, eventTime, stopped = false) => {
   const modifiableUsageProperties = {
     currentRunningInstances: event.entity.instance_count,
     previousRunningInstances: event.entity.previous_instance_count,
@@ -291,7 +291,6 @@ const buildAppUsage = (event, stopped = false) => {
     usage.currentRunningInstances = 0;
   }
 
-  const eventTime = moment.utc(event.metadata.created_at).valueOf();
   return {
     start: eventTime,
     end: eventTime,
@@ -382,6 +381,17 @@ const resetReportingTimeout = (fn, config) => {
   setReportingTimeout(fn, config.minInterval);
 };
 
+const shiftStopEventTime = (event) => {
+  const eventTime = moment.utc(event.metadata.created_at).valueOf();
+  if (event.entity.state === 'STOPPED' && 
+    event.entity.previous_state === 'STARTED') {
+    debug('shift create_at timestamp on STOPPED event');
+    const shifteventTime = eventTime - 1;
+    return shifteventTime;
+  };
+  return eventTime;
+};
+
 const reportAppUsage = (cfToken, abacusToken, { failure, success }) => {
   if (secured && !abacusToken()) {
     setReportingTimeout(() =>
@@ -404,7 +414,8 @@ const reportAppUsage = (cfToken, abacusToken, { failure, success }) => {
   paging.readPage(uri, cfToken, perf, statistics, {
     processResourceFn: (resource, done) => {
       const t0 = moment.now();
-      const usage = buildAppUsage(resource);
+      const eventTime = shiftStopEventTime(resource);
+      const usage = buildAppUsage(resource, eventTime);
 
       if (usage && isElder(resource) && isRequested(resource)) {
         debug('Reporting usage event %j', usage);
@@ -517,11 +528,12 @@ const purgeCompensation = (cfToken, abacusToken, { failure, success }) => {
   paging.readPage(uri, cfToken, perf, statistics, {
     processResourceFn: (resource, done) => {
       const t0 = moment.now();
+      const eventTime = shiftStopEventTime(resource);
       let guid = resource.entity.app_guid;
 
       if (resource.entity.state === 'STARTED') {
         if (cache.apps.indexOf(guid) < 0) {
-          const usage = buildAppUsage(resource, true);
+          const usage = buildAppUsage(resource, eventTime, true);
           if (usage) {
             debug('Submitting STOP usage for app %s', guid);
             reportUsage(usage, abacusToken,(error, response) => {


### PR DESCRIPTION
https://github.com/cloudfoundry-incubator/cf-abacus/issues/631

Fix bridge to prevent conflict error when bridge tries to report start&stop events for the same point in time

To avoid this issue, when the `STOPPED` event occurs shift timestamp 1ms (0.001s)

```
2017-06-22T08:57:56.70+0000 [APP/PROC/WEB/0]OUT 2017-06-22T08:57:56.705Z abacus-cf-bridge 54 Skipping report for non-elder usage event {"start":1498121866999,"end":1498121866999,"organization_id":"27e690d5-7cc0-48e4-8104-80b7ce6ea0ef","space_id":"73abc51c-6219-4f8e-ae3c-c423d676aedf","consumer_id":"app:fd96a416-c1d0-41ce-8551-99be4a9c799a","resource_id":"linux-container","plan_id":"standard","resource_instance_id":"memory:fd96a416-c1d0-41ce-8551-99be4a9c799a","measured_usage":[{"measure":"current_instance_memory","quantity":0},{"measure":"current_running_instances","quantity":0},{"measure":"previous_instance_memory","quantity":67108864},{"measure":"previous_running_instances","quantity":1}]}
2017-06-22T08:57:56.70+0000 [APP/PROC/WEB/0]OUT 2017-06-22T08:57:56.705Z abacus-cf-bridge 54 Initial start event detected. Setting previous memory and instances to 0
2017-06-22T08:57:56.70+0000 [APP/PROC/WEB/0]OUT 2017-06-22T08:57:56.705Z abacus-cf-bridge 54 Resource 8c104cf2-293c-4b81-921c-bd9364a6eec1 has age 9705. Minimum resource age is 60000. Elder: false
2017-06-22T08:57:56.70+0000 [APP/PROC/WEB/0]OUT 2017-06-22T08:57:56.705Z abacus-cf-bridge 54 Skipping report for non-elder usage event {"start":1498121867000,"end":1498121867000,"organization_id":"27e690d5-7cc0-48e4-8104-80b7ce6ea0ef","space_id":"73abc51c-6219-4f8e-ae3c-c423d676aedf","consumer_id":"app:fd96a416-c1d0-41ce-8551-99be4a9c799a","resource_id":"linux-container","plan_id":"standard","resource_instance_id":"memory:fd96a416-c1d0-41ce-8551-99be4a9c799a","measured_usage":[{"measure":"current_instance_memory","quantity":67108864},{"measure":"current_running_instances","quantity":1},{"measure":"previous_instance_memory","quantity":0},{"measure":"previous_running_instances","quantity":0}]}
```

