### PR TITLE
Reporting will ignore aggregated data with missing metrics

### DIFF
--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -122,13 +122,25 @@ const adjustWindows = (windows, ct, t, wl) => map(timewindow.adjustWindows(
   windows, ct, t), (w, i) => first(w, wl[i]));
 
 // Return the charge function for a given plan and metric
-const chargefn = (metrics, metric) => {
-  return filter(metrics, (m) => m.name === metric)[0].chargefn;
+const chargefn = (planId, metrics, metricName) => {
+  const metric = filter(metrics, (m) => m.name === metricName)[0];
+  if (!metric) {
+    edebug('Plan change detected: metric %s missing from plan %s',
+      metricName, planId);
+    return undefined;
+  }
+  return metric.chargefn;
 };
 
 // Return the summarize function for a given metric
-const summarizefn = (metrics, metric) => {
-  return filter(metrics, (m) => m.name === metric)[0].summarizefn;
+const summarizefn = (planId, metrics, metricName) => {
+  const metric = filter(metrics, (m) => m.name === metricName)[0];
+  if (!metric) {
+    edebug('Plan change detected: metric %s missing from plan %s',
+      metricName, planId);
+    return undefined;
+  }
+  return metric.summarizefn;
 };
 
 const setImmediateEx = yieldable((cb) => {
@@ -162,7 +174,8 @@ const hashFunction = (t, values, from, to) =>
   `${t}${JSON.stringify(values)}` +
     `${moment.utc(from).valueOf()}${moment.utc(to).valueOf()}`;
 
-const functionMemoizer = (key, fn) => memoize(fn, hashFunction, lruOpts);
+const functionMemoizer = (key, fn) =>
+  fn ? memoize(fn, hashFunction, lruOpts) : undefined;
 
 // Calculates the charge for a metric under a plan
 // Given the query time, metric object, charge function, usage processed time
@@ -261,7 +274,7 @@ const chargeUsageCb = (t, r, auth, cb) => {
 
           return chargePlanMetric(t, m, r.processed,
             chargeFunctionMemoizer(p.rating_plan_id + m.metric,
-              chargefn(rplan.metrics, m.metric)));
+              chargefn(p.rating_plan_id, rplan.metrics, m.metric)));
         });
 
         // Return the metrics including the calculated charges and the
@@ -278,7 +291,6 @@ const chargeUsageCb = (t, r, auth, cb) => {
         });
 
         cb(undefined, ret);
-        return;
       });
     });
 
@@ -359,7 +371,6 @@ const chargeUsageCb = (t, r, auth, cb) => {
             consumers: accumConsumers
           });
           cb(undefined, res);
-          return;
         });
       });
     };
@@ -381,7 +392,6 @@ const chargeUsageCb = (t, r, auth, cb) => {
         spaces: accumSpaces
       });
       cb(undefined, c);
-      return;
     });
   });
 };
@@ -402,7 +412,7 @@ const chargeInstanceUsage = function *(t, r, auth) {
   const c = extend({}, r, {
     accumulated_usage: map(r.accumulated_usage, (m) => {
       return chargePlanMetric(t, m, r.processed,
-        chargefn(rplan.metrics, m.metric));
+        chargefn(r.rating_plan_id, rplan.metrics, m.metric));
     })
   });
   c.windows = map(zip.apply(_, map(c.accumulated_usage, (au) => au.windows)),
@@ -434,7 +444,6 @@ const transformMapCb = (err, resource, accumResult, cb) => {
   }
 
   cb(undefined, extend({}, resource, accumResult));
-  return;
 };
 
 // Compute usage summaries for the given aggregated usage
@@ -457,10 +466,9 @@ const summarizeUsageCb = (t, a, auth, cb) => {
       }
 
       const mapFn = (m, i, l, cb) => setImmediate(() => {
-
         cb(undefined, summarizeMetric(m, t, a.processed,
           summarizeFunctionMemoizer(p.metering_plan_id + m.metric,
-            summarizefn(mplan.metrics, m.metric))));
+            summarizefn(p.metering_plan_id, mplan.metrics, m.metric))));
       });
 
       tmap(p.aggregated_usage, mapFn, (err, planAccum) => {
@@ -546,7 +554,7 @@ const summarizeInstanceUsage = function *(t, a, auth) {
     accumulated_usage: map(a.accumulated_usage, (m) => {
       setCurrentQuantity(m.windows);
       return summarizeMetric(m, t, a.processed,
-        summarizefn(mplan.metrics, m.metric));
+        summarizefn(a.metering_plan_id, mplan.metrics, m.metric));
     })
   });
   debug('Summarized instance usage %o', s);

--- a/lib/aggregation/reporting/src/test/lib/mocker.js
+++ b/lib/aggregation/reporting/src/test/lib/mocker.js
@@ -7,18 +7,24 @@ const cluster = require('abacus-cluster');
 const oauth = require('abacus-oauth');
 const map = _.map;
 
