### PR TITLE
Refactor transform tests

### DIFF
--- a/lib/utils/transform/src/test/test.js
+++ b/lib/utils/transform/src/test/test.js
@@ -1,77 +1,110 @@
 'use strict';
 
-// Simple async map, reduce, and filter data transformation functions with
-// callbacks.
-
 const transform = require('..');
 
 describe('abacus-transform', () => {
-  it('runs a reduction function asynchronously', () => {
 
-    // Run a reduction function
-    const sum = (a, v, i, l, cb) =>
-      setImmediate(() => cb(undefined, a + v));
-    transform.reduce([1, 2, 3], sum, 0, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val).to.equal(6);
+  describe('reduce', () => {
+
+    it('calls asynchronous iteratee', (done) => {
+      const sumReduce = (memo, value, index, list, cb) =>
+        setImmediate(() => cb(undefined, memo + value));
+
+      transform.reduce([1, 2, 3], sumReduce, 0, (err, value) => {
+        expect(err).to.equal(undefined);
+        expect(value).to.equal(6);
+        done();
+      });
     });
 
-    // Run a reduction function that returns an error
-    const err = new Error('Sum error');
-    const esum = (a, v, i, l, cb) => setImmediate(() => cb(err, 0));
-    transform.reduce([1, 2, 3], esum, 0, (e, val) => {
-      expect(e).to.equal(err);
+    it('handles errors in iteratee', (done) => {
+      const reduceErr = new Error('Reduce error!');
+      const failingReduce = (memo, value, index, list, cb) => 
+        setImmediate(() => cb(reduceErr, 0));
+
+      transform.reduce([1, 2, 3], failingReduce, 0, (err, value) => {
+        expect(err).to.equal(reduceErr);
+        done();
+      });
     });
 
-    // Run a reduce function over an empty list
-    transform.reduce([], (a, v, i, l, cb) => {
-    }, 0, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val).to.equal(0);
+    it('ignores iteratee on empty list', (done) => {
+      const noopReduce = (memo, value, index, list, cb) => {
+        assert.fail('iteratee should not be called!');
+      };
+
+      transform.reduce([], noopReduce, 0, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val).to.equal(0);
+        done();
+      });
     });
+
   });
 
-  it('runs a map function asynchronously', () => {
+  describe('map', () => {
 
-    // Run a map function
-    const sqr = (v, i, l, cb) => setImmediate(() => cb(undefined, v *
-          v));
-    transform.map([1, 2, 3], sqr, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val).to.deep.equal([1, 4, 9]);
+    it('calls asynchronous iteratee', (done) => {
+      const sqrMap = (value, index, list, cb) => 
+        setImmediate(() => cb(undefined, value * value));
+
+      transform.map([1, 2, 3], sqrMap, (err, value) => {
+        expect(err).to.equal(undefined);
+        expect(value).to.deep.equal([1, 4, 9]);
+        done();
+      });
     });
 
-    // Run a map function that returns an error
-    const err = new Error('Sqr error');
-    const esqr = (v, i, l, cb) => setImmediate(() => cb(err, 0));
-    transform.map([1, 2, 3], esqr, (e, val) => {
-      expect(e).to.equal(err);
+    it('handles errors in iteratee', (done) => {
+      const mapErr = new Error('Map error!');
+      const failingMap = (value, index, list, cb) => 
+        setImmediate(() => cb(mapErr, 0));
+
+      transform.map([1, 2, 3], failingMap, (err, value) => {
+        expect(err).to.equal(mapErr);
+        done();
+      });
     });
 
-    // Run a map function over an empty list
-    transform.map([], (v, i, l, cb) => {
-    }, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val).to.deep.equal([]);
+    it('ignores iteratee on empty list', (done) => {
+      const noopMap = (value, index, list, cb) => {
+        assert.fail('iteratee should not be called!');
+      };
+
+      transform.map([], noopMap, (err, value) => {
+        expect(err).to.equal(undefined);
+        expect(value).to.deep.equal([]);
+        done();
+      });
     });
+
   });
 
-  it('runs a filter function asynchronously', () => {
+  describe('filter', () => {
 
-    // Run a filter function
-    const even = (v, i, l, cb) =>
-      setImmediate(() => cb(undefined, v % 2 === 0));
-    transform.filter([1, 2, 3], even, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val).to.deep.equal([2]);
+    it('calls asynchronous iteratee', (done) => {
+      const evenFilter = (value, index, list, cb) =>
+        setImmediate(() => cb(undefined, value % 2 === 0));
+
+      transform.filter([1, 2, 3, 4], evenFilter, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val).to.deep.equal([2, 4]);
+        done();
+      });
     });
 
-    // Run a filter function that returns an error
-    const err = new Error('Even error');
-    const eeven = (v, i, l, cb) => setImmediate(() => cb(err, 0));
-    transform.filter([1, 2, 3], eeven, (e, val) => {
-      expect(e).to.equal(err);
+    it('handles errors in iteratee', (done) => {
+      const filterErr = new Error('Filter error!');
+      const failingFilter = (value, index, list, cb) => 
+        setImmediate(() => cb(filterErr, false));
+
+      transform.filter([1, 2, 3], failingFilter, (err, value) => {
+        expect(err).to.equal(filterErr);
+        done();
+      });
     });
+
   });
+
 });
 


### PR DESCRIPTION
This pull request is a refactoring of the `transform` library test.

* Most importantly, this change fixes a problem in the tests, where they would pass even if the implementation of the `map`, `reduce`, and `filter` functions were commented out. This is achieved by adding the `done` callback to the individual tests.
* Each `it` contained multiple tests inside, which were separated with comments. The comments have now been removed and individual `it` statements extracted.
* The new `it` statements have been grouped in `describe` statements (one for `map`, `reduce`, and `filter`) for best visual and logical representation.
* Variables in the test have now more clear, meaningful, and aligned with `underscore.js` names.
