### PR TITLE
Adding couch-based connect session store

### DIFF
--- a/lib/utils/couchclient/src/index.js
+++ b/lib/utils/couchclient/src/index.js
@@ -140,7 +140,6 @@ const dropDatabase = (server, database, options, cb) => {
         database, server, err);
       return cb(err);
     }
-
     return cb(null);
   });
 };
@@ -510,6 +509,23 @@ const couchclient = (partitionFn, uriFn, connectionFn, errorDBFn) => {
             return row.error ? [error(row.error), undefined] : [null, row];
           }));
         });
+    },
+
+    // runs query for singleton partitions
+    query: (queryid, opt, cb) => {
+      debug('Query is %s', queryid);
+      const t0 = moment.now();
+      dbops.singleOp((db, doc, cb) => {
+        db.query(doc._id, doc.opt, (err, val) =>
+          err && err.name === 'not_found' ?
+            cb(null, undefined) : cb(error(err), val));
+      }, 'read', {
+        _id: queryid,
+        opt: opt
+      }, dbopt.partition, pool, (err, val) => {
+        perf.report('db.query', t0);
+        cb(err, val);
+      });
     }
   };
 };

--- a/lib/utils/couchclient/src/test/test.js
+++ b/lib/utils/couchclient/src/test/test.js
@@ -1664,6 +1664,57 @@ describe('abacus-couchclient', (d) => {
     clean(db, () => put(db, () => get(db, done)));
   });
 