-const mockRequestModule = () => {
+const mockRequestModule = (getHandler) => {
   const getspy = (reqs, cb) => {
-
-    expect(reqs[0][0]).to.equal(
-      'http://localhost:9881/v1/organizations/:org_id/account/:time');
-
-    cb(undefined, map(reqs, (req) => [undefined, {
-      statusCode:
-        /unauthorized/.test(req[1].org_id || req[1].account_id) ? 401 :
-        /unexisting/.test(req[1].org_id) ? 404 :
-        200
-    }]));
+    const endpoint = reqs[0][0];
+    switch(endpoint) {
+      case 'http://localhost:9881/v1/organizations/:org_id/account/:time':
+        cb(undefined, map(reqs, (req) => [undefined, {
+          statusCode:
+            /unauthorized/.test(req[1].org_id || req[1].account_id) ? 401 :
+              /unexisting/.test(req[1].org_id) ? 404 :
+                200
+        }]));
+        break;
+      default:
+        if (getHandler)
+          getHandler(endpoint, reqs, cb);
+        else
+          cb(`unknown endpoint ${endpoint}`);
+    }
   };
   const reqmock = extend({}, request, {
     batch_get: (reqs, cb) => getspy(reqs, cb)

--- a/lib/aggregation/reporting/src/test/reporting-test.js
+++ b/lib/aggregation/reporting/src/test/reporting-test.js
@@ -229,7 +229,6 @@ describe('abacus-usage-report', () => {
       });
 
       it('succeeds when throttle limit is not exceeded', (done) => {
-
         verify(false, () => verify(true, done));
       });
 
@@ -909,6 +908,7 @@ describe('abacus-usage-report', () => {
             });
 
         });
+
       it('should skip older consumers', (done) => {
         const endOfPreviousMonth = 1420002500000;
 

--- a/lib/aggregation/reporting/src/test/specific-report-test.js
+++ b/lib/aggregation/reporting/src/test/specific-report-test.js
@@ -12,8 +12,6 @@ const builder = require('./lib/builder.js');
 const storage = require('./lib/storage.js');
 const mocker = require('./lib/mocker.js');
 
-/* eslint quotes: 1 */
-
 process.env.DB = process.env.DB || 'test';
 process.env.CLUSTER = 'false';
 const testResourceId = 'resource-1';
@@ -22,11 +20,6 @@ let report = require('..');
 mocker.mockRequestModule();
 mocker.mockClusterModule();
 mocker.mockOAuthModule();
-
-// const sid = 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a';
-// const cid = (p) => p !== 'standard' ? 'UNKNOWN' :
-//   'external:bbeae239-f3f8-483c-9dd0-de6781c38bab';
-// const rid = '0b39fa70-a65f-4183-bae8-385633ca5c87';
 
 // Convenient test case:
 // Space A, consumer A, plan basic basic/basic/basic
@@ -83,7 +76,7 @@ describe('Abacus usage specific report', () => {
   });
 
   context('on extracting org usage', () => {
-    const orgUsage1 = {
+    const orgUsage = {
       'organization_id': '5308227d-9e7f-48fb-8db7-1f0680c49491',
       'account_id': '1234',
       'start': 1420502400000,
@@ -106,7 +99,7 @@ describe('Abacus usage specific report', () => {
         'space_id': 'space1',
         'resources': [{
           'resource_id': 'resource-1',
-          'plans': [builder.buildPlanUsage('basic', planAUsage)] // ARRAY !!!
+          'plans': [builder.buildPlanUsage('basic', planAUsage)]
         },
         {
           'resource_id': 'resource-2',
@@ -126,7 +119,7 @@ describe('Abacus usage specific report', () => {
       'end': 1420502400010,
       'processed': 1420502400020,
       'id': 'k/5308227d-9e7f-48fb-8db7-1f0680c49491/space1/' +
-      'app:3653384d-4754-4802-a44c-9fd363204660/t/0001502371509001',
+        'app:3653384d-4754-4802-a44c-9fd363204660/t/0001502371509001',
       'consumer_id': 'app:3653384d-4754-4802-a44c-9fd363204660',
       'resource_id': 'resource-1',
       'processed_id': '1420502400020-4-0-1-0',
@@ -144,7 +137,7 @@ describe('Abacus usage specific report', () => {
     before((done) => {
       dbclient.drop(process.env.DB,
         /^abacus-aggregator|^abacus-accumulator/, () => {
-          storage.aggregator.put(orgUsage1, () =>
+          storage.aggregator.put(orgUsage, () =>
             storage.aggregator.put(consumerUsage, () => {
               done();
             }));


### PR DESCRIPTION
This can happen if:
1. plan containes metric A
2. submit usage for metric A
3. change plan - remove metric A
4. request usage report

Reporting fails with missing summary and charge function. This fix ignores the usage, but a proper solution would be to:
- time-version plans
- disallow plan changes