### PR TITLE
Remove request param code duplication in dataflow

### DIFF
--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -514,6 +514,26 @@ const errordb = (dbname, dbh) => !dbname ? undefined :
 // Error list time limit (1 month)
 const errorTimeLimit = 2629746000;
 
+const requestParamPairs = (req) => pairs(req.params);
+
+const findRequestParams = (req, predicate) =>
+  filter(requestParamPairs(req), (pair) => predicate(pair[0]));
+
+const requestParam = (req, predicate) =>
+  map(findRequestParams(req, predicate), (pair) => pair[1]).join('/');
+
+const requestKeyParam = (req) =>
+  requestParam(req, (name) => /^k/.test(name));
+
+const requestTimeParam = (req) =>
+  requestParam(req, (name) => /^t/.test(name));
+
+const requestStartParam = (req) =>
+  requestParam(req, (name) => /^tstart/.test(name));
+
+const requestEndParam = (req) =>
+  requestParam(req, (name) => /^tend/.test(name));
+
 const buildPlayResponse = (req, opt, played) => {
   return extend({
     statusCode: 201,
@@ -669,10 +689,8 @@ const mapper = (mapfn, opt) => {
   // Retrieve an input doc
   if(opt.input.get)
     routes.get(opt.input.get, throttle(function *(req) {
-      const ks = map(filter(
-        pairs(req.params), (p) => /^k/.test(p[0])), (p) => p[1]).join('/');
-      const ts = map(filter(
-        pairs(req.params), (p) => /^t/.test(p[0])), (p) => p[1]).join('/');
+      const ks = requestKeyParam(req);
+      const ts = requestTimeParam(req);
       const id = dbclient.tkuri(ks, ts);
       debug('Retrieving input doc for id %s', id);
       const doc = yield idb.get(id);
@@ -694,10 +712,8 @@ const mapper = (mapfn, opt) => {
   // Retrieve an output doc
   if(opt.output.get)
     routes.get(opt.output.get, throttle(function *(req) {
-      const ks = map(filter(
-        pairs(req.params), (p) => /^k/.test(p[0])), (p) => p[1]).join('/');
-      const ts = map(filter(
-        pairs(req.params), (p) => /^t/.test(p[0])), (p) => p[1]).join('/');
+      const ks = requestKeyParam(req);      
+      const ts = requestTimeParam(req);
       const id = dbclient.kturi(ks, ts);
       debug('Retrieving output doc for id %s', id);
       const doc = yield odb.get(id);
@@ -719,10 +735,8 @@ const mapper = (mapfn, opt) => {
   // Retrieve error docs
   if(opt.error && opt.error.get)
     routes.get(opt.error.get, throttle(function *(req) {
-      const start = map(filter(
-        pairs(req.params), (p) => /^tstart/.test(p[0])), (p) => p[1]).join('/');
-      const end = map(filter(
-        pairs(req.params), (p) => /^tend/.test(p[0])), (p) => p[1]).join('/');
+      const start = requestStartParam(req);
+      const end = requestEndParam(req);
 
       if (end - start > errorTimeLimit) {
         const msg = 'Cannot retrieve error docs older than ' +
@@ -761,10 +775,8 @@ const mapper = (mapfn, opt) => {
   // Delete an error doc
   if(opt.error && opt.error.delete)
     routes.delete(opt.error.delete, throttle(function *(req) {
-      const ks = map(filter(
-        pairs(req.params), (p) => /^k/.test(p[0])), (p) => p[1]).join('/');
-      const ts = map(filter(
-        pairs(req.params), (p) => /^t/.test(p[0])), (p) => p[1]).join('/');
+      const ks = requestKeyParam(req);
+      const ts = requestTimeParam(req);
 
       let client = 'unknown';
       if (req.headers && req.headers.authorization) {
@@ -1057,10 +1069,8 @@ const reducer = (reducefn, opt) => {
   // Retrieve an input doc
   if(opt.input.get)
     routes.get(opt.input.get, throttle(function *(req) {
-      const ks = map(filter(
-        pairs(req.params), (p) => /^k/.test(p[0])), (p) => p[1]).join('/');
-      const ts = map(filter(
-        pairs(req.params), (p) => /^t/.test(p[0])), (p) => p[1]).join('/');
+      const ks = requestKeyParam(req);
+      const ts = requestTimeParam(req);
       const id = dbclient.tkuri(ks, ts);
       debug('Retrieving input doc for id %s', id);
       const doc = yield idb.get(id);
@@ -1082,10 +1092,8 @@ const reducer = (reducefn, opt) => {
   // Retrieve an output doc
   if(opt.output.get)
     routes.get(opt.output.get, throttle(function *(req) {
-      const ks = map(filter(
-        pairs(req.params), (p) => /^k/.test(p[0])), (p) => p[1]).join('/');
-      const ts = map(filter(
-        pairs(req.params), (p) => /^t/.test(p[0])), (p) => p[1]).join('/');
+      const ks = requestKeyParam(req);
+      const ts = requestTimeParam(req);
       const id = dbclient.kturi(ks, ts);
       debug('Retrieving output doc for id %s', id);
       const doc = yield odb.get(id);
@@ -1107,10 +1115,8 @@ const reducer = (reducefn, opt) => {
   // Retrieve error docs
   if(opt.error && opt.error.get)
     routes.get(opt.error.get, throttle(function *(req) {
-      const start = map(filter(
-        pairs(req.params), (p) => /^tstart/.test(p[0])), (p) => p[1]).join('/');
-      const end = map(filter(
-        pairs(req.params), (p) => /^tend/.test(p[0])), (p) => p[1]).join('/');
+      const start = requestStartParam(req);
+      const end = requestEndParam(req);
 
       if (end - start > errorTimeLimit) {
         const msg = 'Cannot retrieve error docs older than ' +
@@ -1149,10 +1155,8 @@ const reducer = (reducefn, opt) => {
   // Delete an error doc
   if(opt.error && opt.error.delete)
     routes.delete(opt.error.delete, throttle(function *(req) {
-      const ks = map(filter(
-        pairs(req.params), (p) => /^k/.test(p[0])), (p) => p[1]).join('/');
-      const ts = map(filter(
-        pairs(req.params), (p) => /^t/.test(p[0])), (p) => p[1]).join('/');
+      const ks = requestKeyParam(req);      
+      const ts = requestTimeParam(req);
 
       let client = 'unknown';
       if (req.headers && req.headers.authorization) {


### PR DESCRIPTION
While exploring the dataflow code I noticed a significant amount of code duplication in request param processing. This change extracts the duplicate code in a few helper functions.

**Note:** The the `join` operation that is performed on the filtered parameters is still strange to me, but I decided to keep it as is. Any idea if that is ever used? Do we ever specify a regular expression that captures multiple params, which we then want to join with `/`? Do we even get any guarantee as to the order of the params to rely on such behavior?

Ideally, these functions could be extracted into a separate module that deals with stuff related to REST calls and REST processing. My personal feeling is that the dataflow module is overloaded with business, presentation, and storage logic, all of which should be separated.