### PR TITLE
Generate resource specific reporting for organization

### DIFF
--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -697,7 +697,6 @@ const getConsumerUsage = function *(orgid, time, auth, resourceId) {
     debug('Filtering usage document for resource: %s', resourceId);
     usageDoc.resources = filter(usageDoc.resources, (res) =>
       res.resource_id === resourceId);
-    console.log('------> %j', usageDoc.resources);
     for (let space of usageDoc.spaces)
       space.resources = filter(space.resources, (res) =>
         res.resource_id === resourceId);
@@ -974,34 +973,23 @@ const retrieveUsage = (req, res, cb) => {
   debug('Retrieving rated usage for organization %s on %s',
     req.params.organization_id, req.params.time);
 
-  const auth = req.headers.authorization;
-  if (secured() && !auth) {
-    res.status(401).send('Not authorized - missing token');
-    return;
-  }
-
-  const parsedScopes =
-    oauth.parseTokenScope(auth.replace(/^bearer /i, ''));
-  console.log(parsedScopes);
-
   let resourceId;
-
-  if (parsedScopes.readResourceScopes.length > 0)
-    // only the first resource as token with mutiple resources is not available
-    resourceId = parsedScopes.readResourceScopes[0];
-  else if (!parsedScopes.hasSystemReadScope) {
-    res.status(401).send('Invalid token - Insufficient scope');
-    return;
+  const auth = req.headers.authorization;
+  if (secured()) {
+    if (!auth) {
+      res.status(401).send('Not authorized - missing token');
+      return;
+    }
+    const parsedScopes =
+      oauth.parseTokenScope(auth.replace(/^bearer /i, ''));
+    if (parsedScopes.readResourceScopes.length > 0)
+      // only the 1st resource as token with mutiple resources is not available
+      resourceId = parsedScopes.readResourceScopes[0];
+    else if (!parsedScopes.hasSystemReadScope) {
+      res.status(401).send('Invalid token - Insufficient scope');
+      return;
+    }
   }
-  // if (secured())
-  //   try {
-  //     oauth.authorize(req.headers && req.headers.authorization, sysScopes());
-  //   }
-  //   catch (e) {
-  //     res.status(e.statusCode || 500).send(e);
-  //     return;
-  //   }
-
   // Retrieve and return the rated usage for the given org and time
   orgUsage(req.params.organization_id,
     req.params.time ? parseInt(req.params.time) : undefined,

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -737,7 +737,7 @@ const orgUsage = function(orgid, t = moment.now(), auth, resourceId, cb) {
 
 // Return the usage for a list of orgs in a given time period
 const orgsUsageCb = (orgids, t, auth, cb) => {
-  tmap(orgids, (orgid, i, l, cb) => orgUsage(orgid, t, auth, cb),
+  tmap(orgids, (orgid, i, l, cb) => orgUsage(orgid, t, auth, undefined, cb),
     (err, result) => cb(err, result));
 };
 
@@ -845,7 +845,7 @@ const graphSchema = new GraphQLSchema({
         },
         resolve: (root, args) => {
           return yieldable.promise(orgUsage)(
-              args.organization_id, args.time, args.authorization);
+              args.organization_id, args.time, args.authorization, undefined);
         }
       },
       organizations: {
@@ -974,28 +974,28 @@ const retrieveUsage = (req, res, cb) => {
     req.params.organization_id, req.params.time);
 
   let resourceId;
-  const auth = req.headers.authorization;
-  if (secured()) {
-    if (!auth) {
-      res.status(401).send('Not authorized - missing token');
+  // req.headers.authorization;
+  if (secured())
+    try {
+      const parsedScopes =
+        oauth.parseTokenScope(req.headers && req.headers.authorization);
+      if (parsedScopes.readResourceScopes.length > 0)
+        // only the 1st resource as token with mutiple resources isn't available
+        resourceId = parsedScopes.readResourceScopes[0];
+      else if (!parsedScopes.hasSystemReadScope) {
+        res.status(403).send('Invalid token - Insufficient scope');
+        return;
+      }
+    }
+    catch (e) {
+      res.status(e.statusCode).send(e.headers);
       return;
     }
-    const parsedScopes =
-      oauth.parseTokenScope(auth.replace(/^bearer /i, ''));
-    if (parsedScopes.readResourceScopes.length > 0)
-      // only the 1st resource as token with mutiple resources is not available
-      resourceId = parsedScopes.readResourceScopes[0];
-    else if (!parsedScopes.hasSystemReadScope) {
-      res.status(401).send('Invalid token - Insufficient scope');
-      return;
-    }
-  }
   // Retrieve and return the rated usage for the given org and time
   orgUsage(req.params.organization_id,
     req.params.time ? parseInt(req.params.time) : undefined,
     req.headers && req.headers.authorization, resourceId, (err, usage) => {
       if (err) {
-        // TODO: inside cb?
         res.status(err.statusCode || 500).send(err);
         return;
       }

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -469,7 +469,6 @@ const summarizeUsageCb = (t, a, auth, cb) => {
   // Summarize the aggregated usage under a resource
   const summarizeResource = (rs, i, l, cb) => {
     debug('Summarizing resource %s', rs.resource_id);
-
     tmap(rs.plans, summarizePlan, (err, resAccum) => {
       transformMapCb(err, rs, { plans: resAccum }, cb);
     });
@@ -607,7 +606,7 @@ const updateConsumers = function *(u, consumers, spaceId, consumersDocMap) {
 };
 
 // Returns a copy of the passed in org usage with the consumers populated
-const consumerUsage = function *(u) {
+const consumerUsage = function *(u, resourceId) {
   // Collect the list of consumer ids to query for
   const ids = [];
   map(u.spaces, (s) => {
@@ -622,8 +621,14 @@ const consumerUsage = function *(u) {
     keys: ids, include_docs: true })).rows;
 
   const consumersDocMap = new Map();
-  for (let c of consumers)
+  for (let c of consumers) {
+    if (resourceId) {
+      debug('Filtering consumer resources by resource id: %s', resourceId);
+      c.doc.resources = filter(c.doc.resources, (res) =>
+        res.resource_id === resourceId);
+    }
     consumersDocMap.set(dbclient.k(c.doc._id), c.doc);
+  }
 
   const doc = extend({}, u);
   for (let s of doc.spaces) {
@@ -637,7 +642,7 @@ const consumerUsage = function *(u) {
   return doc;
 };
 
-const getConsumerUsage = function *(orgid, time, auth) {
+const getConsumerUsage = function *(orgid, time, auth, resourceId) {
   // Forward authorization header field to account to authorize
   const o = auth ? { headers: { authorization: auth } } : {};
 
@@ -684,16 +689,26 @@ const getConsumerUsage = function *(orgid, time, auth) {
       spaces: []
     };
   }
-
-  debug('Found rated usage %o', doc.rows[0].doc);
-  purgeOldQuantities(doc.rows[0].doc);
-  return yield consumerUsage(doc.rows[0].doc);
+  const usageDoc = doc.rows[0].doc;
+  debug('Found rated usage %o', usageDoc);
+  purgeOldQuantities(usageDoc);
+  // filter by resourceId if needed
+  if (resourceId) {
+    debug('Filtering usage document for resource: %s', resourceId);
+    usageDoc.resources = filter(usageDoc.resources, (res) =>
+      res.resource_id === resourceId);
+    console.log('------> %j', usageDoc.resources);
+    for (let space of usageDoc.spaces)
+      space.resources = filter(space.resources, (res) =>
+        res.resource_id === resourceId);
+  }
+  return yield consumerUsage(usageDoc, resourceId);
 };
 
 // Return the usage for an org in a given time period
-const orgUsage = function(orgid, t = moment.now(), auth, cb) {
+const orgUsage = function(orgid, t = moment.now(), auth, resourceId, cb) {
   const consumerUsageCb = yieldable.functioncb(getConsumerUsage);
-  consumerUsageCb(orgid, t, auth, (err, consumerUsage) => {
+  consumerUsageCb(orgid, t, auth, resourceId, (err, consumerUsage) => {
     if(err) {
       debug('Could not generate consumer usage for org %s due to: %o',
         orgid, err);
@@ -959,20 +974,40 @@ const retrieveUsage = (req, res, cb) => {
   debug('Retrieving rated usage for organization %s on %s',
     req.params.organization_id, req.params.time);
 
-  if (secured())
-    try {
-      oauth.authorize(req.headers && req.headers.authorization, sysScopes());
-    }
-    catch (e) {
-      res.status(e.statusCode || 500).send(e);
-      return;
-    }
+  const auth = req.headers.authorization;
+  if (secured() && !auth) {
+    res.status(401).send('Not authorized - missing token');
+    return;
+  }
+
+  const parsedScopes =
+    oauth.parseTokenScope(auth.replace(/^bearer /i, ''));
+  console.log(parsedScopes);
+
+  let resourceId;
+
+  if (parsedScopes.readResourceScopes.length > 0)
+    // only the first resource as token with mutiple resources is not available
+    resourceId = parsedScopes.readResourceScopes[0];
+  else if (!parsedScopes.hasSystemReadScope) {
+    res.status(401).send('Invalid token - Insufficient scope');
+    return;
+  }
+  // if (secured())
+  //   try {
+  //     oauth.authorize(req.headers && req.headers.authorization, sysScopes());
+  //   }
+  //   catch (e) {
+  //     res.status(e.statusCode || 500).send(e);
+  //     return;
+  //   }
 
   // Retrieve and return the rated usage for the given org and time
   orgUsage(req.params.organization_id,
     req.params.time ? parseInt(req.params.time) : undefined,
-    req.headers && req.headers.authorization, (err, usage) => {
+    req.headers && req.headers.authorization, resourceId, (err, usage) => {
       if (err) {
+        // TODO: inside cb?
         res.status(err.statusCode || 500).send(err);
         return;
       }
@@ -982,6 +1017,7 @@ const retrieveUsage = (req, res, cb) => {
           'accumulated_usage_id', 'resource_instance_id',
           'consumer_id', 'resource_id', 'plan_id','pricing_country','prices']
         );
+
       cb(undefined, {
         body: result
       });

--- a/lib/aggregation/reporting/src/test/auth-test.js
+++ b/lib/aggregation/reporting/src/test/auth-test.js
@@ -107,7 +107,7 @@ process.env.JWTALGO = tokenAlgorithm;
 describe('abacus-usage-report-auth', () => {
   let report;
   let server;
-  
+
   const deleteModules = () => {
     delete require.cache[require.resolve('abacus-oauth')];
     delete require.cache[require.resolve('..')];
@@ -115,7 +115,7 @@ describe('abacus-usage-report-auth', () => {
 
   const prepareRatedUsage = (done) => {
     const id = 'k/' + oid2 + '/t/0001420502400000';
-    const rated = builder.ratedTemplate(id, oid2, sid, 
+    const rated = builder.ratedTemplate(id, oid2, sid,
       testResourceId, 1420502400000, 1420502500000, 1420502500000,
       builder.buildAggregatedUsage(21, 300, 3300, {
         consumed: 1108800000,
@@ -139,7 +139,7 @@ describe('abacus-usage-report-auth', () => {
         consuming: 6
       }), [builder.buildPlanUsage('basic', planAUsage)], 1420502500000);
 
-    storage.aggregator.put(rated, 
+    storage.aggregator.put(rated,
       () => storage.aggregator.put(consumer1, done));
   };
 
@@ -218,13 +218,13 @@ describe('abacus-usage-report-auth', () => {
       }
     };
 
-    it('fails with 403 when retrieving usage for an organization', (done) => {
+    it('succeeds when retrieving usage for an organization', (done) => {
       // Attempt to get the usage for an organization
       request.get('http://localhost::p' + orgUsagePath,
         extend(orgUsageParams, headers, { p: server.address().port }),
         (err, val) => {
           expect(err).to.equal(undefined);
-          expect(val.statusCode).to.equal(403);
+          expect(val.statusCode).to.equal(200);
           done();
         });
     });
@@ -261,17 +261,6 @@ describe('abacus-usage-report-auth', () => {
         authorization: 'bearer ' + signedToken
       }
     };
-
-    it('fails with 403 when retrieving usage for an organization', (done) => {
-      // Attempt to get the usage for an organization
-      request.get('http://localhost::p' + orgUsagePath,
-        extend(orgUsageParams, headers, { p: server.address().port }),
-        (err, val) => {
-          expect(err).to.equal(undefined);
-          expect(val.statusCode).to.equal(403);
-          done();
-        });
-    });
 
     it('fails with 403 when retrieving usage for a res. instance', (done) => {
       // Attempt to get the usage for a resource instance

--- a/lib/aggregation/reporting/src/test/lib/mocker.js
+++ b/lib/aggregation/reporting/src/test/lib/mocker.js
@@ -9,13 +9,13 @@ const map = _.map;
 
 const mockRequestModule = () => {
   const getspy = (reqs, cb) => {
-   
+
     expect(reqs[0][0]).to.equal(
       'http://localhost:9881/v1/organizations/:org_id/account/:time');
 
     cb(undefined, map(reqs, (req) => [undefined, {
       statusCode:
-        /unauthorized/.test(req[1].org_id || req[1].account_id) ? 401 : 
+        /unauthorized/.test(req[1].org_id || req[1].account_id) ? 401 :
         /unexisting/.test(req[1].org_id) ? 404 :
         200
     }]));
@@ -39,10 +39,14 @@ const mockOAuthModule = () => {
     return f;
   });
   const authorizespy = spy((auth, escope) => {});
+  const scopesspy = spy((token) => {
+    return { readResourceScopes : [],hasSystemReadScope : true };
+  });
   const oauthmock = extend({}, oauth, {
     validator: () => validatorspy,
     cache: () => cachespy(),
-    authorize: () => authorizespy()
+    authorize: () => authorizespy(),
+    parseTokenScope: () => scopesspy()
   });
   require.cache[require.resolve('abacus-oauth')].exports = oauthmock;
 

--- a/lib/aggregation/reporting/src/test/specific-report-test.js
+++ b/lib/aggregation/reporting/src/test/specific-report-test.js
@@ -1,0 +1,211 @@
+'use strict';
+
+// Usage reporting service.
+
+const _ = require('underscore');
+const jwt = require('jsonwebtoken');
+const request = require('abacus-request');
+const dbclient = require('abacus-dbclient');
+
+const extend = _.extend;
+const builder = require('./lib/builder.js');
+const storage = require('./lib/storage.js');
+const mocker = require('./lib/mocker.js');
+
+/* eslint quotes: 1 */
+
+process.env.DB = process.env.DB || 'test';
+process.env.CLUSTER = 'false';
+const testResourceId = 'resource-1';
+let report = require('..');
+
+mocker.mockRequestModule();
+mocker.mockClusterModule();
+mocker.mockOAuthModule();
+
+// const sid = 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a';
+// const cid = (p) => p !== 'standard' ? 'UNKNOWN' :
+//   'external:bbeae239-f3f8-483c-9dd0-de6781c38bab';
+// const rid = '0b39fa70-a65f-4183-bae8-385633ca5c87';
+
+// Convenient test case:
+// Space A, consumer A, plan basic basic/basic/basic
+const planAUsage = builder.buildAggregatedUsage(1, 100, 300, {
+  consumed: 475200000,
+  consuming: 6
+}, {
+  consumed: 10843200000,
+  consuming: 6
+}, 1, 3, 45, { price: 0.00014 }, undefined, undefined, undefined, true);
+
+const tokenSecret = 'secret';
+const tokenAlgorithm = 'HS256';
+const tokenPayload = {
+  jti: '254abca5-1c25-40c5-99d7-2cc641791517',
+  sub: 'abacus-usage-reporting',
+  authorities: [
+    'abacus.usage.read'
+  ],
+  scope: [
+    'abacus.usage.read'
+  ],
+  client_id: 'abacus-usage-reporting',
+  cid: 'abacus-usage-reporting',
+  azp: 'abacus-usage-reporting',
+  grant_type: 'client_credentials',
+  rev_sig: '2cf89595',
+  iat: 1456147679,
+  exp: 1456190879,
+  iss: 'https://localhost:1234/oauth/token',
+  zid: 'uaa',
+  aud: [
+    'abacus-usage-reporting',
+    'abacus.usage'
+  ]
+};
+
+process.env.SECURED = 'true';
+process.env.JWTKEY = tokenSecret;
+process.env.JWTALGO = tokenAlgorithm;
+
+describe('Abacus usage specific report', () => {
+  let server;
+
+  const deleteModules = () => {
+    delete require.cache[require.resolve('abacus-oauth')];
+    delete require.cache[require.resolve('..')];
+  };
+
+  before((done) => {
+    deleteModules();
+    report = require('..');
+    done();
+  });
+
+  context('on extracting org usage', () => {
+    const orgUsage1 = {
+      'organization_id': '5308227d-9e7f-48fb-8db7-1f0680c49491',
+      'account_id': '1234',
+      'start': 1420502400000,
+      'end': 1420502400010,
+      'processed': 1420502400020,
+      'id': 'k/5308227d-9e7f-48fb-8db7-1f0680c49491/t/0001420502400000',
+      'consumer_id': 'app:3653384d-4754-4802-a44c-9fd363204660',
+      'resource_id': 'resource-1',
+      'processed_id': '1420502400020-4-0-1-0',
+      'plan_id': 'basic',
+      'resources': [{
+        'resource_id': 'resource-1',
+        'plans': [builder.buildPlanUsage('basic', planAUsage)]
+      },
+      {
+        'resource_id': 'resource-2',
+        'plans': [builder.buildPlanUsage('basic', planAUsage)]
+      }],
+      'spaces': [{
+        'space_id': 'space1',
+        'resources': [{
+          'resource_id': 'resource-1',
+          'plans': [builder.buildPlanUsage('basic', planAUsage)] // ARRAY !!!
+        },
+        {
+          'resource_id': 'resource-2',
+          'plans': [builder.buildPlanUsage('basic', planAUsage)]
+        }],
+        'consumers': [{
+          'id': 'app:3653384d-4754-4802-a44c-9fd363204660',
+          't': '0001502371509001'
+        }]
+      }]
+    };
+
+    const consumerUsage = {
+      'organization_id': '5308227d-9e7f-48fb-8db7-1f0680c49491',
+      'account_id': '1234',
+      'start': 1420502400000,
+      'end': 1420502400010,
+      'processed': 1420502400020,
+      'id': 'k/5308227d-9e7f-48fb-8db7-1f0680c49491/space1/' +
+      'app:3653384d-4754-4802-a44c-9fd363204660/t/0001502371509001',
+      'consumer_id': 'app:3653384d-4754-4802-a44c-9fd363204660',
+      'resource_id': 'resource-1',
+      'processed_id': '1420502400020-4-0-1-0',
+      'plan_id': 'basic',
+      'resources': [{
+        'resource_id': 'resource-1',
+        'plans': [builder.buildPlanUsage('basic', planAUsage)]
+      },
+      {
+        'resource_id': 'resource-2',
+        'plans': [builder.buildPlanUsage('basic', planAUsage)]
+      }]
+    };
+
+    before((done) => {
+      dbclient.drop(process.env.DB,
+        /^abacus-aggregator|^abacus-accumulator/, () => {
+          storage.aggregator.put(orgUsage1, () =>
+            storage.aggregator.put(consumerUsage, () => {
+              done();
+            }));
+        });
+    });
+
+    beforeEach(() => {
+      const app = report();
+      server = app.listen(0);
+    });
+
+    it('with system token', (done) => {
+      const signedToken = jwt.sign(extend(tokenPayload,
+        { scope: ['abacus.usage.read'] }),
+        tokenSecret, { expiresIn: 43200 });
+      const headers = {
+        headers: {
+          authorization: 'bearer ' + signedToken
+        }
+      };
+      request.get(
+        'http://localhost::p/v1/metering/organizations/' +
+        ':organization_id/aggregated/usage/:time',
+        extend(headers, { p: server.address().port,
+          organization_id: '5308227d-9e7f-48fb-8db7-1f0680c49491',
+          time: 1420502400000 })
+          , (err, val) => {
+            expect(err).to.equal(undefined);
+            expect(val.statusCode).to.equal(200);
+            expect(val.body.resources.length).to.equal(2);
+            expect(val.body.spaces[0].resources.length).to.equal(2);
+            expect(val.body.spaces[0].consumers[0].resources.length)
+              .to.equal(2);
+            done();
+          });
+    });
+
+    it('with resource specific token', (done) => {
+      const signedToken = jwt.sign(extend(tokenPayload,
+        { scope: [`abacus.usage.${testResourceId}.read`] }),
+        tokenSecret, { expiresIn: 43200 });
+      const headers = {
+        headers: {
+          authorization: 'bearer ' + signedToken
+        }
+      };
+      request.get(
+        'http://localhost::p/v1/metering/organizations/' +
+        ':organization_id/aggregated/usage/:time',
+        extend(headers, { p: server.address().port,
+          organization_id: '5308227d-9e7f-48fb-8db7-1f0680c49491',
+          time: 1420502400000 })
+          , (err, val) => {
+            expect(err).to.equal(undefined);
+            expect(val.statusCode).to.equal(200);
+            expect(val.body.resources.length).to.equal(1);
+            expect(val.body.spaces[0].resources.length).to.equal(1);
+            expect(val.body.spaces[0].consumers[0].resources.length)
+              .to.equal(1);
+            done();
+          });
+    });
+  });
+});

--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -418,6 +418,35 @@ const basicStrategy = (authServer, scopes, secret, algorithm) => {
   };
 };
 
+const parseTokenScope = (token) => {
+  const result = {
+    readResourceScopes : [],
+    writeResourceScopes : [],
+    hasSystemReadScope : false,
+    hasSystemWriteScope : false,
+    hasValidScopes : false
+  };
+  const scopes = getScope(token);
+  for (let scope of scopes)
+    if (scope.match('abacus.usage.*(read|write)')) {
+      result.hasValidScopes = true;
+      let resource = scope.substring(13);
+      if (resource.endsWith('read'))
+        if (resource === 'read')
+          result.hasSystemReadScope = true;
+        else
+          result.readResourceScopes.push(
+            resource.substring(0, resource.length - 5));
+      else
+        if (resource === 'write')
+          result.hasSystemWriteScope = true;
+        else
+          result.writeResourceScopes.push(
+            resource.substring(0, resource.length - 6));
+    }
+  return result;
+};
+
 module.exports.cache = cache;
 module.exports.validate = validate;
 module.exports.validator = validator;
@@ -426,3 +455,4 @@ module.exports.getUserInfo = getUserInfo;
 module.exports.decodeBasicToken = decodeBasicToken;
 module.exports.getBearerToken = getBearerToken;
 module.exports.basicStrategy = basicStrategy;
+module.exports.parseTokenScope = parseTokenScope;

--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -423,13 +423,11 @@ const parseTokenScope = (token) => {
     readResourceScopes : [],
     writeResourceScopes : [],
     hasSystemReadScope : false,
-    hasSystemWriteScope : false,
-    hasValidScopes : false
+    hasSystemWriteScope : false
   };
   const scopes = getScope(token);
   for (let scope of scopes)
     if (scope.match('abacus.usage.*(read|write)')) {
-      result.hasValidScopes = true;
       let resource = scope.substring(13);
       if (resource.endsWith('read'))
         if (resource === 'read')

--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -418,14 +418,14 @@ const basicStrategy = (authServer, scopes, secret, algorithm) => {
   };
 };
 
-const parseTokenScope = (token) => {
+const parseScopes = (scopes) => {
   const result = {
     readResourceScopes : [],
     writeResourceScopes : [],
     hasSystemReadScope : false,
     hasSystemWriteScope : false
   };
-  const scopes = getScope(token);
+
   for (let scope of scopes)
     if (scope.match('abacus.usage.*(read|write)')) {
       let resource = scope.substring(13);
@@ -443,6 +443,20 @@ const parseTokenScope = (token) => {
             resource.substring(0, resource.length - 6));
     }
   return result;
+};
+
+const parseTokenScope = (auth) => {
+  if (!auth)
+    throw {
+      statusCode: 401,
+      header: {
+        'WWW-Authenticate': 'Bearer realm="cf", error="invalid_token",' +
+          ' error_description="malformed"'
+      }
+    };
+  const token = auth.replace(/^bearer /i, '');
+  const scopes = getScope(token);
+  return parseScopes(scopes);
 };
 
 module.exports.cache = cache;

--- a/lib/utils/oauth/src/test/test.js
+++ b/lib/utils/oauth/src/test/test.js
@@ -138,7 +138,6 @@ describe('abacus-oauth', () => {
       scopes = oauth.parseTokenScope(signedToken);
 
       expect(scopes).not.to.equal(undefined);
-      expect(scopes.hasValidScopes).to.equal(true);
       expect(scopes.hasSystemReadScope).to.equal(false);
       expect(scopes.hasSystemWriteScope).to.equal(false);
       expect(scopes.readResourceScopes).to.deep.equal([ 'test-resource' ]);
@@ -153,9 +152,10 @@ describe('abacus-oauth', () => {
       scopes = oauth.parseTokenScope(signedToken);
 
       expect(scopes).not.to.equal(undefined);
-      expect(scopes.hasValidScopes).to.equal(true);
       expect(scopes.hasSystemReadScope).to.equal(true);
       expect(scopes.hasSystemWriteScope).to.equal(true);
+      expect(scopes.readResourceScopes.length).to.equal(0);
+      expect(scopes.writeResourceScopes.length).to.equal(0);
     });
 
     it('should fail with incorrect scope', () => {
@@ -166,7 +166,25 @@ describe('abacus-oauth', () => {
       scopes = oauth.parseTokenScope(signedToken);
 
       expect(scopes).not.to.equal(undefined);
-      expect(scopes.hasValidScopes).to.equal(false);
+      expect(scopes.hasSystemReadScope).to.equal(false);
+      expect(scopes.hasSystemWriteScope).to.equal(false);
+      expect(scopes.readResourceScopes.length).to.equal(0);
+      expect(scopes.writeResourceScopes.length).to.equal(0);
+    });
+
+    it('should extract system read and resource write scopes', () => {
+      const signedToken = jwt.sign(extend(tokenPayload,
+        { scope: ['abacus.usage.read',
+          'abacus.usage.test-resource.write'] }),
+        tokenSecret, { expiresIn: 43200 });
+
+      scopes = oauth.parseTokenScope(signedToken);
+
+      expect(scopes).not.to.equal(undefined);
+      expect(scopes.hasSystemReadScope).to.equal(true);
+      expect(scopes.hasSystemWriteScope).to.equal(false);
+      expect(scopes.readResourceScopes.length).to.equal(0);
+      expect(scopes.writeResourceScopes).to.deep.equal([ 'test-resource' ]);
     });
   });
 

--- a/lib/utils/oauth/src/test/test.js
+++ b/lib/utils/oauth/src/test/test.js
@@ -106,6 +106,70 @@ const signToken = (authorities, scopes) => {
 const oauth = require('..');
 
 describe('abacus-oauth', () => {
+  context('when retrieving resources from token scope', () => {
+    const tokenPayload = {
+      jti: '254abca5-1c25-40c5-99d7-2cc641791517',
+      sub: 'abacus-usage-reporting',
+      authorities: [
+        'abacus.usage.read'
+      ],
+      client_id: 'abacus-usage-reporting',
+      cid: 'abacus-usage-reporting',
+      azp: 'abacus-usage-reporting',
+      grant_type: 'client_credentials',
+      rev_sig: '2cf89595',
+      iat: 1456147679,
+      exp: 1456190879,
+      iss: 'https://localhost:1234/oauth/token',
+      zid: 'uaa',
+      aud: [
+        'abacus-usage-reporting',
+        'abacus.usage'
+      ]
+    };
+    let scopes;
+
+    it('should extract the resource from the scope', () => {
+      const signedToken = jwt.sign(extend(tokenPayload,
+        { scope: ['abacus.usage.test-resource.read',
+          'abacus.usage.test-resource.write', 'some.other.scope'] }),
+        tokenSecret, { expiresIn: 43200 });
+
+      scopes = oauth.parseTokenScope(signedToken);
+
+      expect(scopes).not.to.equal(undefined);
+      expect(scopes.hasValidScopes).to.equal(true);
+      expect(scopes.hasSystemReadScope).to.equal(false);
+      expect(scopes.hasSystemWriteScope).to.equal(false);
+      expect(scopes.readResourceScopes).to.deep.equal([ 'test-resource' ]);
+      expect(scopes.writeResourceScopes).to.deep.equal([ 'test-resource' ]);
+    });
+
+    it('should extract the system scope', () => {
+      const signedToken = jwt.sign(extend(tokenPayload,
+        { scope: ['abacus.usage.read', 'abacus.usage.write'] }),
+        tokenSecret, { expiresIn: 43200 });
+
+      scopes = oauth.parseTokenScope(signedToken);
+
+      expect(scopes).not.to.equal(undefined);
+      expect(scopes.hasValidScopes).to.equal(true);
+      expect(scopes.hasSystemReadScope).to.equal(true);
+      expect(scopes.hasSystemWriteScope).to.equal(true);
+    });
+
+    it('should fail with incorrect scope', () => {
+      const signedToken = jwt.sign(extend(tokenPayload,
+        { scope: ['some.other.scope'] }),
+        tokenSecret, { expiresIn: 43200 });
+
+      scopes = oauth.parseTokenScope(signedToken);
+
+      expect(scopes).not.to.equal(undefined);
+      expect(scopes.hasValidScopes).to.equal(false);
+    });
+  });
+
   it('authenticate requests using validator middleware', (done) => {
     // Create a test Express application
     const app = express();


### PR DESCRIPTION
Adds ability to request organization usage report using the same oAuth token used to post usage for specific resource. Changes allow to:
- request organization usage report with oAuth token without system token but with resource specific read scope
- return complete org report when called with system token
- return org report containing only the resource which is part of the oAuth token scope (if resource specific token was used)