### PR TITLE
Allow callback in listen function

### DIFF
--- a/lib/utils/express/src/index.js
+++ b/lib/utils/express/src/index.js
@@ -525,7 +525,7 @@ const lconf = (opt) => {
 
 // An implementation of app.listen() that uses our Express handler middleware,
 // and the port configured in the app's environment
-const listen = function(opt) {
+const listen = function(opt, cb) {
   const app = this;
 
   // Configure the listen options
@@ -595,7 +595,7 @@ const listen = function(opt) {
   });
 
   // Listen on the configured port
-  server.listen(conf.port, conf.hostname, undefined, () => {
+  server.listen(conf.port, conf.hostname, undefined, (err) => {
     debug('Server listening on %d', server.address().port);
 
     // Signal that we're listening
@@ -604,6 +604,9 @@ const listen = function(opt) {
         listening: server.address().port
       }
     });
+
+    if (cb)
+      cb(err);
   });
 
   // Return the server we're using

--- a/lib/utils/webapp/src/index.js
+++ b/lib/utils/webapp/src/index.js
@@ -99,12 +99,12 @@ const webapp = () => {
 
   // Monkey patch the app listen function to register some of our middleware
   // after the app's middleware
-  app.listen = wrap(app.listen, (listen, opt) => {
+  app.listen = wrap(app.listen, (listen, opt, cb) => {
     app.use(hystrix.stream());
 
     // Call the original app listen function
     debug('Listening');
-    const server = listen.call(app, opt);
+    const server = listen.call(app, opt, cb);
 
     // Optionally register the app instance in a Eureka registry
     if(cluster.isMaster() && eureka())


### PR DESCRIPTION
## Changes

The original contract of the `express` listen function allows a callback function as a last argument, so that users can check if the server really booted up correctly (i.e. handle port-in-use errors).

In Abacus, we have custom wrapper `listen` functions that don't abide to that contract, hence a server error could not be properly detected.

This change modifies our `listen` wrappers, allowing a callback function to be passed.

Signed-off-by: Martin Aleksandrov <martin.d.aleksandrov@gmail.com>