### PR TITLE
Fix GraphQL types naming

### DIFF
--- a/lib/utils/schema/src/graph.js
+++ b/lib/utils/schema/src/graph.js
@@ -11,6 +11,8 @@ const object = _.object;
 const memoize = _.memoize;
 const identity = _.identity;
 
+const upperFirst = (s) => s[0].toUpperCase() + s.slice(1);
+
 // Convert a data type to a GraphQL schema type
 const schema = memoize((t) => {
   return {
@@ -19,14 +21,14 @@ const schema = memoize((t) => {
     time: (t) => graphql.GraphQLInt,
     arrayOf: (t) => new graphql.GraphQLList(schema(t.items)),
     enumType: (t) => new graphql.GraphQLEnumType({
-      name: t.name,
+      name: upperFirst(t.name),
       description: t.description,
       values: object(map(t.enum, (e) => [e, {
         value: e
       }]))
     }),
     objectType: (t) => new graphql.GraphQLObjectType({
-      name: t.name,
+      name: upperFirst(t.name),
       description: t.description,
       fields: () => object(map(pairs(t.properties), (p) => [p[0], {
         type: p[1].required ?
@@ -38,13 +40,13 @@ const schema = memoize((t) => {
       }]))
     }),
     unionType: (t) => new graphql.GraphQLUnionType({
-      name: t.name,
+      name: upperFirst(t.name),
       types: map(t.types, (type) => schema(type)),
       resolveType: t.resolveType,
       description: t.description
     }),
     anyType: (t) => new graphql.GraphQLScalarType({
-      name: t.name,
+      name: upperFirst(t.name),
       description: t.description,
       coerce: identity,
       serialize: identity

--- a/lib/utils/schema/src/test/test.js
+++ b/lib/utils/schema/src/test/test.js
@@ -348,7 +348,7 @@ describe('abacus-schema', () => {
     }));
 
     const obj = new graphql.GraphQLObjectType({
-      name: 'doc',
+      name: 'Doc',
       description: undefined,
       fields: () => ({
         a: {
@@ -359,7 +359,7 @@ describe('abacus-schema', () => {
         },
         c: {
           type: new graphql.GraphQLEnumType({
-            name: 'xy',
+            name: 'Xy',
             description: undefined,
             values: {
               X: {
@@ -395,19 +395,19 @@ describe('abacus-schema', () => {
     }));
 
     const utype1 = new graphql.GraphQLObjectType({
-      name: 'type1',
+      name: 'Type1',
       fields: () => ({
         g: new graphql.GraphQLNonNull(graphql.GraphQLString)
       })
     });
     const utype2 = new graphql.GraphQLObjectType({
-      name: 'type2',
+      name: 'Type2',
       fields: () => ({
         h: new graphql.GraphQLNonNull(graphql.GraphQLFloat)
       })
     });
     const uobj = new graphql.GraphQLUnionType({
-      name: 'udoc',
+      name: 'Udoc',
       types: [utype1, utype2],
       resolveType: (o) => {
         if(o.g)
@@ -426,7 +426,7 @@ describe('abacus-schema', () => {
     const agraph = schema.graph(anyType('any'));
 
     const aobj = new graphql.GraphQLScalarType({
-      name: 'any',
+      name: 'Any',
       description: undefined,
       coerce: identity,
       serialize: identity


### PR DESCRIPTION
GraphQL types generated from Abacus-Schemas has incorrect naming scheme.