### PR TITLE
Make healthcheck customizable

### DIFF
--- a/lib/utils/hystrix/src/index.js
+++ b/lib/utils/hystrix/src/index.js
@@ -3,12 +3,6 @@
 // Support for Netflix Hystrix, serves a stream of Hystrix command stats
 
 const _ = require('underscore');
-const basicCredentials = require('abacus-basic').credentials;
-const oauth = require('abacus-oauth');
-const perf = require('abacus-perf');
-const urienv = require('abacus-urienv');
-const moment = require('abacus-moment');
-
 const values = _.values;
 const map = _.map;
 const object = _.object;
@@ -17,16 +11,11 @@ const last = _.last;
 const extend = _.extend;
 const sortBy = _.sortBy;
 
+const perf = require('abacus-perf');
+const moment = require('abacus-moment');
+
 // Setup debug log
 const debug = require('abacus-debug')('abacus-hystrix');
-
-// Resolve service URIs
-const uris = urienv({
-  auth_server: 9882
-});
-
-// Secure the hystrix.stream or not
-const secured = () => process.env.SECURED === 'true' ? true : false;
 
 // Compute a percentile from a list of values using the ranking algorithm at
 // http://cnx.org/content/m10805/latest/,
@@ -162,64 +151,45 @@ const command = (s) => {
 };
 
 // Return Oauth system scopes needed to read system status
-const rscope = () => secured() ? {
+const scopes = {
   system: ['abacus.system.read']
-} : undefined;
+};
 
 // Return an Express middleware that serves a Hystrix event stream
