### PR TITLE
Extract basic

### DIFF
--- a/lib/aggregation/accumulator/npm-shrinkwrap.json
+++ b/lib/aggregation/accumulator/npm-shrinkwrap.json
@@ -7,6 +7,11 @@
       "from": "../../utils/audit",
       "resolved": "file:../../utils/audit"
     },
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "../../utils/batch",
@@ -333,9 +338,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1094,6 +1099,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1346,9 +1356,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "dev": true
     },
     "immediate": {
@@ -1410,7 +1420,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1425,9 +1435,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-nan-x": {
       "version": "1.0.1",
@@ -1559,9 +1569,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1809,20 +1819,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -2513,11 +2516,6 @@
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
     },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
-    },
     "samsam": {
       "version": "1.3.0",
       "from": "samsam@>=1.1.3 <2.0.0",
@@ -2605,9 +2603,9 @@
       "dev": true
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -2786,41 +2784,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/aggregation/aggregator/npm-shrinkwrap.json
+++ b/lib/aggregation/aggregator/npm-shrinkwrap.json
@@ -7,6 +7,11 @@
       "from": "../../utils/audit",
       "resolved": "file:../../utils/audit"
     },
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "../../utils/batch",
@@ -333,9 +338,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1094,6 +1099,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1346,9 +1356,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "dev": true
     },
     "immediate": {
@@ -1410,7 +1420,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1425,9 +1435,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-nan-x": {
       "version": "1.0.1",
@@ -1559,9 +1569,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1809,20 +1819,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -2513,11 +2516,6 @@
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
     },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
-    },
     "samsam": {
       "version": "1.3.0",
       "from": "samsam@>=1.1.3 <2.0.0",
@@ -2605,9 +2603,9 @@
       "dev": true
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -2786,41 +2784,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/aggregation/reporting/npm-shrinkwrap.json
+++ b/lib/aggregation/reporting/npm-shrinkwrap.json
@@ -7,6 +7,11 @@
       "from": "../../utils/audit",
       "resolved": "file:../../utils/audit"
     },
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "../../utils/batch",
@@ -497,9 +502,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1248,6 +1253,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1508,9 +1518,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -1574,7 +1584,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1588,9 +1598,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-my-json-valid": {
       "version": "2.16.1",
@@ -1733,9 +1743,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1986,20 +1996,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -2622,9 +2625,9 @@
       }
     },
     "resolve": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "from": "resolve@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
     },
     "resolve-from": {
       "version": "2.0.0",
@@ -2671,11 +2674,6 @@
       "version": "5.1.1",
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-    },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
     },
     "samsam": {
       "version": "1.3.0",
@@ -2768,9 +2766,9 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -2973,41 +2971,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/cf/applications/npm-shrinkwrap.json
+++ b/lib/cf/applications/npm-shrinkwrap.json
@@ -2,6 +2,11 @@
   "name": "abacus-cf-applications",
   "version": "1.0.0",
   "dependencies": {
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "../../utils/batch",
@@ -313,9 +318,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1059,6 +1064,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1306,9 +1316,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "dev": true
     },
     "immediate": {
@@ -1370,7 +1380,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1385,9 +1395,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-nan-x": {
       "version": "1.0.1",
@@ -1519,9 +1529,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1769,20 +1779,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -2473,11 +2476,6 @@
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
     },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
-    },
     "samsam": {
       "version": "1.3.0",
       "from": "samsam@>=1.1.3 <2.0.0",
@@ -2565,9 +2563,9 @@
       "dev": true
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -2746,41 +2744,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/cf/renewer/npm-shrinkwrap.json
+++ b/lib/cf/renewer/npm-shrinkwrap.json
@@ -7,6 +7,11 @@
       "from": "../../utils/audit",
       "resolved": "file:../../utils/audit"
     },
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "../../utils/batch",
@@ -481,9 +486,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1227,6 +1232,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1493,9 +1503,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -1559,7 +1569,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1573,9 +1583,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-my-json-valid": {
       "version": "2.16.1",
