### PR TITLE
Enable blue-green deployment with cfpush

### DIFF
--- a/etc/concourse/scripts/cf-deploy-clean
+++ b/etc/concourse/scripts/cf-deploy-clean
@@ -11,7 +11,7 @@ if [ "$SKIP_SSL_VALIDATION" == "true" ]; then
 fi
 
 cf login -a https://api.$CF_SYS_DOMAIN -u $CF_USER -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE $skip
-getApps \\-old
+getApps '\-old '
 
 set +e
 echo "Deleting old applications ..."

--- a/etc/concourse/scripts/cf-deploy-clean
+++ b/etc/concourse/scripts/cf-deploy-clean
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="${BASH_SOURCE%/*}"
+source $SCRIPT_DIR/common-functions
+
+echo "Logging to $CF_SYS_DOMAIN ..."
+if [ "$SKIP_SSL_VALIDATION" == "true" ]; then
+  skip='--skip-ssl-validation'
+fi
+
+cf login -a https://api.$CF_SYS_DOMAIN -u $CF_USER -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE $skip
+getApps \\-old
+
+set +e
+echo "Deleting old applications ..."
+echo ${APPS[@]} | xargs -n1 -P 50 cf delete -f
+
+echo "Clean-up finished"

--- a/etc/concourse/scripts/cf-deploy-clean
+++ b/etc/concourse/scripts/cf-deploy-clean
@@ -15,6 +15,7 @@ getApps \\-old
 
 set +e
 echo "Deleting old applications ..."
+echo "Apps: ${APPS[@]}"
 echo ${APPS[@]} | xargs -n1 -P 50 cf delete -f
 
 echo "Clean-up finished"

--- a/tools/cfpush/src/index.js
+++ b/tools/cfpush/src/index.js
@@ -103,7 +103,7 @@ const prepareZdm = (props, cb) => {
     const appName = `${props.prefix}${props.name}`;
     const command = `cf app ${appName}`;
     executeCommand(command, (code) => {
-      if (code === 1)
+      if (code !== 0)
         return cb();
       return deleteOld(props, (error) => {
         if (error)
@@ -136,7 +136,7 @@ const getBlueGreenOptionFromManifest = () => {
   const manifestLoc = path.join(process.cwd(), originalManifestFilename);
   try {
     const manifest = yaml.load(fs.readFileSync(manifestLoc));
-    return manifest.applications[0].blue_green_enabled === true;
+    return manifest.applications[0].zdm === true;
   }
   catch (err) {
     return false;

--- a/tools/cfpush/src/index.js
+++ b/tools/cfpush/src/index.js
@@ -160,7 +160,7 @@ const runCLI = () => {
     .parse(process.argv);
 
   const requestZdm = commander.prepareZdm ?
-      commander.prepareZdm : getBlueGreenOptionFromManifest();
+    commander.prepareZdm : getBlueGreenOptionFromManifest();
 
   const commanderProps = {
     name: commander.name,

--- a/tools/cfpush/src/index.js
+++ b/tools/cfpush/src/index.js
@@ -136,7 +136,6 @@ const getBlueGreenOptionFromManifest = () => {
   const manifestLoc = path.join(process.cwd(), originalManifestFilename);
   try {
     const manifest = yaml.load(fs.readFileSync(manifestLoc));
-    console.log('istrue', manifest.applications[0].blue_green_enabled === true);
     return manifest.applications[0].blue_green_enabled === true;
   }
   catch (err) {

--- a/tools/cfpush/src/index.js
+++ b/tools/cfpush/src/index.js
@@ -87,18 +87,21 @@ const push = (props, cb) => {
 };
 
 const rename = (props, cb) => {
-  const command = `cf rename ${props.name} ${props.name}-old`;
+  const appName = `${props.prefix}${props.name}`;
+  const command = `cf rename ${appName} ${appName}-old`;
   return executeCommand(command, cb);
 };
 
 const deleteOld = (props, cb) => {
-  const command = `cf delete -f ${props.name}-old`;
+  const appName = `${props.prefix}${props.name}`;
+  const command = `cf delete -f ${appName}-old`;
   executeCommand(command, cb);
 };
 
 const prepareZdm = (props, cb) => {
   if (props.prepareZdm) {
-    const command = `cf app ${props.name}`;
+    const appName = `${props.prefix}${props.name}`;
+    const command = `cf app ${appName}`;
     executeCommand(command, (code) => {
       if (code === 1)
         return cb();

--- a/tools/cfpush/src/index.js
+++ b/tools/cfpush/src/index.js
@@ -103,7 +103,7 @@ const prepareZdm = (props, cb) => {
     const appName = `${props.prefix}${props.name}`;
     const command = `cf app ${appName}`;
     executeCommand(command, (code) => {
-      if (code !== 0)
+      if (code > 0)
         return cb();
       return deleteOld(props, (error) => {
         if (error)

--- a/tools/cfpush/src/test/cfpush-test.js
+++ b/tools/cfpush/src/test/cfpush-test.js
@@ -187,10 +187,12 @@ describe('Test abacus cfpush', () => {
     });
 
     it('verify prepareZdm', () => {
+      const appName = `${prefix}${adjustedName}`;
       const orderedCommands = {
-        cfApp : `cf app ${adjustedName}`,
-        cfDelete : `cf delete -f ${adjustedName}-old`,
-        cfRename : `cf rename ${adjustedName} ${adjustedName}-old`
+        cfApp : `cf app ${appName}`,
+        cfDelete : `cf delete -f ${appName}-old`,
+        cfRename :
+          `cf rename ${appName} ${appName}-old`
       };
       const envMock = sinon.match.has('env', { CF_HOME: tmpDir.name });
 

--- a/tools/cfpush/src/test/cfpush-test.js
+++ b/tools/cfpush/src/test/cfpush-test.js
@@ -215,7 +215,7 @@ describe('Test abacus cfpush', () => {
         cp.exec,
         `cf push --no-start -f ${manifestPath}`,
         sinon.match.has('env',
-        { CF_HOME: tmpDir.name }));
+          { CF_HOME: tmpDir.name }));
     });
   });
 

--- a/tools/cfpush/src/test/cfpush-test.js
+++ b/tools/cfpush/src/test/cfpush-test.js
@@ -196,8 +196,8 @@ describe('Test abacus cfpush', () => {
       };
       const envMock = sinon.match.has('env', { CF_HOME: tmpDir.name });
 
-      assert.calledWithExactly(cp.exec, orderedCommands.cfDelete, envMock);
       assert.calledWithExactly(cp.exec, orderedCommands.cfApp, envMock);
+      assert.calledWithExactly(cp.exec, orderedCommands.cfDelete, envMock);
       assert.calledWithExactly(cp.exec, orderedCommands.cfRename, envMock);
 
       // verify order of execution


### PR DESCRIPTION
Implements changes that make blue-green deployment possible. 
- cfpush now has a new command line property '-z, --prepare-zdm [boolean]' - if set to 'true' the app will be deployed without downtime by renaming the original app to <appname>-old
- the option can be provided in the application manifest - "zdm": true  
- there is a clean-up script for concourse that will remove the old application versions