### PR TITLE
Add launcher dependency to bridges

### DIFF
--- a/lib/aggregation/accumulator/npm-shrinkwrap.json
+++ b/lib/aggregation/accumulator/npm-shrinkwrap.json
@@ -333,9 +333,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -697,9 +697,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1276,9 +1276,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1346,9 +1346,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
       "dev": true
     },
     "immediate": {
@@ -1421,7 +1421,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1440,9 +1440,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1808,9 +1808,16 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2094,31 +2101,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2810,6 +2795,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/lib/aggregation/aggregator/npm-shrinkwrap.json
+++ b/lib/aggregation/aggregator/npm-shrinkwrap.json
@@ -333,9 +333,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -697,9 +697,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1276,9 +1276,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1346,9 +1346,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
       "dev": true
     },
     "immediate": {
@@ -1421,7 +1421,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1440,9 +1440,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1808,9 +1808,16 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2094,31 +2101,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2810,6 +2795,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/lib/aggregation/reporting/npm-shrinkwrap.json
+++ b/lib/aggregation/reporting/npm-shrinkwrap.json
@@ -492,9 +492,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -824,9 +824,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1433,9 +1433,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1503,9 +1503,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -1579,7 +1579,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1603,9 +1603,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1980,9 +1980,16 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2246,31 +2253,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2992,6 +2977,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/lib/cf/applications/npm-shrinkwrap.json
+++ b/lib/cf/applications/npm-shrinkwrap.json
@@ -112,6 +112,11 @@
       "from": "../../utils/hystrix",
       "resolved": "file:../../utils/hystrix"
     },
+    "abacus-launcher": {
+      "version": "1.0.0",
+      "from": "../../utils/launcher",
+      "resolved": "file:../../utils/launcher"
+    },
     "abacus-lock": {
       "version": "1.0.0",
       "from": "../../utils/lock",
@@ -308,9 +313,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -657,9 +662,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1231,9 +1236,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1301,9 +1306,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
       "dev": true
     },
     "immediate": {
@@ -1376,7 +1381,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1395,9 +1400,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1763,9 +1768,16 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2049,31 +2061,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2765,6 +2755,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/lib/cf/applications/package.json
+++ b/lib/cf/applications/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "abacus-bridge": "file:../../utils/bridge",
     "abacus-debug": "file:../../utils/debug",
+    "abacus-launcher": "file:../../utils/launcher",
     "abacus-moment": "file:../../utils/moment"
   },
   "devDependencies": {

--- a/lib/cf/renewer/npm-shrinkwrap.json
+++ b/lib/cf/renewer/npm-shrinkwrap.json
@@ -481,9 +481,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -808,9 +808,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1423,9 +1423,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1493,9 +1493,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -1569,7 +1569,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1593,9 +1593,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1976,9 +1976,16 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2242,31 +2249,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2995,6 +2980,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/lib/cf/services/npm-shrinkwrap.json
+++ b/lib/cf/services/npm-shrinkwrap.json
@@ -117,6 +117,11 @@
       "from": "../../utils/hystrix",
       "resolved": "file:../../utils/hystrix"
     },
+    "abacus-launcher": {
+      "version": "1.0.0",
+      "from": "../../utils/launcher",
+      "resolved": "file:../../utils/launcher"
+    },
     "abacus-lock": {
       "version": "1.0.0",
       "from": "../../utils/lock",
@@ -318,9 +323,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -667,9 +672,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1241,9 +1246,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1311,9 +1316,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
       "dev": true
     },
     "immediate": {
@@ -1386,7 +1391,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1405,9 +1410,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1773,9 +1778,16 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2059,31 +2071,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2775,6 +2765,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/lib/cf/services/package.json
+++ b/lib/cf/services/package.json
@@ -38,6 +38,7 @@
     "abacus-bridge": "file:../../utils/bridge",
     "abacus-debug": "file:../../utils/debug",
     "abacus-ext-plan-mappings": "0.0.6-dev.9",
+    "abacus-launcher": "file:../../utils/launcher",
     "abacus-moment": "file:../../utils/moment",
     "abacus-paging": "file:../../utils/paging",
     "abacus-perf": "file:../../utils/perf",

--- a/lib/metering/collector/npm-shrinkwrap.json
+++ b/lib/metering/collector/npm-shrinkwrap.json
@@ -492,9 +492,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -824,9 +824,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1433,9 +1433,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1503,9 +1503,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -1579,7 +1579,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1603,9 +1603,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1980,9 +1980,16 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2246,31 +2253,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2992,6 +2977,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/lib/metering/meter/npm-shrinkwrap.json
+++ b/lib/metering/meter/npm-shrinkwrap.json
@@ -323,9 +323,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -687,9 +687,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1266,9 +1266,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1336,9 +1336,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
       "dev": true
     },
     "immediate": {
@@ -1411,7 +1411,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1430,9 +1430,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1798,9 +1798,16 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2084,31 +2091,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2800,6 +2785,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/lib/plugins/account/npm-shrinkwrap.json
+++ b/lib/plugins/account/npm-shrinkwrap.json
@@ -452,9 +452,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -769,9 +769,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1373,9 +1373,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1443,9 +1443,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -1519,7 +1519,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1543,9 +1543,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1920,9 +1920,16 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2186,31 +2193,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2932,6 +2917,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/lib/plugins/authserver/npm-shrinkwrap.json
+++ b/lib/plugins/authserver/npm-shrinkwrap.json
@@ -237,9 +237,9 @@
       }
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -500,9 +500,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -978,9 +978,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
       "dev": true
     },
     "imurmurhash": {

--- a/lib/plugins/eureka/npm-shrinkwrap.json
+++ b/lib/plugins/eureka/npm-shrinkwrap.json
@@ -288,9 +288,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -637,9 +637,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1211,9 +1211,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1281,9 +1281,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
       "dev": true
     },
     "immediate": {
@@ -1356,7 +1356,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1375,9 +1375,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1743,9 +1743,16 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2029,31 +2036,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2745,6 +2730,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/lib/plugins/provisioning/npm-shrinkwrap.json
+++ b/lib/plugins/provisioning/npm-shrinkwrap.json
@@ -452,9 +452,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -769,9 +769,9 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1373,9 +1373,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1443,9 +1443,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -1519,7 +1519,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1543,9 +1543,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1920,9 +1920,16 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2186,31 +2193,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2932,6 +2917,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/lib/utils/pouchserver/npm-shrinkwrap.json
+++ b/lib/utils/pouchserver/npm-shrinkwrap.json
@@ -282,9 +282,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -665,9 +665,9 @@
       "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz"
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -1163,6 +1163,11 @@
           "version": "1.1.0",
           "from": "setprototypeof@1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "from": "statuses@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
         }
       }
     },