@@ -1724,9 +1734,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1977,20 +1987,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -2620,9 +2623,9 @@
       }
     },
     "resolve": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "from": "resolve@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
     },
     "resolve-from": {
       "version": "2.0.0",
@@ -2669,11 +2672,6 @@
       "version": "5.1.1",
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-    },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
     },
     "samsam": {
       "version": "1.3.0",
@@ -2766,9 +2764,9 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -2971,41 +2969,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/cf/services/npm-shrinkwrap.json
+++ b/lib/cf/services/npm-shrinkwrap.json
@@ -2,6 +2,11 @@
   "name": "abacus-cf-services",
   "version": "1.0.0",
   "dependencies": {
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "../../utils/batch",
@@ -323,9 +328,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1069,6 +1074,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1316,9 +1326,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "dev": true
     },
     "immediate": {
@@ -1380,7 +1390,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1395,9 +1405,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-nan-x": {
       "version": "1.0.1",
@@ -1529,9 +1539,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1779,20 +1789,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -2483,11 +2486,6 @@
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
     },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
-    },
     "samsam": {
       "version": "1.3.0",
       "from": "samsam@>=1.1.3 <2.0.0",
@@ -2575,9 +2573,9 @@
       "dev": true
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -2756,41 +2754,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/metering/collector/npm-shrinkwrap.json
+++ b/lib/metering/collector/npm-shrinkwrap.json
@@ -7,6 +7,11 @@
       "from": "../../utils/audit",
       "resolved": "file:../../utils/audit"
     },
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "../../utils/batch",
@@ -492,9 +497,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1243,6 +1248,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1503,9 +1513,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -1569,7 +1579,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1583,9 +1593,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-my-json-valid": {
       "version": "2.16.1",
@@ -1728,9 +1738,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1981,20 +1991,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -2617,9 +2620,9 @@
       }
     },
     "resolve": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "from": "resolve@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
     },
     "resolve-from": {
       "version": "2.0.0",
@@ -2666,11 +2669,6 @@
       "version": "5.1.1",
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-    },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
     },
     "samsam": {
       "version": "1.3.0",
@@ -2763,9 +2761,9 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -2968,41 +2966,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/metering/meter/npm-shrinkwrap.json
+++ b/lib/metering/meter/npm-shrinkwrap.json
@@ -7,6 +7,11 @@
       "from": "../../utils/audit",
       "resolved": "file:../../utils/audit"
     },
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "../../utils/batch",
@@ -323,9 +328,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1084,6 +1089,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1336,9 +1346,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "dev": true
     },
     "immediate": {
@@ -1400,7 +1410,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1415,9 +1425,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-nan-x": {
       "version": "1.0.1",
@@ -1549,9 +1559,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1799,20 +1809,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -2503,11 +2506,6 @@
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
     },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
