### PR TITLE
Refactor transform code

### DIFF
--- a/lib/utils/transform/src/index.js
+++ b/lib/utils/transform/src/index.js
@@ -8,126 +8,143 @@
 const _ = require('underscore');
 const yieldable = require('abacus-yieldable');
 
-const map = _.map;
+const each = _.each;
 const filter = _.filter;
+const isEmpty = _.isEmpty;
 
-// Setup debug log
 const debug = require('abacus-debug')('abacus-transform');
 
-// Apply an asynchronous reduce function to a list and call back when the
-// whole list has been reduced
-const cbreduce = (l, fn, a, cb) => {
-  debug('Reduce list %o, initial accum %o', l, a);
+const recursiveReduce = (memo, index, list, func, cb) => {
+  const value = list[index];
+  debug('Applying reduction to value %o, accum %o', value, memo);
 
-  // Convert to a regular function with callback if needed
-  const f = yieldable.functioncb(fn);
+  func(memo, value, index, list, (err, resultMemo) => {
+    if (err) {
+      debug('Reduction error %o', err);
+      cb(err);
+      return;
+    }
 
-  // Apply the reduction function one value at a time, recursively
-  const reduce1 = (a, i, l, cb) => {
-    debug('Applying reduction to value %o, accum %o', l[i], a);
-    f(a, l[i], i, l, (err, a) => {
-      if(err) {
-        // Return any error
-        debug('Reduction error %o', err);
-        cb(err);
-      }
-      else if(i === l.length - 1) {
-        // Return the final result once we've applied the reduction
-        // function to all values in the list
-        debug('Final reduction accum %o', a);
-        cb(undefined, a);
-      }
-      // Apply the reduction function to the next value in the list
-      else reduce1(a, i + 1, l, cb);
-    });
-  };
+    if (index === list.length - 1) {
+      debug('Final reduction accum %o', resultMemo);
+      cb(undefined, resultMemo);
+      return;
+    }
 
-  // If the given list is empty, return the given accumulator right away
-  if(l.length === 0) {
-    debug('Final reduction accum %o', a);
-    setImmediate(() => {
-      cb(undefined, a);
-    });
-    return;
-  }
-
-  // Apply the reduction function to the given list
-  reduce1(a, 0, l, cb);
+    recursiveReduce(resultMemo, index + 1, list, func, cb);
+  });
 };
 
-// Apply an asynchronous map function to a list and call back when the whole
-// list has been mapped
-const cbmap = (l, fn, cb) => {
-  debug('Map list %o', l);
+// Performs a reduce operation, very similar to the one from the
+// underscore.js library, except that the final result is returned
+// via a callback and the iteratee passes intermediate results via a
+// callback.
+// The function takes four arguments: the list to be reduced, the reduce
+// iteratee that will perform the reduce iterations, the initial
+// memo (accumulation), and a callback that will receive the final
+// result.
+// The iteratee is passed five arguments: the memo (accumulated value),
+// the iteration value, the iteration index, the original list
+// being reduced, and lastly a callback that should be used to
+// return whether there is an error and the result of the reduce iteration.
+const asyncReduce = (list, func, memo, cb) => {
+  debug('Reduce list %o, initial accum %o', list, memo);
 
-  // Convert to a regular function with callback if needed
-  const f = yieldable.functioncb(fn);
-
-  // If the given list is empty, return it right away
-  if(l.length === 0) {
-    debug('Final map result %o', l);
-    setImmediate(() => {
-      cb(undefined, l);
-    });
+  if (isEmpty(list)) {
+    debug('Final reduction accum %o', memo);
+    cb(undefined, memo);
     return;
   }
 
-  // Warning: err is a mutable variable, but that's really the only way to
-  // record reduction errors asynchronously
-  let err;
-  // Warning: accum is a mutable variable, but that's really the only way to
-  // accumulate the map results asynchronously
-  let accum = new Array(l.length);
-  // Warning: n is a mutable variable, but that's really the only way to
-  // count the asynchronous map executions
-  let n = 0;
-  map(l, (v, i, l) => {
-    debug('Applying map to value %o', v);
-    f(v, i, l, (e, r) => {
-      // Warning: mutating variable err
-      err = !err && e ? e : err;
-      // Warning: mutating variable accum
-      accum[i] = r;
-      // Warning: mutating variable n
-      n = n + 1;
-      debug('Map result %o', r);
-      if(n === l.length) {
-        if(err) {
-          debug('Map error %o', err);
-          cb(err);
-          return;
-        }
-        debug('Final map result %o', accum);
-        cb(undefined, accum);
-      }
+  const funcWithCallback = yieldable.functioncb(func);
+  recursiveReduce(memo, 0, list, funcWithCallback, cb);
+};
+
+const finishMap = (err, result, cb) => {
+  if(err) {
+    debug('Map error %o', err);
+    cb(err);
+    return;
+  }
+  debug('Final map result %o', result);
+  cb(undefined, result);
+};
+
+// Performs a map operation, very similar to the one from the
+// underscore.js library, except that the final result is returned
+// via a callback and the iteratee passes intermediate results via
+// a callback.
+// The function takes three arguments: the list to be mapped, the iteratee
+// to perform the mapping operation, a callback that will receive the final
+// map result.
+// The iteratee is passed four arguments: the iteration value, the iteration
+// index, the original list to be mapped, and lastly a callback that should
+// be used to return whether there is an error and the result of the map
+// iteration.
+const asyncMap = (list, func, cb) => {
+  debug('Map list %o', list);
+
+  if (isEmpty(list)) {
+    debug('Final map result %o', list);
+    cb(undefined, list);
+    return;
+  }
+
+  let mapErr = undefined;
+  let mapResult = new Array(list.length);
+  let mapOperations = 0;
+  const funcWithCallback = yieldable.functioncb(func);
+
+  each(list, (value, index, list) => {
+    debug('Applying map to value %o', value);
+
+    funcWithCallback(value, index, list, (err, result) => {
+      debug('Map result %o', result);
+      mapErr = mapErr || err;
+      mapResult[index] = result;
+      mapOperations++;
+      if (mapOperations === list.length)
+        finishMap(mapErr, mapResult, cb);
     });
   });
 };
 
-// Apply an asynchronous filter function to a list and call back when the whole
-// list has been filtered
-const cbfilter = (l, fn, cb) => {
-  debug('Filter list %o', l);
+const filterSelected = (list, mask, cb) => {
+  const filterCondition = (value, index, list) => mask[index];
+  const result = filter(list, filterCondition);
+  debug('Final filter result %o', result);
+  cb(undefined, result);
+};
 
-  // Convert to a regular function with callback if needed
-  const f = yieldable.functioncb(fn);
+// Performs a filter operation, very similar to the one from the
+// underscore.js library, except that the final result is returned
+// via a callback and the iteratee passes selection information
+// via a callback.
+// The function takes three arguments: the list to be filtered,
+// the iteratee to perform the selection, and lastly a callback that 
+// will receive the final filter result.
+// The iteratee is passed four arguments: the iteration value, the iteration
+// index, the original list to be filtered, and lastly a callback that should
+// be used to return whether there is an error and a boolean flag indicating 
+// whether the value should be preserved or not.
+const asyncFilter = (list, func, cb) => {
+  debug('Filter list %o', list);
 
-  cbmap(l, f, (err, accum) => {
+  const funcWithCallback = yieldable.functioncb(func);
+
+  asyncMap(list, funcWithCallback, (err, selection) => {
     if(err) {
       debug('Filter error %o', err);
       cb(err);
+      return;
     }
-    else {
-      const res = filter(l, (v, i, l) => accum[i]);
-      debug('Final filter result %o', res);
-      cb(undefined, res);
-    }
+    filterSelected(list, selection, cb);
   });
 };
 
 // Export our public functions
-module.exports = cbreduce;
-module.exports.reduce = cbreduce;
-module.exports.map = cbmap;
-module.exports.filter = cbfilter;
+module.exports = asyncReduce;
+module.exports.reduce = asyncReduce;
+module.exports.map = asyncMap;
+module.exports.filter = asyncFilter;
 


### PR DESCRIPTION
Refactoring of the `transform` package implementation.

* Mostly variable name changes and function extraction / simplification.
* One `map` was replaced with an `each` statement, which works better in that case.
* All small-talk comments have been removed. New major comments have been written to document the API of the exposed functions.
* The use of `setImmediate` was removed, when handling empty list cases. This was not in alignment with the non-empty case, where the callbacks are called directly. Eitherway, the current implementation of the functions expects that the callbacks themselves are implemented via asynchronous behavior (as expressed in the tests).

**Note:** If the last change is to ever cause problems (e.g. large stacks), then we should consider documenting the behavior and verifying it with a test and not leaving it to guessing.