### PR TITLE
Introduce authorizer & minor improvements

### DIFF
--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -125,16 +125,17 @@ const getUserInfo = (token) => {
 // token cannot be trusted
 // Returns decoded token
 const validate = (token, secret, algorithm, cb) => {
+  let decoded;
   try {
-    const decoded = jwt.verify(token, secret, { algorithms: algorithm });
-
-    debug('Token validated successfully');
-    cb(null, decoded);
+    decoded = jwt.verify(token, secret, { algorithms: algorithm });
   }
   catch (error) {
     debug('Token validation failed %o', error);
     cb(error);
+    return;
   }
+  debug('Token validated successfully');
+  cb(null, decoded);
 };
 
 // Return an Express middleware that verifies an oauth bearer access token
@@ -245,6 +246,26 @@ const authorize = (auth, expectedScope) => {
   }
 
   debug('Authorized request with scope %o', authScopes);
+};
+
+const authorizer = (secret, algorithm, scopes) => {
+  const validate = validator(secret, algorithm);
+  return (req, res, next) => {
+    validate(req, res, () => {
+      const authHeader = req && req.headers && req.headers.authorization;
+      try {
+        authorize(authHeader, {
+          resource: scopes
+        });
+      }
+      catch (err) {
+        res.status(err.statusCode).
+          header('WWW-Authenticate', err.header['WWW-Authenticate']).end();
+        return;
+      }
+      next();
+    });
+  };
 };
 
 const cache = (authServer, id, secret, scopes, path = 'oauth/token',
@@ -472,6 +493,7 @@ module.exports.cache = cache;
 module.exports.validate = validate;
 module.exports.validator = validator;
 module.exports.authorize = authorize;
+module.exports.authorizer = authorizer;
 module.exports.getUserInfo = getUserInfo;
 module.exports.decodeBasicToken = decodeBasicToken;
 module.exports.getBearerToken = getBearerToken;

--- a/lib/utils/oauth/src/test/test.js
+++ b/lib/utils/oauth/src/test/test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* eslint-disable no-unused-expressions */
-
 const _ = require('underscore');
 const jwt = require('jsonwebtoken');
 const request = require('abacus-request');
@@ -14,7 +12,8 @@ const extend = _.extend;
 const tokenSecret = '2DCQ@#R!Cyhj7nbs4t4fWbb34b';
 const tokenAlgorithm = 'HS256';
 
-const encodedToken = 'eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJmYTFiMjlmZS03NmE' +
+const invalidClientToken =
+  'eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJmYTFiMjlmZS03NmE' +
   '5LTRjMmQtOTAzZS1kZGRkMDU2M2E5ZTMiLCJzdWIiOiJydW50aW1lZXh0IiwiYXV0aG9' +
   'yaXRpZXMiOlsic2NpbS5yZWFkIiwidWFhLnJlc291cmNlIiwib3BlbmlkIiwiY2xvdWR' +
   'fY29udHJvbGxlci5yZWFkIiwic2VydmljZV9icm9rZXIiXSwic2NvcGUiOlsic2NpbS5' +
@@ -26,46 +25,8 @@ const encodedToken = 'eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJmYTFiMjlmZS03NmE' +
   'iLCJzY2ltIiwiY2xvdWRfY29udHJvbGxlciIsInVhYSIsIm9wZW5pZCJdfQ.XscT83dP' +
   'U5pNXODiS0gWJUd0e7OorEQWK6-VFrcmG3s';
 
-const decodedToken = {
-  header: {
-    alg: tokenAlgorithm
-  },
-  payload: {
-    jti: 'fa1b29fe-76a9-4c2d-903e-dddd0563a9e3',
-    sub: 'runtimeext',
-    authorities: [
-      'scim.read',
-      'uaa.resource',
-      'openid',
-      'cloud_controller.read',
-      'service_broker'
-    ],
-    scope: [
-      'scim.read',
-      'uaa.resource',
-      'openid',
-      'cloud_controller.read'
-    ],
-    client_id: 'runtimeext',
-    cid: 'runtimeext',
-    azp: 'runtimeext',
-    grant_type: 'client_credentials',
-    iat: 1440464329,
-    exp: 1440507529,
-    iss: 'https://uaa.cf.net/oauth/token',
-    zid: 'uaa',
-    aud: [
-      'runtimeext',
-      'scim',
-      'cloud_controller',
-      'uaa',
-      'openid'
-    ]
-  },
-  signature: 'XscT83dPU5pNXODiS0gWJUd0e7OorEQWK6-VFrcmG3s'
-};
-
-const encodedUserToken = 'eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI1NTU1NTU1NS02' +
+const invalidUserToken =
+  'eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI1NTU1NTU1NS02' +
   'NjY2LTc3NzctODg4OC05OTk5OTk5OTk5OTkiLCJzdWIiOiIxMTExMTExMS0yMjIyLTMz' +
   'MzMtNDQ0NC0wMDAwMDAwMDAwMDAiLCJzY29wZSI6WyJwYXNzd29yZC53cml0ZSIsIm9w' +
   'ZW5pZCIsImNsb3VkX2NvbnRyb2xsZXIud3JpdGUiLCJjbG91ZF9jb250cm9sbGVyLnJl' +
@@ -77,80 +38,53 @@ const encodedUserToken = 'eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI1NTU1NTU1NS02' +
   'bG91ZF9jb250cm9sbGVyIiwicGFzc3dvcmQiLCJjZiJdfQ.WD1dxkXslvFL8TF87NezU' +
   'EtZ7EYk7kAHZ0LlXfwvdAs';
 
-// Default OAuth bearer access token
-const token = {
-  jti: 'fa1b29fe-76a9-4c2d-903e-dddd0563a9e3',
-  sub: 'test-token',
-  client_id: 'test-token',
-  cid: 'test-token',
-  azp: 'test-token',
-  grant_type: 'client_credentials',
-  iss: 'https://uaa.cf.net/oauth/token',
-  zid: 'uaa',
-  aud: [
-    'abacus',
-    'account'
-  ]
-};
-
 const signToken = (authorities, scopes) => {
-  // signed OAUTH bearer access token with resource scopes and system scopes
-  return jwt.sign(extend(token, {
+  const payload = extend({
+    jti: 'fa1b29fe-76a9-4c2d-903e-dddd0563a9e3',
+    sub: 'test-token',
+    client_id: 'test-token',
+    cid: 'test-token',
+    azp: 'test-token',
+    grant_type: 'client_credentials',
+    iss: 'https://uaa.cf.net/oauth/token',
+    zid: 'uaa',
+    aud: [
+      'abacus',
+      'account'
+    ]
+  },{
     authorities: authorities,
     scope: scopes
-  }), tokenSecret, {
+  });
+  return jwt.sign(payload, tokenSecret, {
     expiresIn: 43200
   });
 };
 
-const oauth = require('..');
-
 describe('abacus-oauth', () => {
-  context('when retrieving resources from token scope', () => {
-    const tokenPayload = {
-      jti: '254abca5-1c25-40c5-99d7-2cc641791517',
-      sub: 'abacus-usage-reporting',
-      authorities: [
-        'abacus.usage.read'
-      ],
-      client_id: 'abacus-usage-reporting',
-      cid: 'abacus-usage-reporting',
-      azp: 'abacus-usage-reporting',
-      grant_type: 'client_credentials',
-      rev_sig: '2cf89595',
-      iat: 1456147679,
-      exp: 1456190879,
-      iss: 'https://localhost:1234/oauth/token',
-      zid: 'uaa',
-      aud: [
-        'abacus-usage-reporting',
-        'abacus.usage'
-      ]
-    };
-    let scopes;
+  const oauth = require('..');
 
+  describe('parseTokenScope', () => {
     it('should extract the resource from the scope', () => {
-      const signedToken = jwt.sign(extend(tokenPayload,
-        { scope: ['abacus.usage.test-resource.read',
-          'abacus.usage.test-resource.write', 'some.other.scope'] }),
-      tokenSecret, { expiresIn: 43200 });
-
-      scopes = oauth.parseTokenScope(signedToken);
-
+      const token = signToken([], [
+        'abacus.usage.test-resource.read',
+        'abacus.usage.test-resource.write',
+        'some.other.scope'
+      ]);
+      const scopes = oauth.parseTokenScope(token);
       expect(scopes).not.to.equal(undefined);
       expect(scopes.hasSystemReadScope).to.equal(false);
       expect(scopes.hasSystemWriteScope).to.equal(false);
-      expect(scopes.readResourceScopes).to.deep.equal([ 'test-resource' ]);
-      expect(scopes.writeResourceScopes).to.deep.equal([ 'test-resource' ]);
+      expect(scopes.readResourceScopes).to.deep.equal(['test-resource']);
+      expect(scopes.writeResourceScopes).to.deep.equal(['test-resource']);
     });
 
     it('should extract the system scope', () => {
-      const signedToken = jwt.sign(extend(tokenPayload,
-        { scope: ['abacus.usage.read', 'abacus.usage.write'] }),
-      tokenSecret, { expiresIn: 43200 });
-
-      scopes = oauth.parseTokenScope(signedToken);
-
+      const token = signToken([], [
+        'abacus.usage.read',
+        'abacus.usage.write'
+      ]);
+      const scopes = oauth.parseTokenScope(token);
       expect(scopes).not.to.equal(undefined);
       expect(scopes.hasSystemReadScope).to.equal(true);
       expect(scopes.hasSystemWriteScope).to.equal(true);
@@ -159,12 +93,10 @@ describe('abacus-oauth', () => {
     });
 
     it('should fail with incorrect scope', () => {
-      const signedToken = jwt.sign(extend(tokenPayload,
-        { scope: ['some.other.scope'] }),
-      tokenSecret, { expiresIn: 43200 });
-
-      scopes = oauth.parseTokenScope(signedToken);
-
+      const token = signToken([], [
+        'some.other.scope'
+      ]);
+      const scopes = oauth.parseTokenScope(token);
       expect(scopes).not.to.equal(undefined);
       expect(scopes.hasSystemReadScope).to.equal(false);
       expect(scopes.hasSystemWriteScope).to.equal(false);
@@ -173,13 +105,11 @@ describe('abacus-oauth', () => {
     });
 
     it('should extract system read and resource write scopes', () => {
-      const signedToken = jwt.sign(extend(tokenPayload,
-        { scope: ['abacus.usage.read',
-          'abacus.usage.test-resource.write'] }),
-      tokenSecret, { expiresIn: 43200 });
-
-      scopes = oauth.parseTokenScope(signedToken);
-
+      const token = signToken([], [
+        'abacus.usage.read',
+        'abacus.usage.test-resource.write'
+      ]);
+      const scopes = oauth.parseTokenScope(token);
       expect(scopes).not.to.equal(undefined);
       expect(scopes.hasSystemReadScope).to.equal(true);
       expect(scopes.hasSystemWriteScope).to.equal(false);
@@ -188,74 +118,154 @@ describe('abacus-oauth', () => {
     });
   });
 
-  it('authenticate requests using validator middleware', (done) => {
-    // Create a test Express application
-    const app = express();
+  describe('validator', () => {
+    let server;
 
-    // Add oauth validator middleware
-    app.use(oauth.validator(tokenSecret, tokenAlgorithm));
-
-    // Get a protected resource
-    app.get('/protected/resource', (req, res) => {
-      res.send('okay');
+    beforeEach((done) => {
+      const app = express();
+      app.use(oauth.validator(tokenSecret, tokenAlgorithm));
+      app.get('/protected/resource', (req, res) => {
+        res.send('okay');
+      });
+      server = app.listen(0, done);
     });
 
-    // Listen on an ephemeral port
-    const server = app.listen(0);
-
-    let cbs = 0;
-    const cb = () => {
-      if (++cbs === 3) done();
-    };
-
-    // Request the protected resource without oauth token
-    request.get('http://localhost::port/protected/resource', {
-      port: server.address().port
-    }, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val.statusCode).to.equal(401);
-      expect(val.headers['www-authenticate']).to.equal('Bearer realm="cf"');
-      cb();
+    afterEach(() => {
+      server.close();
     });
 
-    // Request the protected resource using an oauth token with
-    // invalid signature
-    request.get('http://localhost::port/protected/resource', {
-      port: server.address().port,
-      auth: {
-        bearer: encodedUserToken
-      }
-    }, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val.statusCode).to.equal(401);
-      expect(val.headers['www-authenticate']).to.equal('Bearer realm="cf",' +
-        ' error="invalid_token",' +
-        ' error_description="invalid signature"');
-      cb();
+    it('rejects calls with a missing token', (done) => {
+      request.get('http://localhost::port/protected/resource', {
+        port: server.address().port
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(401);
+        expect(val.headers['www-authenticate']).to.equal('Bearer realm="cf"');
+        done();
+      });
     });
 
-    // Sign a known token using default algorithm (HS256)
-    const signed = jwt.sign(decodedToken.payload, tokenSecret, {
-      expiresIn: 43200
+    it('rejects calls with a token with invalid signature', (done) => {
+      request.get('http://localhost::port/protected/resource', {
+        port: server.address().port,
+        auth: {
+          bearer: invalidUserToken
+        }
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(401);
+        expect(val.headers['www-authenticate']).to.equal(
+          'Bearer realm="cf",' +
+          ' error="invalid_token",' +
+          ' error_description="invalid signature"'
+        );
+        done();
+      });
     });
 
-    // Request the protected resource using a vaid oauth token
-    request.get('http://localhost::port/protected/resource', {
-      port: server.address().port,
-      auth: {
-        bearer: signed
-      }
-    }, (err, val) => {
-      expect(err).to.equal(undefined);
-      expect(val.statusCode).to.equal(200);
-      expect(val.headers['www-authenticate']).to.equal(undefined);
-      expect(val.body).to.equal('okay');
-      cb();
+    it('allows calls with a valid token', (done) => {
+      const token = signToken([], []);
+      request.get('http://localhost::port/protected/resource', {
+        port: server.address().port,
+        auth: {
+          bearer: token
+        }
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.headers['www-authenticate']).to.equal(undefined);
+        expect(val.body).to.equal('okay');
+        done();
+      });
     });
   });
 
-  context('authorize', () => {
+  describe('authorizer', () => {
+    let server;
 
+    beforeEach((done) => {
+      const app = express();
+      app.use(
+        oauth.authorizer(tokenSecret, tokenAlgorithm, ['read', 'write'])
+      );
+      app.get('/protected/resource', (req, res) => {
+        res.send('okay');
+      });
+      server = app.listen(0, done);
+    });
+
+    afterEach(() => {
+      server.close();
+    });
+
+    it('rejects calls with a missing token', (done) => {
+      request.get('http://localhost::port/protected/resource', {
+        port: server.address().port
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(401);
+        expect(val.headers['www-authenticate']).to.equal('Bearer realm="cf"');
+        done();
+      });
+    });
+
+    it('rejects calls with a token with invalid signature', (done) => {
+      request.get('http://localhost::port/protected/resource', {
+        port: server.address().port,
+        auth: {
+          bearer: invalidUserToken
+        }
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(401);
+        expect(val.headers['www-authenticate']).to.equal('Bearer realm="cf",' +
+          ' error="invalid_token",' +
+          ' error_description="invalid signature"');
+        done();
+      });
+    });
+
+    it('rejects calls with a token with insufficient scopes', (done) => {
+      const token = signToken([], []);
+      request.get('http://localhost::port/protected/resource', {
+        port: server.address().port,
+        auth: {
+          bearer: token
+        }
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(403);
+        expect(val.headers['www-authenticate']).to.equal(
+          'Bearer realm="cf",' +
+          ' error="insufficient_scope",' +
+          ' error_description="read,write"'
+        );
+        done();
+      });
+    });
+
+    it('allows calls with a token with required scopes', (done) => {
+      const token = signToken([], [
+        'read',
+        'write',
+        'other'
+      ]);
+      request.get('http://localhost::port/protected/resource', {
+        port: server.address().port,
+        auth: {
+          bearer: token
+        }
+      }, (err, val) => {
+        expect(err).to.equal(undefined);
+        expect(val.statusCode).to.equal(200);
+        expect(val.headers['www-authenticate']).to.equal(undefined);
+        expect(val.body).to.equal('okay');
+        done();
+      });
+    });
+  });
+
+  describe('authorize', () => {
     const assertFails = (func, cb) => {
       let thrown = false;
       try {
@@ -265,19 +275,15 @@ describe('abacus-oauth', () => {
         cb(err);
         thrown = true;
       }
-      expect(thrown).to.be.true;
+      expect(thrown).to.equal(true);
     };
 
-    const authHeader = 'Bearer ' + jwt.sign(extend(token, {
-      authorities: [
-        'resource.write', 'resource.read', 'system.write', 'system.read'
-      ],
-      scope: [
-        'resource.write', 'resource.read', 'system.write', 'system.read'
-      ]
-    }), tokenSecret, {
-      expiresIn: 43200
-    });
+    const authorities = [
+      'resource.write', 'resource.read', 'system.write', 'system.read'
+    ];
+    const scopes = authorities;
+    const token = signToken(authorities, scopes);
+    const authHeader = `Bearer ${token}`;
 
     const expectedError = {
       statusCode: 403,
@@ -287,27 +293,27 @@ describe('abacus-oauth', () => {
       }
     };
 
-    it('pass when no scopes defined', () => {
+    it('passes when no scopes defined', () => {
       oauth.authorize(authHeader, undefined);
     });
 
-    it('pass when empty scopes defined', () => {
+    it('passes when empty scopes defined', () => {
       oauth.authorize(authHeader, {});
     });
 
-    it('pass when all requested (single) resource scopes contained', () => {
+    it('passes when all requested (single) resource scopes contained', () => {
       oauth.authorize(authHeader, {
         resource: ['resource.write']
       });
     });
 
-    it('pass when all requested (multiple) resource scopes contained', () => {
+    it('passes when all requested (multiple) resource scopes contained', () => {
       oauth.authorize(authHeader, {
         resource: ['resource.write', 'resource.read']
       });
     });
 
-    it('pass when requested system scope contained', () => {
+    it('passes when requested system scope contained', () => {
       oauth.authorize(authHeader, {
         resource: [],
         system: ['system.write']
@@ -315,7 +321,7 @@ describe('abacus-oauth', () => {
     });
 
     // eslint-disable-next-line max-len
-    it('pass when requested system scope contained, regardless of resource scopes', () => {
+    it('passes when requested system scope contained, regardless of resource scopes', () => {
       oauth.authorize(authHeader, {
         resource: ['missing.write'],
         system: ['system.write']
@@ -557,15 +563,13 @@ describe('abacus-oauth', () => {
   });
 
   it('Get user information', () => {
-    // Get user information and validate it
-    const user = oauth.getUserInfo(encodedUserToken);
+    const user = oauth.getUserInfo(invalidUserToken);
     expect(user).to.deep.equal({
       user_id: '11111111-2222-3333-4444-000000000000',
       user_name: 'user@cf.org'
     });
 
-    // Get client information and validate it
-    const client = oauth.getUserInfo(encodedToken);
+    const client = oauth.getUserInfo(invalidClientToken);
     expect(client).to.deep.equal({
       client_id: 'runtimeext'
     });


### PR DESCRIPTION
## Changes

* We introduce a new `authorizer` middleware that performs OAuth scope-based authorization.
* We fix a problem where if a middleware throws an error, the `validator` middleware would obscure that and report it as an OAuth authentication problem.
* We refactored a large part of the OAuth tests (boy scout rule).

Signed-off-by: Martin Aleksandrov <martin.d.aleksandrov@gmail.com>