+  // query test for singleton db
+  it('query test with design doc ', (done) => {
+    const db = couchclient(partition.singleton, couchclient.dburi(
+        dbserver(), 'abacus-couchclient-test-querydb'));
+    let doc = {
+      _id: '_design/design',
+      'language': 'javascript',
+      'views': {
+        'view': {
+          'map': '(function (doc) {\n emit(doc._id);\n })'
+        }
+      }
+    };
+
+    let options = { reduce:false,include_docs: true };
+
+    // try to query undefined query
+    db.query('test-design/test', options , (err , queryresp) => {
+      expect(err).to.be.equal(null);
+      expect(queryresp).to.be.equal(undefined);
+      // create the design document
+      db.put(doc, (err,putresp) => {
+        expect(err).to.be.equal(null);
+        expect(putresp.ok).to.be.equal(true);
+        let document = {
+          id: 'test-doc-id',
+          name: 'doc_test',
+          value: 'test'
+        };
+
+        // insert validate document to db
+        db.put(document, (err, docput) => {
+          expect(err).to.be.equal(null);
+          expect(docput.ok).to.be.equal(true);
+         // run the query to get document
+          db.query('design/view' , options , (err, queryresp) => {
+            expect(err).to.be.equal(null);
+            expect(queryresp.rows.length).to.be.equal(1);
+            expect(queryresp.rows[0].key).to.be.equal('test-doc-id');
+            // delete rmview db if inmemory
+            if(!/:/.test(dbserver()))
+              couchclient.drop(undefined,
+              /^abacus-couchclient-test-querydb-0-0-mrview/, done);
+            else
+              done();
+          });
+        });
+      });
+    });
+  });
+
   context('when dropping databases and partitions', () => {
     before(function() {
       if (process.env.DBCLIENT &&

--- a/lib/utils/couchstore/.gitignore
+++ b/lib/utils/couchstore/.gitignore
@@ -1,0 +1,2 @@
+lib/**
+node_modules/**

--- a/lib/utils/couchstore/README.md
+++ b/lib/utils/couchstore/README.md
@@ -1,0 +1,5 @@
+abacus-couchstore
+===
+
+Couch based session store.
+

--- a/lib/utils/couchstore/package.json
+++ b/lib/utils/couchstore/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "abacus-couchstore",
+  "description": "Couch based Session Store",
+  "license": "Apache-2.0",
+  "version": "0.0.6-dev.9",
+  "private": true,
+  "homepage": "https://github.com/cloudfoundry-incubator/cf-abacus/lib/utils/couchstore",
+  "bugs": {
+    "url": "https://github.com/cloudfoundry-incubator/cf-abacus/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/cloudfoundry-incubator/cf-abacus.git"
+  },
+  "keywords": [
+    "cf",
+    "abacus"
+  ],
+  "files": [
+    ".npmrc",
+    "src/"
+  ],
+  "main": "src/index.js",
+  "scripts": {
+    "test": "eslint && mocha",
+    "lint": "eslint",
+    "pub": "publish"
+  },
+  "dependencies": {
+    "abacus-debug": "file:../debug",
+    "abacus-moment": "file:../moment",
+    "abacus-dbclient":"file:../dbclient",
+    "express-session":"1.15.2"
+  },
+  "devDependencies": {
+    "abacus-eslint": "file:../../../tools/eslint",
+    "abacus-mocha": "file:../../../tools/mocha",
+    "abacus-publish": "file:../../../tools/publish"
+  },
+  "engines": {
+    "node": ">=6.10.0",
+    "npm": "<5.0.0"
+  }
+}

--- a/lib/utils/couchstore/src/index.js
+++ b/lib/utils/couchstore/src/index.js
@@ -1,0 +1,150 @@
+'use strict';
+/*  eslint-disable max-len,no-param-reassign*/
+const moment = require('abacus-moment');
+const partition = require('abacus-partition');
+const couchclient = require('abacus-dbclient');
+const debug = require('abacus-debug')('abacus-couchstore');
+const _ = require('underscore');
+
+const conectCouch = (connect) => {
+  let Store = connect.Store;
+
+  class CouchStore extends Store {
+
+    constructor(options) {
+      super();
+      let dbHandle = couchclient(partition.singleton, couchclient.dburi(
+        options.dbUri, options.dbName));
+      this.db = dbHandle;
+      this.autoRemoveInterval = options.autoRemoveInterval;
+      this.setDesignDocument();
+      this._removeExpiredSession = setInterval(() => this.removeExpiredSession(), this.autoRemoveInterval);
+    }
+
+    set(sid, session, callback) {
+      debug('couchstore set method called');
+      this.db.get(sid, (err, doc) => {
+        if (err || !doc) {
+          debug('no data found constructing document !!');
+          let expires = this.getExpiryTime(session);
+          doc = {
+            '_id': sid,
+            'type': 'connect-session',
+            'session': session,
+            'expires': expires
+          };
+        }
+        else
+          doc.session = session;
+        this.db.put(doc, (err, resp) => {
+          if (err) {
+            debug('failed to update %o', err);
+            return callback(err, resp);
+          }
+          debug('successfully posted document');
+          return callback(null, resp);
+        });
+      });
+    }
+
+    getExpiryTime(session) {
+      debug('expiry time is %s',moment.utc(session.cookie.expires).isValid());
+      if (session && session.cookie && session.cookie.expires)
+        return moment.utc(session.cookie.expires).valueOf();
+      // default expiry time is 15 min
+      return moment.utc().add(15, 'minutes').valueOf();
+    }
+
+    get(sid, callback) {
+      this.db.get(sid, (err, doc) => {
+        if (err || !doc)
+          return callback(err,doc);
+        debug('got this data %o', doc);
+        return callback(null, doc.session);
+      });
+    }
+
+    destroy(sid, callback) {
+      this.db.get(sid, (err, doc) => {
+        if (err || !doc)
+          return callback(err, doc);
+        debug('destroying cookie %o', sid);
+        return this.db.remove(doc, callback);
+      });
+    }
+
+    touch(sid, session, callback) {
+      debug('touch called ');
+      this.db.get(sid, (err, doc) => {
+        if (err)
+          return callback(err);
+        if (session && session.cookie && session.cookie.expires) {
+          debug('touching session from %s to %s', doc.expires, session.cookie.expires);
+          doc.expires = this.getExpiryTime(session);
+          doc.session = session;
+        }
+        return this.db.put(doc, callback);
+      });
+    }
+
+    setDesignDocument() {
+      const createDesignDoc = () => {
+        let doc = {
+          _id: '_design/couchdb-session',
+          'language': 'javascript',
+          'views': {
+            'expires': {
+              'map': '(function (doc) {\n if (doc.type == "connect-session" && doc.expires) {\n emit(doc.expires);\n }\n })'
+            }
+          }
+        };
+
+        this.db.put(doc, (err) => {
+          if (err)
+            debug('failed to update %o', err);
+          else
+            debug('successfully posted design document');
+        });
+      };
+
+      this.db.get('_design/couchdb-session', (err, doc) => {
+        // Delete the design docs if it exists & create the new one
+        if (err || _.isEmpty(doc))
+          createDesignDoc();
+      });
+    }
+
+    removeExpiredSession(callback) {
+      debug('Remove auto interval called');
+      let now = moment.utc().valueOf();
+      let options = { endkey: now, reduce: false, include_docs: true };
+      this.db.query('couchdb-session/expires', options, (err, resp) => {
+        if (err)
+          return callback && callback(err);
+        return this.bulkDestroy(resp.rows, callback);
+      });
+    }
+
+    unsetRemoveExpiredSession() {
+      clearInterval(this._removeExpiredSession);
+    }
+
+    bulkDestroy(rows, callback) {
+      debug('bulk destroy called with %o', rows);
+      let deleteDocs = [];
+      rows.forEach((doc) => {
+        deleteDocs.push({ _id: doc.doc._id, _rev: doc.doc._rev, _deleted: true });
+      });
+      this.db.bulkDocs(deleteDocs, {}, (err, resp) => {
+        if (err)
+          return callback && callback(err);
+        debug('sucessfully deleted session entries');
+        return callback(null,resp);
+      });
+    }
+  }
+
+  return CouchStore;
+};
+
+module.exports = conectCouch;

--- a/lib/utils/couchstore/src/index.js
+++ b/lib/utils/couchstore/src/index.js
@@ -1,12 +1,11 @@
 'use strict';
-/*  eslint-disable max-len,no-param-reassign*/
 const moment = require('abacus-moment');
 const partition = require('abacus-partition');
 const couchclient = require('abacus-dbclient');
 const debug = require('abacus-debug')('abacus-couchstore');
 const _ = require('underscore');
 
-const conectCouch = (connect) => {
+const connectCouch = (connect) => {
   let Store = connect.Store;
 
   class CouchStore extends Store {
@@ -18,25 +17,29 @@ const conectCouch = (connect) => {
       this.db = dbHandle;
       this.autoRemoveInterval = options.autoRemoveInterval;
       this.setDesignDocument();
-      this._removeExpiredSession = setInterval(() => this.removeExpiredSession(), this.autoRemoveInterval);
+      this._removeExpiredSession = setInterval(
+        () => this.removeExpiredSession(), this.autoRemoveInterval);
     }
 
     set(sid, session, callback) {
       debug('couchstore set method called');
       this.db.get(sid, (err, doc) => {
+        let document = null;
         if (err || !doc) {
           debug('no data found constructing document !!');
           let expires = this.getExpiryTime(session);
-          doc = {
+          document = {
             '_id': sid,
             'type': 'connect-session',
             'session': session,
             'expires': expires
           };
         }
-        else
+        else{
           doc.session = session;
-        this.db.put(doc, (err, resp) => {
+          document = doc;
+        }
+        this.db.put(document, (err, resp) => {
           if (err) {
             debug('failed to update %o', err);
             return callback(err, resp);
@@ -79,7 +82,8 @@ const conectCouch = (connect) => {
         if (err)
           return callback(err);
         if (session && session.cookie && session.cookie.expires) {
-          debug('touching session from %s to %s', doc.expires, session.cookie.expires);
+          debug('touch session from %s to %s',
+          doc.expires, session.cookie.expires);
           doc.expires = this.getExpiryTime(session);
           doc.session = session;
         }
@@ -94,7 +98,9 @@ const conectCouch = (connect) => {
           'language': 'javascript',
           'views': {
             'expires': {
-              'map': '(function (doc) {\n if (doc.type == "connect-session" && doc.expires) {\n emit(doc.expires);\n }\n })'
+              'map': '(function (doc) {\n' +
+                'if (doc.type == "connect-session" && doc.expires)' +
+                '{\n emit(doc.expires);\n }\n })'
             }
           }
         };
@@ -133,13 +139,14 @@ const conectCouch = (connect) => {
       debug('bulk destroy called with %o', rows);
       let deleteDocs = [];
       rows.forEach((doc) => {
-        deleteDocs.push({ _id: doc.doc._id, _rev: doc.doc._rev, _deleted: true });
+        deleteDocs.push({ _id: doc.doc._id,
+          _rev: doc.doc._rev, _deleted: true });
       });
       this.db.bulkDocs(deleteDocs, {}, (err, resp) => {
         if (err)
           return callback && callback(err);
-        debug('sucessfully deleted session entries');
-        return callback(null,resp);
+        debug('deleted successfully session entries');
+        return callback && callback(null,resp);
       });
     }
   }
@@ -147,4 +154,4 @@ const conectCouch = (connect) => {
   return CouchStore;
 };
 
-module.exports = conectCouch;
+module.exports = connectCouch;

--- a/lib/utils/couchstore/src/test/test.js
+++ b/lib/utils/couchstore/src/test/test.js
@@ -1,0 +1,142 @@
+'use strict';
+const session = require('express-session');
+const couchStore = require('..')(session);
+const dbclient = require('abacus-dbclient');
+const moment = require('abacus-moment');
+const server = () => process.env.DB;
+
+describe('abacus-couchStore', () => {
+  let store;
+  let dbName = 'abacus-test-dashboard';
+  let cookie = { name: 'test-cookie', cookie: { maxAge: 5000 } };
+
+  before(() => {
+    store = new couchStore({
+      'dbUri': server(),
+      'dbName': dbName,
+      'type': 'connect-session'
+    });
+    store.unsetRemoveExpiredSession();
+  });
+
+  after((done) => {
+    if(!/:/.test(server()))
+      dbclient.drop(undefined, /^abacus-test-dashboard-0-0-mrview/, () => {
+        dbclient.drop(undefined,/^abacus-test-dashboard/, done);
+      });
+    else
+      dbclient.drop(server(),/^abacus-test-dashboard/, done);
+  });
+
+  it('upsert session cookie', (done) => {
+    store.set('test-cookie', cookie, (err, doc) => {
+      expect(err).to.be.equal(null);
+      expect(doc.id).to.be.equal('test-cookie');
+      // test upsert method
+      store.set('test-cookie', cookie, (err, getdoc) => {
+        expect(err).to.be.equal(null);
+        done();
+      });
+    });
+  });
+
+  it('get session cookie', (done) => {
+    store.get('test-cookie', (err, doc) => {
+      expect(err).to.be.equal(null);
+      expect(doc).to.deep.equal(
+        { name: 'test-cookie', cookie: { maxAge: 5000 } });
+      done();
+    });
+  });
+
+  it('get session cookie failure', (done) => {
+    store.get('test-cookie1', (err, doc) => {
+      expect(err).to.be.equal(null);
+      expect(doc).to.be.equal(undefined);
+      done();
+    });
+  });
+
+  it('destroy session cookie', (done) => {
+    store.destroy('test-cookie', (err, resp) => {
+      expect(err).to.be.equal(null);
+      expect(resp.ok).to.be.equal(true);
+      done();
+    });
+  });
+
+  it('destroy session cookie failure', (done) => {
+    store.destroy('test-cookie1', (err, resp) => {
+      expect(err).to.be.equal(null);
+      expect(resp).to.be.equal(undefined);
+      done();
+    });
+  });
+
+  it('touch session cookie without expire time', (done) => {
+    let updateCookie = {
+      name: 'test-cookie', cookie: {
+        expires: null
+      }
+    };
+
+    store.set('test-cookie', updateCookie, (err, resp) => {
+      store.touch('test-cookie', updateCookie, (err, resp) => {
+        store.get('test-cookie', (err, doc) => {
+          expect(err).to.be.equal(null);
+          expect(doc).to.deep.equal({
+            name: 'test-cookie', cookie: {
+              expires: null
+            }
+          });
+          done();
+        });
+
+      });
+    });
+  });
+
+  it('touch session cookie with expire time', (done) => {
+    let updateCookie = {
+      name: 'test-cookie', cookie: {
+        expires: moment.utc(
+          '2014-11-06 19:07:54')
+      }
+    };
+
+    store.set('test-cookie', cookie, (err, resp) => {
+      store.touch('test-cookie', updateCookie, (err, resp) => {
+        store.get('test-cookie', (err, doc) => {
+          expect(err).to.be.equal(null);
+          expect(doc).to.deep.equal({
+            name: 'test-cookie',
+            cookie: { expires: '2014-11-06T19:07:54.000Z' }
+          });
+          done();
+        });
+      });
+    });
+  });
+
+  it('remove expired session', (done) => {
+    let updateCookie = {
+      name: 'test-cookie', cookie: {
+        expires: moment.utc(
+          '2017-08-08 19:07:54')
+      }
+    };
+    store.set('test-cookie-2', updateCookie, (err, setresp) => {
+      expect(setresp.ok).to.be.equal(true);
+      store.removeExpiredSession((err, resp) => {
+        expect(err).to.be.equal(null);
+        expect(resp[0].id).to.deep.equal('test-cookie');
+        expect(resp[1].id).to.deep.equal('test-cookie-2');
+        store.get('test-cookie-2', (err, getresp) => {
+          expect(err).to.be.equal(null);
+          expect(getresp).to.be.equal(undefined);
+          done();
+        });
+      });
+    });
+  });
+});

--- a/lib/utils/couchstore/src/test/test.js
+++ b/lib/utils/couchstore/src/test/test.js
@@ -10,22 +10,40 @@ describe('abacus-couchStore', () => {
   let dbName = 'abacus-test-dashboard';
   let cookie = { name: 'test-cookie', cookie: { maxAge: 5000 } };
 
-  before(() => {
+  let isNotCouchClient = process.env.DBCLIENT &&
+  process.env.DBCLIENT !== 'abacus-couchclient' ;
+  before(function(done) {
+    if(isNotCouchClient) {
+      console.log('  Skipping couchstore tests. DBCLIENT set to',
+        process.env.DBCLIENT);
+      console.log('+++++');
+      this.skip();
+      done();
+    }
     store = new couchStore({
       'dbUri': server(),
       'dbName': dbName,
       'type': 'connect-session'
     });
     store.unsetRemoveExpiredSession();
+    done();
   });
 
-  after((done) => {
+  after(function(done) {
+    if(isNotCouchClient) {
+      console.log('  Skipping couchstore tests. DBCLIENT set to',
+        process.env.DBCLIENT);
+      console.log('+++++');
+      this.skip();
+      done();
+    }
     if(!/:/.test(server()))
       dbclient.drop(undefined, /^abacus-test-dashboard-0-0-mrview/, () => {
         dbclient.drop(undefined,/^abacus-test-dashboard/, done);
       });
     else
       dbclient.drop(server(),/^abacus-test-dashboard/, done);
+    done();
   });
 
   it('upsert session cookie', (done) => {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "abacus-client": "file:lib/utils/client",
     "abacus-cluster": "file:lib/utils/cluster",
     "abacus-couchclient": "file:lib/utils/couchclient",
+    "abacus-couchstore": "file:lib/utils/couchstore",
     "abacus-dataflow": "file:lib/utils/dataflow",
     "abacus-dbclient": "file:lib/utils/dbclient",
     "abacus-dbcommons": "file:lib/utils/dbcommons",


### PR DESCRIPTION
This enables us to support non-sticky, serialized sessions for the Abacus service
dashboard, deployed with couchdb. This change includes:
- Addition of query method to couchclient to run map/reduce queries
- Addition of couch based sessionStore for session management