@@ -1258,7 +1263,14 @@
     "finalhandler": {
       "version": "1.1.0",
       "from": "finalhandler@1.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "dependencies": {
+        "statuses": {
+          "version": "1.3.1",
+          "from": "statuses@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+        }
+      }
     },
     "flat-cache": {
       "version": "1.3.0",
@@ -1456,9 +1468,9 @@
       "dev": true
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -1517,9 +1529,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
       "dev": true
     },
     "immediate": {
@@ -1617,7 +1629,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -1636,9 +1648,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -2053,9 +2065,16 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -2352,31 +2371,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -2957,9 +2954,9 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "q": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "from": "q@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
     },
     "qs": {
       "version": "6.5.1",
@@ -3138,7 +3135,14 @@
     "send": {
       "version": "0.16.1",
       "from": "send@0.16.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz"
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "dependencies": {
+        "statuses": {
+          "version": "1.3.1",
+          "from": "statuses@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+        }
+      }
     },
     "serve-static": {
       "version": "1.13.1",
@@ -3244,9 +3248,9 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
     },
     "statuses": {
-      "version": "1.3.1",
+      "version": "1.4.0",
       "from": "statuses@>=1.3.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
     },
     "string_decoder": {
       "version": "0.10.31",
@@ -3380,6 +3384,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1558,9 +1558,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.3",
+      "version": "5.2.4",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.4.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1945,9 +1945,9 @@
       }
     },
     "compressible": {
-      "version": "2.0.11",
+      "version": "2.0.12",
       "from": "compressible@>=2.0.11 <2.1.0",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
     },
     "compression": {
       "version": "1.7.1",
@@ -2972,9 +2972,9 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
     },
     "has-own-property-x": {
-      "version": "3.1.1",
+      "version": "3.2.0",
       "from": "has-own-property-x@>=3.1.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz"
     },
     "has-symbol-support-x": {
       "version": "1.4.1",
@@ -3172,9 +3172,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.5",
+      "version": "3.3.6",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -3285,7 +3285,7 @@
     },
     "is-function-x": {
       "version": "3.3.0",
-      "from": "is-function-x@>=3.1.1 <4.0.0",
+      "from": "is-function-x@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
@@ -3309,9 +3309,9 @@
       "resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz"
     },
     "is-object-like-x": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "is-object-like-x@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -3779,9 +3779,16 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-4.4.0.tgz"
     },
     "math-clamp-x": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
+      "dependencies": {
+        "to-number-x": {
+          "version": "2.0.0",
+          "from": "to-number-x@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
+        }
+      }
     },
     "math-sign-x": {
       "version": "2.1.0",
@@ -4093,31 +4100,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
     },
     "parse-int-x": {
-      "version": "1.1.0",
-      "from": "parse-int-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz",
-      "dependencies": {
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "parse-int-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz"
     },
     "parseurl": {
       "version": "1.3.2",
@@ -4924,9 +4909,9 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "q": {
-      "version": "1.5.0",
+      "version": "1.5.1",
       "from": "q@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
     },
     "qs": {
       "version": "6.5.1",
@@ -5479,6 +5464,11 @@
       "from": "to-number-x@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
       "dependencies": {
+        "parse-int-x": {
+          "version": "1.1.0",
+          "from": "parse-int-x@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
+        },
         "trim-left-x": {
           "version": "2.0.1",
           "from": "trim-left-x@>=2.0.1 <3.0.0",


### PR DESCRIPTION
## Changes

* Restores the `abacus-launcher` dependency to bridge applications
* Updates shrinkwrap files
