### PR TITLE
Enable replay logic when cluster is disabled

### DIFF
--- a/lib/aggregation/accumulator/src/index.js
+++ b/lib/aggregation/accumulator/src/index.js
@@ -351,7 +351,7 @@ const startApp = (err) => {
   app.listen();
 
   // Replay any failed events on master
-  if (!cluster.isWorker()) {
+  if (!cluster.isWorker() || cluster.isDisabled()) {
     const replayDelay = err ? 20000 : 0;
     debug('Starting replay in %d ms ...', replayDelay);
     setTimeout(() => dataflow.replay(app.reducer, 0, (err) => {

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -601,7 +601,7 @@ const startApp = (err) => {
   app.listen();
 
   // Replay any failed events on master
-  if (!cluster.isWorker()) {
+  if (!cluster.isWorker() || cluster.isDisabled()) {
     const replayDelay = err ? 20000 : 0;
     debug('Starting replay in %d ms ...', replayDelay);
     setTimeout(() => dataflow.replay(app.reducer, 0, (err) => {

--- a/lib/metering/collector/src/index.js
+++ b/lib/metering/collector/src/index.js
@@ -369,7 +369,7 @@ const startApp = (err) => {
   app.listen();
 
   // Replay any failed events on master
-  if (!cluster.isWorker()) {
+  if (!cluster.isWorker() || cluster.isDisabled()) {
     const replayDelay = err ? 20000 : 0;
     debug('Starting replay in %d ms ...', replayDelay);
     setTimeout(() => dataflow.replay(app.mapper, 0, (err) => {

--- a/lib/metering/meter/src/index.js
+++ b/lib/metering/meter/src/index.js
@@ -164,7 +164,7 @@ const startApp = (err) => {
   app.listen();
 
   // Replay any failed events on master
-  if (!cluster.isWorker()) {
+  if (!cluster.isWorker() || cluster.isDisabled()) {
     const replayDelay = err ? 20000 : 0;
     debug('Starting replay in %d ms ...', replayDelay);
     setTimeout(() => dataflow.replay(app.mapper, 0, (err) => {

--- a/lib/utils/cluster/src/index.js
+++ b/lib/utils/cluster/src/index.js
@@ -47,6 +47,9 @@ const isMaster = () => cluster.isMaster;
 // Return true if we're in a cluster worker process
 const isWorker = () => cluster.noCluster || cluster.isWorker;
 
+// Return true if the cluster is disabled
+const isDisabled = () => cluster.noCluster;
+
 // Return the current worker id
 const wid = () => cluster.worker ? cluster.worker.id : 0;
 
@@ -369,3 +372,4 @@ module.exports.scale = scale;
 module.exports.singleton = singleton;
 module.exports.size = size;
 module.exports.wid = wid;
+module.exports.isDisabled = isDisabled;


### PR DESCRIPTION
When the CLUSTER env variable is set to FALSE the replay logic will not be executed. 
This change fixes this behavior.