### PR TITLE
perf(reporter): use each instead of map where possible

### DIFF
--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -557,8 +557,8 @@ const summarizeInstanceUsage = function *(time, aggregaredUsage,
 
   // Sets all quantities to their current quantity
   const setCurrentQuantity = (windows) => {
-    map(windows, (w) => {
-      map(w, (sw) => {
+    each(windows, (w) => {
+      each(w, (sw) => {
         if(sw)
           sw.quantity = sw.quantity.current;
       });
@@ -583,9 +583,9 @@ const summarizeInstanceUsage = function *(time, aggregaredUsage,
 const purgeOldQuantities = (doc) => {
   const deletePreviousQuantity = (entity) => {
     if (entity.aggregated_usage)
-      map(entity.aggregated_usage, (aggregatedUsage) =>
-        map(aggregatedUsage.windows, (timeWindow) =>
-          map(timeWindow, (quantity) => {
+      each(entity.aggregated_usage, (aggregatedUsage) =>
+        each(aggregatedUsage.windows, (timeWindow) =>
+          each(timeWindow, (quantity) => {
             if (quantity)
               delete quantity.previous_quantity;
           })));
@@ -593,13 +593,13 @@ const purgeOldQuantities = (doc) => {
 
   const purgeInResource = (resource) => {
     deletePreviousQuantity(resource);
-    map(resource.plans, (plan) => deletePreviousQuantity(plan));
+    each(resource.plans, (plan) => deletePreviousQuantity(plan));
   };
 
-  map(doc.resources, (resource) => purgeInResource(resource));
+  each(doc.resources, (resource) => purgeInResource(resource));
   if(doc.spaces)
-    map(doc.spaces, (space) =>
-      map(space.resources, (resource) =>
+    each(doc.spaces, (space) =>
+      each(space.resources, (resource) =>
         purgeInResource(resource)));
 };
 
@@ -621,10 +621,10 @@ const updateConsumers = function *(usage, consumers, spaceId, consumersDocMap) {
     purgeOldQuantities(consumer);
 
     // Shift all the windows
-    map(consumer.resources, (resource) => {
-      map(resource.plans, (plan) => {
-        map(plan.aggregated_usage, (au) => {
-          map(au.windows, (w, i) => {
+    each(consumer.resources, (resource) => {
+      each(resource.plans, (plan) => {
+        each(plan.aggregated_usage, (au) => {
+          each(au.windows, (w, i) => {
             timewindow.shiftWindow(consumer.processed, usage.processed,
               w, dimensions[i]);
           });
@@ -689,8 +689,8 @@ const buildConsumersMap = (consumers, ids, startOfMonthKey, resourceId) => {
 const consumerUsage = function *(usage, resourceId, startOfMonthKey, counter) {
   // Collect the list of consumer ids to query for
   const ids = [];
-  map(usage.spaces, (space) => {
-    map(space.consumers, (consumer) => {
+  each(usage.spaces, (space) => {
+    each(space.consumers, (consumer) => {
       ids.push(['k', usage.organization_id, space.space_id, consumer.id,
         't', consumer.t].join('/'));
     });
@@ -870,7 +870,7 @@ const resourceInstanceUsage = function *(orgid, spaceid, resourceInstanceId,
   }
 
   // Adjust the windows to the requested time
-  map(doc.accumulated_usage, (au) => {
+  each(doc.accumulated_usage, (au) => {
     au.windows = adjustWindows(au.windows, doc.processed, time,
       findWindowLength());
   });


### PR DESCRIPTION
There were a lot of places in the `reporting` module that use `map` for iterating over arrays. This produces arrays in the heap that get are left unused and increase effort on the garbage collector.

This has now been fixed by having those places use `each` instead. This should decrease **CPU** and **Memory** usage, though I have not performed any measurements as to how much. Either way, it makes for much cleaner and maintainable code.
