### PR TITLE
Use Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ jobs:
           sources:
             - mongodb-upstart
           packages:
-            - mongodb-org-server
-            - mongodb-org-shell
+            - mongodb-org-server=2.6.9
+            - mongodb-org-shell=2.6.9
       install:
         - sleep 15
     - <<: *unit-tests
@@ -82,8 +82,8 @@ jobs:
           sources:
             - mongodb-upstart
           packages:
-            - mongodb-org-server
-            - mongodb-org-shell
+            - mongodb-org-server=2.6.9
+            - mongodb-org-shell=2.6.9
       install:
         - sleep 15
     - <<: *integration-tests
@@ -130,8 +130,8 @@ jobs:
           sources:
             - mongodb-upstart
           packages:
-            - mongodb-org-server
-            - mongodb-org-shell
+            - mongodb-org-server=2.6.9
+            - mongodb-org-shell=2.6.9
       install:
         - sleep 15
     - <<: *extended-tests
@@ -178,8 +178,8 @@ jobs:
           sources:
             - mongodb-upstart
           packages:
-            - mongodb-org-server
-            - mongodb-org-shell
+            - mongodb-org-server=2.6.9
+            - mongodb-org-shell=2.6.9
       install:
         - sleep 15
     - <<: *perf-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js: "6.10.0"
-dist: trusty
+dist: precise
 sudo: false
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js: "6.10.0"
-
+dist: trusty
 sudo: false
 
 env:
@@ -49,7 +49,6 @@ jobs:
         apt:
           sources:
             - mongodb-upstart
-            - mongodb-3.2-precise
           packages:
             - mongodb-org-server
             - mongodb-org-shell
@@ -98,7 +97,6 @@ jobs:
         apt:
           sources:
             - mongodb-upstart
-            - mongodb-3.2-precise
           packages:
             - mongodb-org-server
             - mongodb-org-shell
@@ -147,7 +145,6 @@ jobs:
         apt:
           sources:
             - mongodb-upstart
-            - mongodb-3.2-precise
           packages:
             - mongodb-org-server
             - mongodb-org-shell
@@ -196,7 +193,6 @@ jobs:
         apt:
           sources:
             - mongodb-upstart
-            - mongodb-3.2-precise
           packages:
             - mongodb-org-server
             - mongodb-org-shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js: "6.10.0"
-dist: precise
+dist: trusty
 sudo: false
 
 env:
@@ -26,34 +26,12 @@ jobs:
         - couchdb
     - <<: *unit-tests
       env:
-        - DESCRIPTION="mongodb 2.6"
+        - DESCRIPTION="mongodb"
         - JOBS=1
         - DBCLIENT=abacus-mongoclient
         - DB=mongodb://localhost:27017
-      addons:
-        apt:
-          sources:
-            - mongodb-upstart
-          packages:
-            - mongodb-org-server=2.6.9
-            - mongodb-org-shell=2.6.9
-      install:
-        - sleep 15
-    - <<: *unit-tests
-      env:
-        - DESCRIPTION="mongodb 3.2"
-        - JOBS=1
-        - DBCLIENT=abacus-mongoclient
-        - DB=mongodb://localhost:27017
-      addons:
-        apt:
-          sources:
-            - mongodb-upstart
-          packages:
-            - mongodb-org-server
-            - mongodb-org-shell
-      install:
-        - sleep 15
+      services:
+        - mongodb
     - &integration-tests
       stage: integration tests
       before_script: npm run provision
@@ -72,36 +50,13 @@ jobs:
         - couchdb
     - <<: *integration-tests
       env:
-        - DESCRIPTION="mongodb 2.6"
+        - DESCRIPTION="mongodb"
         - JOBS=1
         - DBCLIENT=abacus-mongoclient
         - DB=mongodb://localhost:27017
         - CI_TEST=itest
-      addons:
-        apt:
-          sources:
-            - mongodb-upstart
-          packages:
-            - mongodb-org-server=2.6.9
-            - mongodb-org-shell=2.6.9
-      install:
-        - sleep 15
-    - <<: *integration-tests
-      env:
-        - DESCRIPTION="mongodb 3.2"
-        - JOBS=1
-        - DBCLIENT=abacus-mongoclient
-        - DB=mongodb://localhost:27017
-        - CI_TEST=itest
-      addons:
-        apt:
-          sources:
-            - mongodb-upstart
-          packages:
-            - mongodb-org-server
-            - mongodb-org-shell
-      install:
-        - sleep 15
+      services:
+        - mongodb
     - &extended-tests
       stage: extended tests
       before_script: npm run provision
@@ -120,36 +75,13 @@ jobs:
         - couchdb
     - <<: *extended-tests
       env:
-        - DESCRIPTION="mongodb 2.6"
+        - DESCRIPTION="mongodb"
         - JOBS=1
         - DBCLIENT=abacus-mongoclient
         - DB=mongodb://localhost:27017
         - CI_TEST=extended
-      addons:
-        apt:
-          sources:
-            - mongodb-upstart
-          packages:
-            - mongodb-org-server=2.6.9
-            - mongodb-org-shell=2.6.9
-      install:
-        - sleep 15
-    - <<: *extended-tests
-      env:
-        - DESCRIPTION="mongodb 3.2"
-        - JOBS=1
-        - DBCLIENT=abacus-mongoclient
-        - DB=mongodb://localhost:27017
-        - CI_TEST=extended
-      addons:
-        apt:
-          sources:
-            - mongodb-upstart
-          packages:
-            - mongodb-org-server
-            - mongodb-org-shell
-      install:
-        - sleep 15
+      services:
+        - mongodb
     - &perf-tests
       stage: performance tests
       script: travis_retry npm run citest -- --start-timeout $START_TIMEOUT --total-timeout $TOTAL_TIMEOUT
@@ -173,31 +105,8 @@ jobs:
         - DBCLIENT=abacus-mongoclient
         - DB=mongodb://localhost:27017
         - CI_TEST=perf
-      addons:
-        apt:
-          sources:
-            - mongodb-upstart
-          packages:
-            - mongodb-org-server=2.6.9
-            - mongodb-org-shell=2.6.9
-      install:
-        - sleep 15
-    - <<: *perf-tests
-      env:
-        - DESCRIPTION="mongodb 3.2"
-        - JOBS=1
-        - DBCLIENT=abacus-mongoclient
-        - DB=mongodb://localhost:27017
-        - CI_TEST=perf
-      addons:
-        apt:
-          sources:
-            - mongodb-upstart
-          packages:
-            - mongodb-org-server
-            - mongodb-org-shell
-      install:
-        - sleep 15
+      services:
+        - mongodb
     - stage: deploy
       script: travis_retry npm run cftest -- --start-timeout $START_TIMEOUT --total-timeout $TOTAL_TIMEOUT
 


### PR DESCRIPTION
Upstart has mongodb 3.2 by default, so we end-up running 2 mongo 3.2 builds.
We need to find a way to install 2.6 on trusty