-    },
     "samsam": {
       "version": "1.3.0",
       "from": "samsam@>=1.1.3 <2.0.0",
@@ -2595,9 +2593,9 @@
       "dev": true
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -2776,41 +2774,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/plugins/account/npm-shrinkwrap.json
+++ b/lib/plugins/account/npm-shrinkwrap.json
@@ -2,6 +2,11 @@
   "name": "abacus-account-plugin",
   "version": "1.0.0",
   "dependencies": {
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "../../utils/batch",
@@ -452,9 +457,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1188,6 +1193,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1443,9 +1453,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -1509,7 +1519,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1523,9 +1533,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-my-json-valid": {
       "version": "2.16.1",
@@ -1668,9 +1678,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1921,20 +1931,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -2557,9 +2560,9 @@
       }
     },
     "resolve": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "from": "resolve@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
     },
     "resolve-from": {
       "version": "2.0.0",
@@ -2606,11 +2609,6 @@
       "version": "5.1.1",
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-    },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
     },
     "samsam": {
       "version": "1.3.0",
@@ -2703,9 +2701,9 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -2908,41 +2906,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/plugins/authserver/npm-shrinkwrap.json
+++ b/lib/plugins/authserver/npm-shrinkwrap.json
@@ -2,6 +2,11 @@
   "name": "abacus-authserver-plugin",
   "version": "1.0.0",
   "dependencies": {
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-cfpack": {
       "version": "1.0.0",
       "from": "../../../tools/cfpack",
@@ -237,9 +242,9 @@
       }
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -783,6 +788,11 @@
       "from": "fast-deep-equal@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -978,9 +988,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "dev": true
     },
     "imurmurhash": {
@@ -1124,9 +1134,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1142,7 +1152,8 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "from": "json-stable-stringify@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -1164,7 +1175,8 @@
     "jsonify": {
       "version": "0.0.0",
       "from": "jsonify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "dev": true
     },
     "jsonwebtoken": {
       "version": "5.7.0",
@@ -1740,9 +1752,9 @@
       "dev": true
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",

--- a/lib/plugins/eureka/npm-shrinkwrap.json
+++ b/lib/plugins/eureka/npm-shrinkwrap.json
@@ -2,6 +2,11 @@
   "name": "abacus-eureka-plugin",
   "version": "1.0.0",
   "dependencies": {
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "../../utils/batch",
@@ -288,9 +293,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1034,6 +1039,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1281,9 +1291,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "dev": true
     },
     "immediate": {
@@ -1345,7 +1355,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1360,9 +1370,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-nan-x": {
       "version": "1.0.1",
@@ -1494,9 +1504,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1744,20 +1754,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -2448,11 +2451,6 @@
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
     },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
-    },
     "samsam": {
       "version": "1.3.0",
       "from": "samsam@>=1.1.3 <2.0.0",
@@ -2540,9 +2538,9 @@
       "dev": true
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -2721,41 +2719,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/plugins/provisioning/npm-shrinkwrap.json
+++ b/lib/plugins/provisioning/npm-shrinkwrap.json
@@ -2,6 +2,11 @@
   "name": "abacus-provisioning-plugin",
   "version": "1.0.0",
   "dependencies": {
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../../utils/basic",
+      "resolved": "file:../../utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "../../utils/batch",
@@ -452,9 +457,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1188,6 +1193,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1443,9 +1453,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -1509,7 +1519,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1523,9 +1533,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-my-json-valid": {
       "version": "2.16.1",
@@ -1668,9 +1678,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -1921,20 +1931,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -2557,9 +2560,9 @@
       }
     },
     "resolve": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "from": "resolve@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
     },
     "resolve-from": {
       "version": "2.0.0",
@@ -2606,11 +2609,6 @@
       "version": "5.1.1",
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-    },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
     },
     "samsam": {
       "version": "1.3.0",
@@ -2703,9 +2701,9 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -2908,41 +2906,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/utils/basic/.gitignore
+++ b/lib/utils/basic/.gitignore
@@ -1,0 +1,2 @@
+lib/**
+node_modules/**

--- a/lib/utils/basic/.npmrc
+++ b/lib/utils/basic/.npmrc
@@ -1,0 +1,1 @@
+optional=false

--- a/lib/utils/basic/README.md
+++ b/lib/utils/basic/README.md
@@ -1,0 +1,3 @@
+abacus-basic
+===
+Contains a number of helper functions for working with Basic Authentication

--- a/lib/utils/basic/package.json
+++ b/lib/utils/basic/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "abacus-hystrix",
-  "description": "Express middleware that serves Hystrix perf stats",
+  "name": "abacus-basic",
+  "description": "Basic authentication helpers",
   "license": "Apache-2.0",
   "version": "1.0.0",
   "private": true,
-  "homepage": "https://github.com/cloudfoundry-incubator/cf-abacus/lib/utils/hystrix",
+  "homepage": "https://github.com/cloudfoundry-incubator/cf-abacus/lib/utils/basic",
   "bugs": {
     "url": "https://github.com/cloudfoundry-incubator/cf-abacus/issues"
   },
@@ -13,8 +13,9 @@
     "url": "http://github.com/cloudfoundry-incubator/cf-abacus.git"
   },
   "keywords": [
-    "cf",
-    "abacus"
+    "abacus",
+    "basic",
+    "cf"
   ],
   "files": [
     ".npmrc",
@@ -26,17 +27,9 @@
     "lint": "eslint",
     "pub": "publish"
   },
-  "dependencies": {
-    "abacus-basic": "file:../basic",
-    "abacus-debug": "file:../debug",
-    "abacus-moment": "file:../moment",
-    "abacus-oauth": "file:../oauth",
-    "abacus-perf": "file:../perf",
-    "abacus-urienv": "file:../urienv",
-    "underscore": "^1.8.3"
-  },
   "devDependencies": {
     "abacus-eslint": "file:../../../tools/eslint",
+    "abacus-express": "file:../express",
     "abacus-mocha": "file:../../../tools/mocha",
     "abacus-publish": "file:../../../tools/publish"
   },

--- a/lib/utils/basic/src/check.js
+++ b/lib/utils/basic/src/check.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * abacus-basic/check module. 
+ * 
+ * Exposes functions for checking basic authentication
+ * related aspects
+ * @module abacus-basic/check
+ */
+
+
+/**
+ * Returns whether the header represents a basic authentication one.
+ * @param {string} header - the authorization header of the request.
+ * @returns true if a basic authentication header, false otherwise
+ */
+const isBasicHeader = (header) => {
+  return /^basic /i.test(header);
+};
+
+/**
+ * Returns whether the request contains a basic authentication header.
+ * @see isBasicHeader
+ * @param req - an express request
+ * @returns true if a basic authentication request, false otherwise
+ */
+const isBasicRequest = (req) => {
+  return isBasicHeader(req.headers && req.headers.authorization);
+};
+
+module.exports = {
+  isBasicHeader,
+  isBasicRequest
+};

--- a/lib/utils/basic/src/credentials.js
+++ b/lib/utils/basic/src/credentials.js
@@ -1,0 +1,65 @@
+'use strict';
+
+/**
+ * abacus-basic/credentials module. 
+ * 
+ * Exposes functions for extracting credentials off of 
+ * basic authentication requests.
+ * @module abacus-basic/credentials
+ */
+
+
+const createMalformedAuthenticationError = () => ({
+  statusCode: 401,
+  header: {
+    'WWW-Authenticate': 'Basic realm="cf", error="invalid_token",' +
+      ' error_description="malformed"'
+  }
+});
+
+const basicPrefix = 'Basic ';
+
+/**
+ * Extracts basic authentication credentials from the specified
+ * express request authorization header.
+ * It is valid to have a missing username or missing password,
+ * in which case the missing component will contain an empty string.
+ * @param {string} header - the authorization header of the request.
+ * @throws in case the header is missing or invalid
+ */
+const fromHeader = (header) => {
+  if (!header)
+    throw createMalformedAuthenticationError();
+
+  if (!header.startsWith(basicPrefix))
+    throw createMalformedAuthenticationError();
+  const encodedCredentials = header.substring(basicPrefix.length);
+
+  const decodedCredentials = 
+    new Buffer(encodedCredentials, 'base64').toString();
+  
+  const segments = decodedCredentials.split(':');
+  if (segments.length !== 2)
+    throw createMalformedAuthenticationError();
+
+  return {
+    username: segments[0],
+    password: segments[1]
+  };
+};
+
+/**
+ * Extracts basic authentication credentials from the specified
+ * express request by checking the authorization header.
+ * @see fromHeader
+ * @param req - an express request
+ * @throws in case the authorization header is missing or invalid
+ */
+const fromRequest = (req) => {
+  return fromHeader(req.headers && req.headers.authorization);
+};
+
+module.exports = {
+  fromHeader,
+  fromRequest
+};

--- a/lib/utils/basic/src/index.js
+++ b/lib/utils/basic/src/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * abacus-basic module. 
+ * 
+ * Exposes functionality related to basic authentication.
+ * @module abacus-basic
+ */
+
+const check = require('./check');
+const credentials = require('./credentials');
+
+module.exports = {
+  check,
+  credentials
+};

--- a/lib/utils/basic/src/test/check-test.js
+++ b/lib/utils/basic/src/test/check-test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const check = require('../check');
+
+describe('check', () => {
+  const basicHeader = 'Basic YWJhY3VzOnRvcC1zZWNyZXQ=';
+  const bearerHeader = 'Bearer YWJhY3VzOnRvcC1zZWNyZXQ=';
+  const corruptBasicHeader = 'BasicYWJhY3VzOnRvcC1zZWNyZXQ=';
+  const request = {
+    headers: {
+      authorization: basicHeader
+    }
+  };
+  const unauthorizedRequest = {
+    headers: {}
+  };
+  const blankRequest = {};
+
+  describe('isBasicHeader', () => {
+    it('returns true on basic auth header', () => {
+      expect(check.isBasicHeader(basicHeader)).to.equal(true);
+    });
+
+    it('returns false on non-basic auth header', () => {
+      expect(check.isBasicHeader(bearerHeader)).to.equal(false);
+    });
+
+    it('returns false on corrupt basic auth header', () => {
+      expect(check.isBasicHeader(corruptBasicHeader)).to.equal(false);
+    });
+  });
+    
+  describe('isBasicRequest', () => {
+    it('returns true on basic request', () => {
+      expect(check.isBasicRequest(request)).to.equal(true);
+    });
+
+    it('returns false on missing auth header', () => {
+      expect(check.isBasicRequest(unauthorizedRequest)).to.equal(false);
+    });
+
+    it('returns false on empty request', () => {
+      expect(check.isBasicRequest(blankRequest)).to.equal(false);
+    });
+  });
+});

--- a/lib/utils/basic/src/test/credentials-test.js
+++ b/lib/utils/basic/src/test/credentials-test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const credentials = require('../credentials');
+
+describe('credentials', () => {
+
+  const username = 'abacus';
+  const password = 'top-secret';
+
+  const header = 'Basic YWJhY3VzOnRvcC1zZWNyZXQ=';
+  const noUsernameHeader = 'Basic OnRvcC1zZWNyZXQ=';
+  const noPasswordHeader = 'Basic YWJhY3VzOg==';
+  const singleSegmentHeader = 'Basic YWJhY3Vz';
+  const threeSegmentHeader = 'Basic YWJhY3VzOnRvcC1zZWNyZXQ6dHJhaWxpbmc=';
+
+  const request = {
+    headers: {
+      authorization: header
+    }
+  };
+  const unauthorizedRequest = {
+    headers: {}
+  };
+  const blankRequest = {};
+
+  describe('fromHeader', () => {
+    it('extracts credentials', () => {
+      const result = credentials.fromHeader(header);
+      expect(result).to.deep.equal({
+        username,
+        password
+      });
+    });
+
+    it('extracts credentials without username', () => {
+      const result = credentials.fromHeader(noUsernameHeader);
+      expect(result).to.deep.equal({
+        username: '',
+        password
+      });
+    });
+
+    it('extracts credentials without password', () => {
+      const result = credentials.fromHeader(noPasswordHeader);
+      expect(result).to.deep.equal({
+        username,
+        password: ''
+      });
+    });
+
+    it('fails on undefined header', () => {
+      expect(() => {
+        credentials.fromHeader(undefined);
+      }).to.throw(Object)
+        .that.has.property('statusCode').that.equals(401);
+    });
+
+    it('fails on empty header', () => {
+      expect(() => {
+        credentials.fromHeader('');
+      }).to.throw(Object)
+        .that.has.property('statusCode').that.equals(401);
+    });
+
+    it('fails on invalid header', () => {
+      expect(() => {
+        credentials.fromHeader('BasicYWJhY3VzOnRvcC1zZWNyZXQ=');
+      }).to.throw(Object)
+        .that.has.property('statusCode').that.equals(401);
+    });
+
+    it('fails on insufficient segments', () => {
+      expect(() => {
+        credentials.fromHeader(singleSegmentHeader);
+      }).to.throw(Object)
+        .that.has.property('statusCode').that.equals(401);
+    });
+
+    it('fails on excess segments', () => {
+      expect(() => {
+        credentials.fromHeader(threeSegmentHeader);
+      }).to.throw(Object)
+        .that.has.property('statusCode').that.equals(401);
+    });
+  });
+
+  describe('fromRequest', () => {
+    it('extracts credentials', () => {
+      const result = credentials.fromRequest(request);
+      expect(result).to.deep.equal({
+        username,
+        password
+      });
+    });
+
+    it('fails on missing header', () => {
+      expect(() => {
+        credentials.fromRequest(unauthorizedRequest);
+      }).to.throw(Object)
+        .that.has.property('statusCode').that.equals(401);
+    });
+
+    it('fails on missing headers', () => {
+      expect(() => {
+        credentials.fromRequest(blankRequest);
+      }).to.throw(Object)
+        .that.has.property('statusCode').that.equals(401);
+    });
+  });
+});

--- a/lib/utils/basic/src/test/test.js
+++ b/lib/utils/basic/src/test/test.js
@@ -1,0 +1,10 @@
+'use strict';
+
+describe('basic', () => {
+  it('exposes credentials module', () => {
+    expect(require('..').credentials).equals(require('../credentials'));
+  });
+  it('exposes check module', () => {
+    expect(require('..').check).equals(require('../check'));
+  });
+});

--- a/lib/utils/hystrix/src/index.js
+++ b/lib/utils/hystrix/src/index.js
@@ -3,6 +3,7 @@
 // Support for Netflix Hystrix, serves a stream of Hystrix command stats
 
 const _ = require('underscore');
+const basicCredentials = require('abacus-basic').credentials;
 const oauth = require('abacus-oauth');
 const perf = require('abacus-perf');
 const urienv = require('abacus-urienv');
@@ -204,13 +205,9 @@ const stream = () => {
       };
 
       if(secured()) {
-        // Get basic token
-        const auth = req.headers && req.headers.authorization;
-        // Extracts username and password
-        const user = oauth.decodeBasicToken(auth);
-        // Get bearer token from UAA to get the credentials
-        oauth.getBearerToken(uris.auth_server, user[0],
-          user[1], 'abacus.system.read', (err, token) => {
+        const { username, password } = basicCredentials.fromRequest(req);
+        oauth.getBearerToken(uris.auth_server, username,
+          password, 'abacus.system.read', (err, token) => {
             if(err)
               throw err;
             oauth.authorize(token, rscope());

--- a/lib/utils/oauth/package.json
+++ b/lib/utils/oauth/package.json
@@ -28,6 +28,7 @@
     "pub": "publish"
   },
   "dependencies": {
+    "abacus-basic": "file:../basic",
     "abacus-debug": "file:../debug",
     "abacus-moment": "file:../moment",
     "abacus-request": "file:../request",

--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -7,6 +7,10 @@ const jwt = require('jsonwebtoken');
 const lru = require('abacus-lrucache');
 const request = require('abacus-request');
 const retry = require('abacus-retry');
+const basic = require('abacus-basic');
+
+const isBasicRequest = basic.check.isBasicRequest;
+const basicCredentials = basic.credentials;
 
 const each = _.each;
 const isEmpty = _.isEmpty;
@@ -348,25 +352,6 @@ const cache = (authServer, id, secret, scopes, path = 'oauth/token',
   return wrapper;
 };
 
-// Extract basic token to get username and password
-const decodeBasicToken = (auth) => {
-  try {
-    const user = new Buffer(auth.split(' ')[1], 'base64').toString().split(':');
-    if (!user[0] || !user[1])
-      throw new Error('Invalid token');
-    return user;
-  }
-  catch (e) {
-    throw {
-      statusCode: 401,
-      header: {
-        'WWW-Authenticate': 'Basic realm="cf", error="invalid_token",' +
-          ' error_description="malformed"'
-      }
-    };
-  }
-};
-
 // Get OAuth bearer access token
 const getBearerToken = (authServer, id, secret, scopes, cb) => {
   // Get token endpoint from OAuth server
@@ -401,13 +386,10 @@ const basicStrategy = (authServer, scopes, secret, algorithm) => {
   return (req, res, next) => {
     debug('Authenticating request using basic strategy');
 
-    if (req.headers && req.headers.authorization &&
-      /^basic /i.test(req.headers.authorization)) {
-      const basicToken = req.headers.authorization;
-      let credentials;
+    if (isBasicRequest(req))
       try {
-        credentials = decodeBasicToken(basicToken);
-        getBearerToken(authServer, credentials[0], credentials[1],
+        const { username, password } = basicCredentials.fromRequest(req);
+        getBearerToken(authServer, username, password,
           scopes, (err, token) => {
             if(err) {
               edebug('Error while retrieving bearer token due to %o', err);
@@ -436,7 +418,6 @@ const basicStrategy = (authServer, scopes, secret, algorithm) => {
         edebug('Error decoding basic auth token due to %o', e);
         res.status(e.statusCode).header(e.header).end();
       }
-    }
     else {
       edebug('Invalid authorization token, %o',
         req.headers ? req.headers.authorization : '');
@@ -495,7 +476,6 @@ module.exports.validator = validator;
 module.exports.authorize = authorize;
 module.exports.authorizer = authorizer;
 module.exports.getUserInfo = getUserInfo;
-module.exports.decodeBasicToken = decodeBasicToken;
 module.exports.getBearerToken = getBearerToken;
 module.exports.basicStrategy = basicStrategy;
 module.exports.parseTokenScope = parseTokenScope;

--- a/lib/utils/oauth/src/test/test.js
+++ b/lib/utils/oauth/src/test/test.js
@@ -575,17 +575,6 @@ describe('abacus-oauth', () => {
     });
   });
 
-  it('Decode basic token', () => {
-    const user = oauth.decodeBasicToken('Basic YWJhY3VzOkhTMjU2');
-    expect(user).to.deep.equal(['abacus', 'HS256']);
-    try {
-      oauth.decodeBasicToken('Basic a');
-    }
-    catch(e) {
-      expect(e.statusCode).to.equal(401);
-    }
-  });
-
   it('Get bearer access token', (done) => {
     // Create a test Express application
     const app = express();

--- a/lib/utils/pouchserver/npm-shrinkwrap.json
+++ b/lib/utils/pouchserver/npm-shrinkwrap.json
@@ -2,6 +2,11 @@
   "name": "abacus-pouchserver",
   "version": "1.0.0",
   "dependencies": {
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "../basic",
+      "resolved": "file:../basic"
+    },
     "abacus-cfpack": {
       "version": "1.0.0",
       "from": "../../../tools/cfpack",
@@ -282,9 +287,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -1229,6 +1234,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -1529,9 +1539,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.3.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "dev": true
     },
     "immediate": {
@@ -1618,7 +1628,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -1633,9 +1643,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-nan-x": {
       "version": "1.0.1",
@@ -1772,9 +1782,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "json-schema": {
@@ -2066,20 +2076,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -3106,11 +3109,6 @@
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
     },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
-    },
     "samsam": {
       "version": "1.3.0",
       "from": "samsam@>=1.1.3 <2.0.0",
@@ -3209,9 +3207,9 @@
       "dev": true
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.1.31",
@@ -3375,41 +3373,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/lib/utils/webapp/package.json
+++ b/lib/utils/webapp/package.json
@@ -31,6 +31,7 @@
     "pub": "publish"
   },
   "dependencies": {
+    "abacus-basic": "file:../basic",
     "abacus-cluster": "file:../cluster",
     "abacus-debug": "file:../debug",
     "abacus-eureka": "file:../eureka",

--- a/lib/utils/webapp/src/index.js
+++ b/lib/utils/webapp/src/index.js
@@ -4,6 +4,7 @@
 // Also sets up some call perf metrics collection across the cluster.
 
 const _ = require('underscore');
+const basicCredentials = require('abacus-basic').credentials;
 const express = require('abacus-express');
 const cluster = require('abacus-cluster');
 const vcapenv = require('abacus-vcapenv');
@@ -55,10 +56,9 @@ const healthCheck = (req, res) => {
     return;
   }
 
-  const token = req.headers && req.headers.authorization;
-  const userPassPair = oauth.decodeBasicToken(token);
+  const { username, password } = basicCredentials.fromRequest(req);
 
-  oauth.getBearerToken(uris.auth_server, userPassPair[0], userPassPair[1],
+  oauth.getBearerToken(uris.auth_server, username, password,
     'abacus.system.read', (err, token) => {
       if(err) {
         edebug('Error during health check user validation %o', err);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,6 +17,11 @@
       "from": "lib/plugins/authserver",
       "resolved": "file:lib/plugins/authserver"
     },
+    "abacus-basic": {
+      "version": "1.0.0",
+      "from": "lib/utils/basic",
+      "resolved": "file:lib/utils/basic"
+    },
     "abacus-batch": {
       "version": "1.0.0",
       "from": "lib/utils/batch",
@@ -1563,9 +1568,9 @@
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz"
     },
     "ajv": {
-      "version": "5.2.5",
+      "version": "5.3.0",
       "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
       "dependencies": {
         "co": {
           "version": "4.6.0",
@@ -2739,6 +2744,11 @@
       "from": "fast-future@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz"
     },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "from": "fast-levenshtein@>=2.0.4 <2.1.0",
@@ -3177,9 +3187,9 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
     },
     "ignore": {
-      "version": "3.3.6",
+      "version": "3.3.7",
       "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz"
     },
     "immediate": {
       "version": "3.2.3",
@@ -3280,7 +3290,7 @@
     },
     "is-finite-x": {
       "version": "3.0.2",
-      "from": "is-finite-x@>=3.0.1 <4.0.0",
+      "from": "is-finite-x@>=3.0.2 <4.0.0",
       "resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz"
     },
     "is-fullwidth-code-point": {
@@ -3294,9 +3304,9 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz"
     },
     "is-index-x": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-index-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz"
     },
     "is-my-json-valid": {
       "version": "2.16.1",
@@ -3437,9 +3447,9 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz"
     },
     "jschardet": {
-      "version": "1.5.1",
+      "version": "1.6.0",
       "from": "jschardet@>=1.4.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "dev": true
     },
     "jshint": {
@@ -3785,20 +3795,13 @@
     },
     "math-clamp-x": {
       "version": "1.2.0",
-      "from": "math-clamp-x@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "dependencies": {
-        "to-number-x": {
-          "version": "2.0.0",
-          "from": "to-number-x@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
-        }
-      }
+      "from": "math-clamp-x@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz"
     },
     "math-sign-x": {
-      "version": "2.1.0",
-      "from": "math-sign-x@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "math-sign-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz"
     },
     "max-safe-integer": {
       "version": "1.0.1",
@@ -5059,9 +5062,9 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
     },
     "resolve": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "from": "resolve@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
     },
     "resolve-from": {
       "version": "2.0.0",
@@ -5114,11 +5117,6 @@
       "version": "5.1.1",
       "from": "safe-buffer@>=5.1.1 <6.0.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-    },
-    "safe-to-string-x": {
-      "version": "2.0.3",
-      "from": "safe-to-string-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-to-string-x/-/safe-to-string-x-2.0.3.tgz"
     },
     "samsam": {
       "version": "1.3.0",
@@ -5216,9 +5214,9 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
     "sntp": {
-      "version": "2.0.2",
+      "version": "2.1.0",
       "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
     },
     "source-map": {
       "version": "0.5.7",
@@ -5460,41 +5458,14 @@
       "resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz"
     },
     "to-integer-x": {
-      "version": "2.1.0",
-      "from": "to-integer-x@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-2.1.0.tgz"
+      "version": "3.0.0",
+      "from": "to-integer-x@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz"
     },
     "to-number-x": {
-      "version": "1.2.0",
-      "from": "to-number-x@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-1.2.0.tgz",
-      "dependencies": {
-        "parse-int-x": {
-          "version": "1.1.0",
-          "from": "parse-int-x@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-1.1.0.tgz"
-        },
-        "trim-left-x": {
-          "version": "2.0.1",
-          "from": "trim-left-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-2.0.1.tgz"
-        },
-        "trim-right-x": {
-          "version": "2.0.1",
-          "from": "trim-right-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-2.0.1.tgz"
-        },
-        "trim-x": {
-          "version": "2.0.2",
-          "from": "trim-x@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-2.0.2.tgz"
-        },
-        "white-space-x": {
-          "version": "2.0.3",
-          "from": "white-space-x@>=2.0.3 <3.0.0",
-          "resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-2.0.3.tgz"
-        }
-      }
+      "version": "2.0.0",
+      "from": "to-number-x@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz"
     },
     "to-object-x": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "abacus-account-plugin": "file:lib/plugins/account",
     "abacus-audit": "file:lib/utils/audit",
     "abacus-authserver-plugin": "file:lib/plugins/authserver",
+    "abacus-basic": "file:lib/utils/basic",
     "abacus-batch": "file:lib/utils/batch",
     "abacus-breaker": "file:lib/utils/breaker",
     "abacus-bridge": "file:lib/utils/bridge",


### PR DESCRIPTION
## Changes

Introduces a new package called `basic` that contains logic related to basic authentication and header processing.

Dependencies have been adapted. There don't seem to be references to the removed functions in `cf-abacus-broker`.

This pull request is related to issue #783 .