### PR TITLE
Remove unused auth param in dataflow tests

### DIFF
--- a/lib/utils/dataflow/src/test/test.js
+++ b/lib/utils/dataflow/src/test/test.js
@@ -1439,7 +1439,7 @@ describe('abacus-dataflow', () => {
 
       // Define a test reduce transform that accumulates the sum of
       // numbers
-      const sum = function *(accum, udoc, auth) {
+      const sum = function *(accum, udoc) {
         const p = accum[0] || {
           val: 0
         };
@@ -1614,7 +1614,7 @@ describe('abacus-dataflow', () => {
 
       // Define a test reduce transform that accumulates the sum of
       // numbers
-      const sum = function *(accum, udoc, auth) {
+      const sum = function *(accum, udoc) {
         const p = accum[0] || {
           val: 0
         };
@@ -1799,7 +1799,7 @@ describe('abacus-dataflow', () => {
 
       // Define a test reduce transform that accumulates the sum of
       // numbers
-      const sum = function *(accum, udoc, auth) {
+      const sum = function *(accum, udoc) {
         const p = accum[0] || {
           val: 0
         };
@@ -1970,7 +1970,7 @@ describe('abacus-dataflow', () => {
 
       // Define a test reduce transform that accumulates the sum of
       // numbers
-      const bigSum = function *(accum, udoc, auth) {
+      const bigSum = function *(accum, udoc) {
         if(udoc.x < 7)
           return [extend({
             t: udoc.t,
@@ -2147,7 +2147,7 @@ describe('abacus-dataflow', () => {
 
       // Define a test reduce transform that accumulates the sum of
       // numbers
-      const bigSum = function *(accum, udoc, auth) {
+      const bigSum = function *(accum, udoc) {
         if(udoc.x < 7)
           return [extend({
             t: udoc.t,
@@ -2290,7 +2290,7 @@ describe('abacus-dataflow', () => {
 
         // Define a test reduce transform that accumulates the sum of
         // numbers
-        const bigSum = function *(accum, udoc, auth) {
+        const bigSum = function *(accum, udoc) {
           const p = accum[0] || {
             val: 0
           };
@@ -2466,7 +2466,7 @@ describe('abacus-dataflow', () => {
         validate: (doc) => doc
       };
 
-      const multiDoc = function *(accum, udoc, auth) {
+      const multiDoc = function *(accum, udoc) {
         const p = accum[0] || {
           val: 0
         };
@@ -2670,7 +2670,7 @@ describe('abacus-dataflow', () => {
 
         // Define a test reduce transform that accumulates the sum of
         // numbers
-        const bigSum = function *(accum, udoc, auth) {
+        const bigSum = function *(accum, udoc) {
           if (udoc.x < 7)
             return [extend({
               t: udoc.t,
@@ -3057,9 +3057,7 @@ describe('abacus-dataflow', () => {
 
         // Define a test reduce transform that accumulates the sum of
         // numbers
-        const sum = function *(accum, udoc, auth) {
-          expect(auth).to.equal(undefined, 'Unexpected auth token/header');
-
+        const sum = function *(accum, udoc) {
           const p = accum[0] || {
             val: 0
           };


### PR DESCRIPTION
The `dataflow` tests don't make any use of the `auth` parameter, so we might as well remove it. 

Either way, the `dataflow` implementation never does pass an `auth` parameter to the `reduce` function (https://github.com/cloudfoundry-incubator/cf-abacus/blob/933c1cf3f4e03d32a4e6d0b2571ea9f83c96e17d/lib/utils/dataflow/src/index.js#L834). 

That was probably the case a while back, and was not properly aligned in the tests when removed.
