### PR TITLE
Remove authorization duplication in dataflow

### DIFF
--- a/lib/utils/dataflow/src/index.js
+++ b/lib/utils/dataflow/src/index.js
@@ -514,6 +514,27 @@ const errordb = (dbname, dbh) => !dbname ? undefined :
 // Error list time limit (1 month)
 const errorTimeLimit = 2629746000;
 
+const getAuthorization = (req) =>
+  req && req.headers && req.headers.authorization;
+
+const assureReadAuthorized = (cfg, req, doc) => {
+  if (!cfg.rscope)
+    return;
+  oauth.authorize(getAuthorization(req), cfg.rscope(doc));
+};
+
+const assureWriteAuthorized = (cfg, req, doc) => {
+  if (!cfg.wscope)
+    return;
+  oauth.authorize(getAuthorization(req), cfg.wscope(doc));
+};
+
+const assureDeleteAuthorized = (cfg, req) => {
+  if (!cfg.dscope)
+    return;
+  oauth.authorize(getAuthorization(req), cfg.dscope());
+};
+
 const buildPlayResponse = (req, opt, played) => {
   return extend({
     statusCode: 201,
@@ -652,15 +673,10 @@ const mapper = (mapfn, opt) => {
     if(opt.input.schema)
       opt.input.schema.validate(idoc);
 
-    // Request authorization information
-    const auth = req && req.headers && req.headers.authorization;
-
-    // Authorize using input write access
-    if (opt.input.wscope)
-      oauth.authorize(auth, opt.input.wscope(idoc));
+    assureWriteAuthorized(opt.input, req, idoc);
 
     // Process the input doc
-    const played = yield play(idoc, auth);
+    const played = yield play(idoc, getAuthorization(req));
 
     // Return the input doc location
     return buildPlayResponse(req, opt, played);
@@ -681,10 +697,7 @@ const mapper = (mapfn, opt) => {
           statusCode: 404
         };
 
-      // Authorize using input read access
-      if (opt.input.rscope)
-        oauth.authorize(req.headers && req.headers.authorization,
-          opt.input.rscope(doc));
+      assureReadAuthorized(opt.input, req, doc);
 
       return {
         body: dbclient.undbify(doc)
@@ -706,10 +719,7 @@ const mapper = (mapfn, opt) => {
           statusCode: 404
         };
 
-      // Authorize using output read access
-      if (opt.output.rscope)
-        oauth.authorize(req.headers && req.headers.authorization,
-          opt.output.rscope(doc));
+      assureReadAuthorized(opt.output, req, doc);
 
       return {
         body: dbclient.undbify(doc)
@@ -746,10 +756,7 @@ const mapper = (mapfn, opt) => {
         include_docs: true
       });
 
-      // Authorize using error read access
-      if (opt.error.rscope)
-        oauth.authorize(req.headers && req.headers.authorization,
-          opt.error.rscope(docs));
+      assureReadAuthorized(opt.error, req, docs);
 
       return {
         body: map(docs.rows, (row) => {
@@ -767,15 +774,13 @@ const mapper = (mapfn, opt) => {
         pairs(req.params), (p) => /^t/.test(p[0])), (p) => p[1]).join('/');
 
       let client = 'unknown';
-      if (req.headers && req.headers.authorization) {
-        let authHeader = req.headers.authorization.replace(/^bearer /i, '');
+      const auth = getAuthorization(req);
+      if (auth) {
+        let authHeader = auth.replace(/^bearer /i, '');
         client = oauth.getUserInfo(authHeader);
       }
 
-      // Authorize using error delete access
-      if (opt.error.dscope)
-        oauth.authorize(req.headers && req.headers.authorization,
-          opt.error.dscope());
+      assureDeleteAuthorized(opt.error, req);
 
       // Get doc from edb
       const id = dbclient.tkuri(ks, ts);
@@ -1040,15 +1045,10 @@ const reducer = (reducefn, opt) => {
     if(opt.input.schema)
       opt.input.schema.validate(idoc);
 
-    // Request authorization information
-    const auth = req && req.headers && req.headers.authorization;
-
-    // Authorize using input write access
-    if (opt.input.wscope)
-      oauth.authorize(auth, opt.input.wscope(idoc));
+    assureWriteAuthorized(opt.input, req, idoc);
 
     // Process the input doc
-    const played = yield play(idoc, auth);
+    const played = yield play(idoc, getAuthorization(req));
 
     // Return the input doc location
     return buildPlayResponse(req, opt, played);
@@ -1069,10 +1069,7 @@ const reducer = (reducefn, opt) => {
           statusCode: 404
         };
 
-      // Authorize using input read access
-      if (opt.input.rscope)
-        oauth.authorize(req.headers && req.headers.authorization,
-          opt.input.rscope(doc));
+      assureReadAuthorized(opt.input, req, doc);
 
       return {
         body: dbclient.undbify(doc)
@@ -1094,10 +1091,7 @@ const reducer = (reducefn, opt) => {
           statusCode: 404
         };
 
-      // Authorize using output read access
-      if (opt.output.rscope)
-        oauth.authorize(req.headers && req.headers.authorization,
-          opt.output.rscope(doc));
+      assureReadAuthorized(opt.output, req, doc);
 
       return {
         body: dbclient.undbify(doc)
@@ -1134,10 +1128,7 @@ const reducer = (reducefn, opt) => {
         include_docs: true
       });
 
-      // Authorize using error read access
-      if (opt.error.rscope)
-        oauth.authorize(req.headers && req.headers.authorization,
-          opt.error.rscope(docs));
+      assureReadAuthorized(opt.error, req, docs);
 
       return {
         body: map(docs.rows, (row) => {
@@ -1155,15 +1146,13 @@ const reducer = (reducefn, opt) => {
         pairs(req.params), (p) => /^t/.test(p[0])), (p) => p[1]).join('/');
 
       let client = 'unknown';
-      if (req.headers && req.headers.authorization) {
-        let authHeader = req.headers.authorization.replace(/^bearer /i, '');
+      const auth = getAuthorization(req);
+      if (auth) {
+        let authHeader = auth.replace(/^bearer /i, '');
         client = oauth.getUserInfo(authHeader);
       }
 
-      // Authorize using error delete access
-      if (opt.error.dscope)
-        oauth.authorize(req.headers && req.headers.authorization,
-          opt.error.dscope());
+      assureDeleteAuthorized(opt.error, req);
 
       // Get doc from edb
       const id = dbclient.tkuri(ks, ts);


### PR DESCRIPTION
Removes code duplication in `dataflow` related to getting authorization information from HTTP request and performing oauth authorization checks.