-const stream = () => {
-  return (req, res, next) => {
-    if(req.path === '/hystrix.stream') {
-      const openStream = () => {
-        // Keep the text/event-stream response open forever
-        req.socket.setTimeout(0);
-        res.writeHead(200, {
-          'Content-Type': 'text/event-stream; charset=utf-8',
-          'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate',
-          'Connection': 'keep-alive'
-        });
+const stream = () => (req, res, next) => {
+  // Keep the text/event-stream response open forever
+  req.socket.setTimeout(0);
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream; charset=utf-8',
+    'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate',
+    'Connection': 'keep-alive'
+  });
 
-        // Write the latest Hystrix command stats right away, then
-        // periodically as specified in the client request or every 2000 ms
-        const write = () => {
-          const now = moment.now();
-          const all = values(perf.all(now));
-          if(all.length)
-            map(all, (s) => {
-              res.write('data: ' + JSON.stringify(command(s)) + '\n\n');
-              if(res.flush) res.flush();
-            });
-          else {
-            res.write('ping:\n\n');
-            if(res.flush) res.flush();
-          }
-        };
-        write();
-        const writer = setInterval(write,
-          Math.max(req.query.delay || 2000, 200));
-
-        // Stop when the request closes
-        req.on('close', () => {
-          clearInterval(writer);
-        });
-      };
-
-      if(secured()) {
-        const { username, password } = basicCredentials.fromRequest(req);
-        oauth.getBearerToken(uris.auth_server, username,
-          password, 'abacus.system.read', (err, token) => {
-            if(err)
-              throw err;
-            oauth.authorize(token, rscope());
-            openStream();
-          });
-      }
-      else
-        openStream();
+  // Write the latest Hystrix command stats right away, then
+  // periodically as specified in the client request or every 2000 ms
+  const write = () => {
+    const now = moment.now();
+    const all = values(perf.all(now));
+    if(all.length)
+      map(all, (s) => {
+        res.write('data: ' + JSON.stringify(command(s)) + '\n\n');
+        if(res.flush) res.flush();
+      });
+    else {
+      res.write('ping:\n\n');
+      if(res.flush) res.flush();
     }
-    else next();
   };
+  write();
+  const writer = setInterval(write,
+    Math.max(req.query.delay || 2000, 200));
+
+  // Stop when the request closes
+  req.on('close', () => {
+    clearInterval(writer);
+  });
 };
 
 // Export our public functions
 module.exports.stream = stream;
+module.exports.scopes = scopes;

--- a/lib/utils/hystrix/src/test/test.js
+++ b/lib/utils/hystrix/src/test/test.js
@@ -2,10 +2,11 @@
 
 // Support for Netflix Hystrix, serves a stream of Hystrix command stats
 
-const oauth = require('abacus-oauth');
-const moment = require('abacus-moment');
 const _ = require('underscore');
 const extend = _.extend;
+
+const oauth = require('abacus-oauth');
+const moment = require('abacus-moment');
 
 process.env.SECURED = 'true';
 
@@ -95,12 +96,6 @@ describe('abacus-hystrix', () => {
     res.write = stub().returns(res);
     res.flush = stub().returns(res);
     const on = spy();
-
-    // Expect middleware to only process /hystrix.stream path
-    stream({
-      path: '/else'
-    }, res, next);
-    expect(next.args.length).to.equal(1);
 
     // Expect middleware to return a Hystrix stats stream
     stream({

--- a/lib/utils/oauth/src/index.js
+++ b/lib/utils/oauth/src/index.js
@@ -382,8 +382,8 @@ const getBearerToken = (authServer, id, secret, scopes, cb) => {
 };
 
 // Return an Express middleware that verifies basic authentication
-const basicStrategy = (authServer, scopes, secret, algorithm) => {
-  return (req, res, next) => {
+const basicStrategy = (authServer, scopes, secret, algorithm) =>
+  (req, res, next) => {
     debug('Authenticating request using basic strategy');
 
     if (isBasicRequest(req))
@@ -397,7 +397,7 @@ const basicStrategy = (authServer, scopes, secret, algorithm) => {
               return;
             }
             validate(token.replace(/^bearer /i, ''),
-              secret, algorithm, (err, val) => {
+              secret, algorithm, (err, decoded) => {
                 if (err) {
                   edebug('OAuth bearer access token validation failed, %s',
                     err.message);
@@ -426,7 +426,6 @@ const basicStrategy = (authServer, scopes, secret, algorithm) => {
         'Basic realm="cf"').end();
     }
   };
-};
 
 const parseScopes = (scopes) => {
   const result = {

--- a/lib/utils/webapp/src/index.js
+++ b/lib/utils/webapp/src/index.js
@@ -4,7 +4,8 @@
 // Also sets up some call perf metrics collection across the cluster.
 
 const _ = require('underscore');
-const basicCredentials = require('abacus-basic').credentials;
+const wrap = _.wrap;
+
 const express = require('abacus-express');
 const cluster = require('abacus-cluster');
 const vcapenv = require('abacus-vcapenv');
@@ -15,67 +16,26 @@ const oauth = require('abacus-oauth');
 const cp = require('child_process');
 const commander = require('commander');
 const rc = require('abacus-rc');
-const urienv = require('abacus-urienv');
-
-const wrap = _.wrap;
 
 // Setup debug log
 const debug = require('abacus-debug')('abacus-webapp');
 const edebug = require('abacus-debug')('e-abacus-webapp');
 
-const uris = urienv({
-  auth_server: 9882
-});
-
-const defaultSecurity = () => process.env.SECURED === 'true' ? true : false;
+const defaultSecurity = () => process.env.SECURED === 'true';
 const secured = () => process.env.HEALTHCHECK_SECURED === 'false' ? false :
   defaultSecurity();
 
-const requiredScope = () => secured() ? {
+const healthCheckScopes = {
   system: ['abacus.system.read']
-} : undefined;
+};
 
-const sendHealthStatus = (res) => {
+const healthCheck = (req, res) => {
+  debug(`Entering ${secured ? 'secured' : ''} healthcheck`);
   const h = perf.healthy();
   debug('Returning app health %s', h);
   res.status(h ? 200 : 500).send({
     healthy: h
   });
-};
-
-const sendErrorResponse = (err, res, defaultCode) => {
-  const statusCode = err.statusCode || defaultCode;
-  res.status(statusCode).end(err.toString());
-};
-
-const healthCheck = (req, res) => {
-  debug(`Entering ${secured ? 'secured' : ''} healthcheck`);
-
-  if (!secured()) {
-    sendHealthStatus(res);
-    return;
-  }
-
-  const { username, password } = basicCredentials.fromRequest(req);
-
-  oauth.getBearerToken(uris.auth_server, username, password,
-    'abacus.system.read', (err, token) => {
-      if(err) {
-        edebug('Error during health check user validation %o', err);
-        sendErrorResponse(err, res, 500);
-        return;
-      }
-
-      try {
-        oauth.authorize(token, requiredScope());
-      }
-      catch (err) {
-        sendErrorResponse(err, res, 401);
-        return;
-      }
-
-      sendHealthStatus(res);
-    });
 };
 
 // Configure a clustered Express-based Web app
@@ -94,13 +54,22 @@ const webapp = () => {
   // Configure the app to report its app instance id and instance index
   app.use(vcapenv.headers());
 
-  // Add healthcheck endpoint before app's middleware
-  app.get('/healthcheck', healthCheck);
-
   // Monkey patch the app listen function to register some of our middleware
   // after the app's middleware
   app.listen = wrap(app.listen, (listen, opt, cb) => {
-    app.use(hystrix.stream());
+    if (secured())
+      app.use('/hystrix.stream', oauth.basicStrategy(
+        process.env.CF_API, hystrix.scopes,
+        process.env.JWTKEY, process.env.JWTALGO
+      ));
+    app.use('/hystrix.stream', hystrix.stream());
+
+    if (secured())
+      app.use('/healthcheck', oauth.basicStrategy(
+        process.env.CF_API, healthCheckScopes,
+        process.env.JWTKEY, process.env.JWTALGO
+      ));
+    app.get('/healthcheck', healthCheck);
 
     // Call the original app listen function
     debug('Listening');
@@ -175,7 +144,7 @@ const runCLI = () => {
     // Stop the Webapp
     cp.exec('pkill -f "node ' + vcapenv.appname() + '.* master"',
       (err, stdout, stderr) => {
-        if(err) debug('Stop error %o', err);
+        if(err) edebug('Stop error %o', err);
       });
 };
 

--- a/lib/utils/webapp/src/test/healthcheck-test.js
+++ b/lib/utils/webapp/src/test/healthcheck-test.js
@@ -43,8 +43,7 @@ describe('abacus-webapp healthcheck', () => {
   };
 
   context('with secured Abacus', () => {
-    let getBearerTokenMock;
-    let authorizeMock;
+    let basicStrategyMock;
     let oauth;
 
     beforeEach(() => {
@@ -69,19 +68,17 @@ describe('abacus-webapp healthcheck', () => {
     beforeEach(() => {
       oauth = require('abacus-oauth');
 
-      require.cache[require.resolve('abacus-oauth')]
-        .exports.getBearerToken = (authServer, id, secret, scopes, cb) => {
-          getBearerTokenMock(authServer, id, secret, scopes, cb);
-        };
-      require.cache[require.resolve('abacus-oauth')]
-        .exports.authorize = (token, scope) => {
-          authorizeMock(token, scope);
+      require.cache[require.resolve('abacus-oauth')].exports.basicStrategy =
+        (authServer, scopes, secret, algorithm) => (req, res, next) => {
+          if (basicStrategyMock)
+            basicStrategyMock(req, res, next);
+          else
+            next();
         };
     });
 
     afterEach(() => {
-      getBearerTokenMock = undefined;
-      authorizeMock = undefined;
+      basicStrategyMock = undefined;
       oauth = undefined;
     });
 
@@ -92,41 +89,33 @@ describe('abacus-webapp healthcheck', () => {
 
       const testHealthCheck = () => {
         it('deny access, when error in acquiring token', (done) => {
-          getBearerTokenMock = (authServer, id, secret, scopes, cb) => {
-            cb(new Error('Error'), undefined);
+          basicStrategyMock = (req, res, next) => {
+            res.status(500).send({ statusCode: 500, error: 'error' });
           };
 
           verifyHealthCheck(500, authHeaders, true, done);
         });
 
-        it('deny access, if UNAUTHORIZED when acquiring token', (done) => {
-          getBearerTokenMock = (authServer, id, secret, scopes, cb) => {
-            cb({ statusCode: 401 });
+        it('deny access, if UNAUTHORIZED', (done) => {
+          basicStrategyMock = (req, res, next) => {
+            res.status(401).send({ statusCode: 401 });
           };
 
           verifyHealthCheck(401, authHeaders, false, done);
         });
 
         it('deny access, when no credentials are sent', (done) => {
+          basicStrategyMock = (req, res, next) => {
+            res.status(401).send({ statusCode: 401 });
+          };
+
           verifyHealthCheck(401, noAuthHeaders, false, done);
         });
 
-        it('deny access, when scope not exist', (done) => {
-          getBearerTokenMock = (authServer, id, secret, scopes, cb) => {
-            cb(undefined, 'Bearer 123567890');
-          };
-          authorizeMock = () => {
-            throw { statusCode: 401 };
-          };
-
-          verifyHealthCheck(401, authHeaders, false, done);
-        });
-
         it('allows access to authorized user', (done) => {
-          getBearerTokenMock = (authServer, id, secret, scopes, cb) => {
-            cb(undefined, 'Bearer 123567890');
+          basicStrategyMock = (req, res, next) => {
+            res.status(200).send({});
           };
-          authorizeMock = () => { };
 
           verifyHealthCheck(200, authHeaders, false, done);
         });


### PR DESCRIPTION
- apps can provide own /healthcheck endpoint 
- reuse oauth.basicStrategy

fixes #655
[delivers #146699159]