### PR TITLE
Updated pipelines with missing/new variables and additional checks

### DIFF
--- a/etc/concourse/scripts/cf-test-infra
+++ b/etc/concourse/scripts/cf-test-infra
@@ -12,8 +12,13 @@ fi
 cf api $skip https://api.$CF_SYS_DOMAIN
 echo "" | cf login -u $CF_ADMIN_USER -p $CF_ADMIN_PASSWORD
 
-echo "Recreating organization and space ..."
-cf delete-org -f $CF_ORG
+if [ "$SKIP_CREATE_ORG" == "true" ]; then
+  echo "Using existing org $CF_ORG ..."
+else
+  echo "Recreating organization and space ..."
+  cf delete-org -f $CF_ORG
+fi
+
 cf create-quota $CF_ORG -m 40g -i 4g -r 40 -s 1 --allow-paid-service-plans
 cf create-org $CF_ORG -q $CF_ORG
 cf create-space $CF_SPACE -o $CF_ORG
@@ -25,6 +30,7 @@ else
   cf delete-user -f "$CF_USER"
   cf create-user "$CF_USER" "$CF_PASSWORD"
 fi
+
 cf set-org-role $CF_USER $CF_ORG OrgManager
 cf set-space-role $CF_USER $CF_ORG $CF_SPACE SpaceManager
 cf set-space-role $CF_USER $CF_ORG $CF_SPACE SpaceDeveloper

--- a/etc/concourse/test-pipeline-vars.yml
+++ b/etc/concourse/test-pipeline-vars.yml
@@ -1,6 +1,10 @@
 # Cloud Foundry domain
 cf-sys-domain: cf.mycompany.com
 
+# Set this to true if you are using an existing org
+# Setting this to false, will explicitly delete the cf-org and recreate it
+skip-create-org: true
+
 # Organization for the Abacus apps
 cf-org: abacus
 
@@ -10,28 +14,32 @@ cf-space: abacus
 # Domain that will host the Abacus applications
 cf-domain: cfapps.mycompany.com
 
-# User that has SpaceDeveloper permissions for the Abacus' org
+# Set this to true if you are using an existing user
+# Setting this to false, will explicitly delete the user and recreate it
+skip-create-user: true
+
+# cf user that will deploy apps to the cf-org
 cf-user: abacus
 
-# Password of the Abacus user
+# password for the cf-user
 cf-password: abacus123
 
-# Admin user. Should be able to create orgs, users, quotas
+# cf uaa admin user that has the ability to create orgs, users, quotas
 cf-admin-user: admin
 
-# Password of the admin user
+# Password for the cf-admin-user
 cf-admin-password: admin
 
 # Comma-separated debug logs
 debug:
 
-# Use to skip ssl validation
+# Set this to true to skip ssl validation
 skip-ssl-validation: true
 
-# UAA admin user
+# new abacus uaa admin user that will be created
 uaa-admin: admin
 
-# UAA admin user secret/password
+# Password for the uaa-admin user
 uaa-secret: admin-secret
 
 # UAA client: Abacus system user ID
@@ -93,3 +101,17 @@ project-dir: "abacus"
 
 # Location of the test pipeline configuration
 config-dir: "landscape/abacus-config/test"
+
+# Abacus repo URI (or landscape project URI)
+landscape-git-repo: https://github.com/cloudfoundry-incubator/cf-abacus.git
+
+# Abacus repo branch
+landscape-git-repo-branch: master
+
+# Abacus repo (or landscape project repo) private key.
+# Leave it as it is for mainstream github.com Abacus repo
+landscape-git-repo-private-key: |
+  -----BEGIN RSA PRIVATE KEY-----
+     ... insert key here ...
+  -----END RSA PRIVATE KEY-----
+

--- a/etc/concourse/test-pipeline-vars.yml
+++ b/etc/concourse/test-pipeline-vars.yml
@@ -36,7 +36,7 @@ debug:
 # Set this to true to skip ssl validation
 skip-ssl-validation: true
 
-# new abacus uaa admin user that will be created
+# cf uaa admin client credentials required to authenticate using uaac
 uaa-admin: admin
 
 # Password for the uaa-admin user

--- a/etc/concourse/test-pipeline.yml
+++ b/etc/concourse/test-pipeline.yml
@@ -38,10 +38,12 @@ jobs:
             - name: abacus
           params:
             CF_SYS_DOMAIN: {{cf-sys-domain}}
+            SKIP_CREATE_USER: {{skip-create-user}}
             CF_USER: {{cf-user}}
             CF_PASSWORD: {{cf-password}}
             CF_ADMIN_USER: {{cf-admin-user}}
             CF_ADMIN_PASSWORD: {{cf-admin-password}}
+            SKIP_CREATE_ORG: {{skip-create-org}}
             CF_ORG: {{cf-org}}
             CF_SPACE: {{cf-space}}
             CF_DOMAIN: {{cf-domain}}


### PR DESCRIPTION
Updated test vars file with missing variables for landscape repo. Added new variable skip-create-org which will avoid deleting existing orgs. Added variable skip-create-user which is available in the cf-test-infra script but is not defined in the vars file. Updated pipeline to use the skip-create-org and skip-create-user variables. Updated cf-test-infra script to do the skip-create-org check.