### PR TITLE
Extract spaces into separate documents in DB

### DIFF
--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -160,28 +160,15 @@ Org.prototype.resource = function(id) {
   return lazyCons(this.resources, 'resource_id', id, Org.Resource);
 };
 Org.prototype.space = function(id, doctime) {
-  // Construct or retrieve the consumer object
   const space = lazyCons(this.spaces, 'space_id', id, Org.Space);
   space.t = doctime;
-  // this.consumers = filter(this.consumers, (c) => shouldNotPrune(c.t.match(/(\d+)/)[0]));
 };
 
-// Represent a space, aggregated resource usage and the consumers it contains
-// Org.Space = function(id) {
-//   extend(this, {
-//     space_id: id,
-//     resources: [],
-//     consumers: []
-//   });
-// };
 Org.Space = function(id) {
   extend(this, {
     space_id: id
   });
 };
-// Org.Space.prototype.resource = function(id) {
-//   return lazyCons(this.resources, 'resource_id', id, Org.Resource);
-// };
 
 const Space = function(id) {
   extend(this, {
@@ -246,14 +233,6 @@ Space.ResourceInstance = function(rid) {
     id: rid
   });
 };
-
-// Space.Plan.prototype.resource_instance = function(rid, time, processed) {
-//   const instance = lazyCons(this.resource_instances, 'id', rid, Space.ResourceInstance);
-//   instance.t = time;
-//   instance.p = processed;
-//   this.resource_instances = filter(this.resource_instances, (ri) => shouldNotPrune(ri.p));
-//   return instance;
-// };
 
 // Represent a consumer and aggregated resource usage
 const Consumer = function(id) {
@@ -358,12 +337,6 @@ const reviveOrg = (org) => {
   });
   each(org.spaces, (s) => {
     s.consumer = Org.Space.prototype.consumer;
-    // each(s.resources, (r) => {
-    //   r.plan = Org.Resource.prototype.plan;
-    //   each(r.plans, (p) => {
-    //     p.metric = Org.Plan.prototype.metric;
-    //   });
-    // });
   });
   return org;
 };

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -57,6 +57,7 @@ const itime = (udoc) => seqid();
 const igroups = (udoc) => [
   udoc.organization_id,
   [udoc.organization_id, udoc.space_id, udoc.consumer_id || 'UNKNOWN'].join('/'),
+  [udoc.organization_id, udoc.space_id].join('/'),
   [
     udoc.organization_id,
     udoc.resource_instance_id,
@@ -71,6 +72,7 @@ const igroups = (udoc) => [
 const okeys = (udoc, ikey) => [
   udoc.organization_id,
   [udoc.organization_id, udoc.space_id, udoc.consumer_id || 'UNKNOWN'].join('/'),
+  [udoc.organization_id, udoc.space_id].join('/'),
   [
     udoc.organization_id,
     udoc.resource_instance_id,
@@ -90,6 +92,7 @@ const skeys = (udoc) => [udoc.account_id, udoc.account_id, undefined];
 const sampling = process.env.SAMPLING;
 
 const otimes = (udoc, itime) => [
+  seqid.sample(itime, sampling),
   seqid.sample(itime, sampling),
   seqid.sample(itime, sampling),
   map([udoc.end, udoc.start], seqid.pad16).join('/')
@@ -156,24 +159,44 @@ const newOrg = function(id) {
 Org.prototype.resource = function(id) {
   return lazyCons(this.resources, 'resource_id', id, Org.Resource);
 };
-Org.prototype.space = function(id) {
-  return lazyCons(this.spaces, 'space_id', id, Org.Space);
+Org.prototype.space = function(id, doctime) {
+  // Construct or retrieve the consumer object
+  const space = lazyCons(this.spaces, 'space_id', id, Org.Space);
+  space.t = doctime;
+  // this.consumers = filter(this.consumers, (c) => shouldNotPrune(c.t.match(/(\d+)/)[0]));
 };
 
 // Represent a space, aggregated resource usage and the consumers it contains
+// Org.Space = function(id) {
+//   extend(this, {
+//     space_id: id,
+//     resources: [],
+//     consumers: []
+//   });
+// };
 Org.Space = function(id) {
   extend(this, {
-    space_id: id,
-    resources: [],
-    consumers: []
+    space_id: id
   });
 };
-Org.Space.prototype.resource = function(id) {
-  return lazyCons(this.resources, 'resource_id', id, Org.Resource);
+// Org.Space.prototype.resource = function(id) {
+//   return lazyCons(this.resources, 'resource_id', id, Org.Resource);
+// };
+
+const Space = function(id) {
+  extend(this, {
+    space_id: id,
+    consumers: [],
+    resources: []
+  });
 };
-Org.Space.prototype.consumer = function(id, doctime) {
+const newSpace = function(id) {
+  return new Space(id);
+};
+
+Space.prototype.consumer = function(id, doctime) {
   // Construct or retrieve the consumer object
-  const consumer = lazyCons(this.consumers, 'id', id, Org.Consumer);
+  const consumer = lazyCons(this.consumers, 'id', id, Space.Consumer);
   consumer.t = doctime;
   this.consumers = filter(this.consumers, (c) => shouldNotPrune(c.t.match(/(\d+)/)[0]));
 };
@@ -181,11 +204,56 @@ Org.Space.prototype.consumer = function(id, doctime) {
 // Represent a consumer reference
 // id represents consumer_id
 // t represents time component of the consumer aggregated doc id.
-Org.Consumer = function(id) {
+Space.Consumer = function(id) {
   extend(this, {
     id: id
   });
 };
+
+Space.Resource = function(id) {
+  extend(this, {
+    resource_id: id,
+    plans: []
+  });
+};
+
+Space.prototype.resource = function(id) {
+  return lazyCons(this.resources, 'resource_id', id, Space.Resource);
+};
+
+Space.Plan = function(id) {
+  extend(
+    this,
+    {
+      plan_id: id,
+      aggregated_usage: []
+    },
+    object(['metering_plan_id', 'rating_plan_id', 'pricing_plan_id'], rest(id.split('/')))
+  );
+};
+
+Space.Resource.prototype.plan = function(id) {
+  return lazyCons(this.plans, 'plan_id', id, Space.Plan);
+};
+
+Space.Plan.prototype.metric = function(metric) {
+  return lazyCons(this.aggregated_usage, 'metric', metric, Org.Metric);
+};
+
+// Represent a resource instance reference
+Space.ResourceInstance = function(rid) {
+  extend(this, {
+    id: rid
+  });
+};
+
+// Space.Plan.prototype.resource_instance = function(rid, time, processed) {
+//   const instance = lazyCons(this.resource_instances, 'id', rid, Space.ResourceInstance);
+//   instance.t = time;
+//   instance.p = processed;
+//   this.resource_instances = filter(this.resource_instances, (ri) => shouldNotPrune(ri.p));
+//   return instance;
+// };
 
 // Represent a consumer and aggregated resource usage
 const Consumer = function(id) {
@@ -289,14 +357,13 @@ const reviveOrg = (org) => {
     });
   });
   each(org.spaces, (s) => {
-    s.resource = Org.Space.prototype.resource;
     s.consumer = Org.Space.prototype.consumer;
-    each(s.resources, (r) => {
-      r.plan = Org.Resource.prototype.plan;
-      each(r.plans, (p) => {
-        p.metric = Org.Plan.prototype.metric;
-      });
-    });
+    // each(s.resources, (r) => {
+    //   r.plan = Org.Resource.prototype.plan;
+    //   each(r.plans, (p) => {
+    //     p.metric = Org.Plan.prototype.metric;
+    //   });
+    // });
   });
   return org;
 };
@@ -312,6 +379,20 @@ const reviveCon = (con) => {
     });
   });
   return con;
+};
+
+// Revive a space object
+const reviveSpace = (space) => {
+  space.resource = Space.prototype.resource;
+  space.consumer = Space.prototype.consumer;
+  each(space.resources, (r) => {
+    r.plan = Space.Resource.prototype.plan;
+    each(r.plans, (p) => {
+      p.metric = Space.Plan.prototype.metric;
+      p.resource_instance = Space.Plan.prototype.resource_instance;
+    });
+  });
+  return space;
 };
 
 // find info with error and reason to redirect
@@ -340,7 +421,7 @@ const purgeOldQuantities = (doc) => {
     );
   };
   each(doc.resources, (r) => purgeInResource(r));
-  if (doc.spaces) each(doc.spaces, (s) => each(s.resources, (r) => purgeInResource(r)));
+  // if (doc.spaces) each(doc.spaces, (s) => each(s.resources, (r) => purgeInResource(r)));
 };
 
 // Return the configured price for the metrics that is attached in the usage document
@@ -387,6 +468,21 @@ const rateFunction = (ratingPlanId, metrics, metricName) => {
   return rateFn;
 };
 
+const getSpace = (orgDoc, usageDoc) => {
+  const spaceId = usageDoc.space_id;
+  const f = filter(orgDoc.spaces, (s) => s.space_id === spaceId);
+  if (f.length) {
+    // remove the space from the org document
+    orgDoc.spaces.splice(orgDoc.spaces.indexOf(f[0]), 1);
+    return reviveSpace(extend(JSON.parse(JSON.stringify(f[0]), {
+      start: usageDoc.start,
+      end: usageDoc.end,
+      organization_id: usageDoc.organization_id
+    })));
+  }
+  return newSpace(spaceId);
+};
+
 // Aggregate usage and return new aggregated usage
 const aggregate = function*(aggrs, u) {
   debug('Aggregating usage %o from %d and new usage %o from %d', aggrs[0], aggrs[0] ? aggrs[0].end : 0, u, u.end);
@@ -395,6 +491,7 @@ const aggregate = function*(aggrs, u) {
   // org level, the second one contains usage at the consumer level
   const a = aggrs[0];
   const c = aggrs[1];
+  const s = aggrs[2];
 
   const meteringPlanId = u.metering_plan_id;
   const ratingPlanId = u.rating_plan_id;
@@ -452,14 +549,22 @@ const aggregate = function*(aggrs, u) {
     pricing_country: u.pricing_country,
     prices: u.prices
   });
+  const news = s ? reviveSpace(JSON.parse(JSON.stringify(s))) : getSpace(newa, u);
+  extend(news, {
+    start: u.start,
+    end: u.end,
+    organization_id: u.organization_id
+  });
   // An empty doc only used to detect duplicate usage
   const iddoc = {};
 
   timewindow.shift(newa, a, u.processed);
   timewindow.shift(newc, c, u.processed);
+  timewindow.shift(news, s, u.processed);
   purgeOldQuantities(newa);
   purgeOldQuantities(newc);
-
+  purgeOldQuantities(news);
+  newa.space(u.space_id, seqid.sample(u.processed_id, sampling));
 
   // Go through the incoming accumulated usage metrics
   each(u.accumulated_usage, (accumulatedUsage) => {
@@ -527,16 +632,22 @@ const aggregate = function*(aggrs, u) {
     );
 
     aggr(
-      newa
-        .space(u.space_id)
+      news
         .resource(u.resource_id)
         .plan(pid)
         .metric(metricName)
     );
+    // aggr(
+    //   newa
+    //     .space(u.space_id)
+    //     .resource(u.resource_id)
+    //     .plan(pid)
+    //     .metric(metricName)
+    // );
 
     // Apply the aggregate function to the consumer usage tree
-    newa.space(u.space_id).consumer(u.consumer_id || 'UNKNOWN', seqid.sample(u.processed_id, sampling));
-
+    // newa.space(u.space_id).consumer(u.consumer_id || 'UNKNOWN', seqid.sample(u.processed_id, sampling));
+    news.consumer(u.consumer_id || 'UNKNOWN', seqid.sample(u.processed_id, sampling));
     aggr(
       newc
         .resource(u.resource_id)
@@ -554,9 +665,10 @@ const aggregate = function*(aggrs, u) {
 
   timewindow.shift(newa, u, parseInt(u.processed_id));
   timewindow.shift(newc, u, parseInt(u.processed_id));
+  timewindow.shift(news, u, parseInt(u.processed_id));
 
   // Remove aggregated usage object behavior and return
-  const jsa = JSON.parse(JSON.stringify([newa, newc, iddoc]));
+  const jsa = JSON.parse(JSON.stringify([newa, newc, news, iddoc]));
   debug('New aggregated usage %o', jsa);
   return jsa;
 };

--- a/lib/aggregation/aggregator/src/index.js
+++ b/lib/aggregation/aggregator/src/index.js
@@ -537,6 +537,7 @@ const aggregate = function*(aggrs, u) {
   purgeOldQuantities(newa);
   purgeOldQuantities(newc);
   purgeOldQuantities(news);
+
   newa.space(u.space_id, seqid.sample(u.processed_id, sampling));
 
   // Go through the incoming accumulated usage metrics

--- a/lib/aggregation/aggregator/src/test/test-aggregate.js
+++ b/lib/aggregation/aggregator/src/test/test-aggregate.js
@@ -1,0 +1,85 @@
+'use strict';
+
+delete process.env.SAMPLING;
+
+const dbclient = require('abacus-dbclient');
+const moment = require('abacus-moment');
+const yieldable = require('abacus-yieldable');
+const seqid = require('abacus-seqid');
+const aggregator = require('..');
+
+describe('abacus-usage-aggregator', () => {
+  const aggregate = yieldable.functioncb(aggregator.aggregate);
+  const accumulatedUsage = (rid, s, e, p, api, dmem, mmem) => ({
+    id: dbclient.kturi(rid, p),
+    collected_usage_id: '555',
+    start: s,
+    end: e,
+    processed: p,
+    processed_id: seqid(),
+    resource_id: 'test-resource',
+    resource_instance_id: rid,
+    organization_id: 'a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28',
+    space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
+    consumer_id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
+    plan_id: 'basic',
+    resource_type: 'test-resource',
+    account_id: '1234',
+    pricing_country: 'USA',
+    metering_plan_id: 'test-metering-plan',
+    rating_plan_id: 'test-rating-plan',
+    pricing_plan_id: 'test-pricing-basic',
+    prices: {
+      metrics: [{ name: 'heavy_api_calls', price: 0.15 }, { name: 'memory', price: 0.00014 }]
+    },
+    accumulated_usage: [
+      {
+        metric: 'heavy_api_calls',
+        windows: [[null], [null], [null], [api, null, null], [api, null]]
+      },
+      {
+        metric: 'memory',
+        windows: [[null], [null], [null], [dmem, null, null], [mmem, null]]
+      }
+    ]
+  });
+
+  it('calls aggregate function for new org', (done) => {
+    const usage = accumulatedUsage('id1',
+      moment.now(), moment.now() + 1, moment.now(),
+      {
+        'quantity' : {
+          'current' : 10
+        },
+        'cost' : 1
+      },
+      {
+        'quantity' : {
+          'current': {
+            'consumed': 518400000,
+            'consuming': 6,
+            'since': 1420243200000
+          }
+        }
+      },
+      {
+        'quantity' : {
+          'current': {
+            'consumed': 518400000,
+            'consuming': 6,
+            'since': 1420243200000
+          }
+        }
+      });
+
+    aggregate([undefined, undefined, undefined], usage, (err, result) => {
+      expect(err).to.equal(null);
+      expect(result.length).to.equal(4);
+      expect(result[2].space_id).to.equal(usage.space_id);
+      expect(result[2].resources[0].plans[0]).not.to.equal(undefined);
+      expect(result[2].resources[0].plans[0].aggregated_usage[0].windows[4][0].quantity).to.equal(10);
+      expect(result[2].resources[0].plans[0].aggregated_usage[1].windows[4][0].quantity.consuming).to.equal(6);
+      done();
+    });
+  });
+});

--- a/lib/aggregation/aggregator/src/test/test.js
+++ b/lib/aggregation/aggregator/src/test/test.js
@@ -18,6 +18,7 @@ const extend = _.extend;
 const omit = _.omit;
 const map = _.map;
 
+
 const brequest = batch(request);
 
 const debug = require('abacus-debug')('abacus-usage-aggregator-test');
@@ -94,7 +95,6 @@ const pid = 'basic/test-metering-plan/' + 'test-rating-plan/test-pricing-basic';
 
 describe('abacus-usage-aggregator', () => {
   let clock;
-
   const systemToken = () => {};
 
   before((done) => {
@@ -149,13 +149,7 @@ describe('abacus-usage-aggregator', () => {
         spaces: [
           {
             space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
-            resources: resource([12, 22, 32, 42, 52], [1, 2, 3, 4, 5]),
-            consumers: [
-              {
-                id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
-                t: '0001420286400000/0001420286400000'
-              }
-            ]
+            t: seqid.sample('0001525261459051-0-0-1-0', 1)
           }
         ]
       },
@@ -165,13 +159,7 @@ describe('abacus-usage-aggregator', () => {
         spaces: [
           {
             space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
-            resources: resource([112, 122, 132, 142, 152], [11, 12, 13, 14, 15]),
-            consumers: [
-              {
-                id: 'external:bbeae239-f3f8-483c-9dd0-de6781c38bab',
-                t: '0001420286400000/0001420286400000'
-              }
-            ]
+            t: seqid.sample('0001525261459051-0-0-1-0', 1)
           }
         ]
       }
@@ -185,16 +173,7 @@ describe('abacus-usage-aggregator', () => {
       .plan(pid)
       .metric('heavy_api_calls').windows = twindows([12, 22, 32, 42, 52], [1, 2, 3, 4, 5]);
     agg[0]
-      .space('aaeae239-f3f8-483c-9dd0-de5d41c38b6a')
-      .resource('test-resource')
-      .plan(pid)
-      .metric('heavy_api_calls').windows = twindows([12, 22, 32, 42, 52], [1, 2, 3, 4, 5]);
-    agg[0]
-      .space('aaeae239-f3f8-483c-9dd0-de5d41c38b6a')
-      .consumer('external:bbeae239-f3f8-483c-9dd0-de6781c38bab', '0001420286400000/0001420286400000');
-    agg[0]
-      .space('aaeae239-f3f8-483c-9dd0-de5d41c38b6a')
-      .consumer('external:bbeae239-f3f8-483c-9dd0-de6781c38bab', '0001420286400000/0001420286400000');
+      .space('aaeae239-f3f8-483c-9dd0-de5d41c38b6a', seqid.sample('0001525261459051-0-0-1-0', 1));
 
     // Serialize to JSON to simulate db storage and retrieval, and expect
     // the object tree to match
@@ -208,16 +187,7 @@ describe('abacus-usage-aggregator', () => {
       .plan(pid)
       .metric('heavy_api_calls').windows = twindows([112, 122, 132, 142, 152], [11, 12, 13, 14, 15]);
     agg[1]
-      .space('aaeae239-f3f8-483c-9dd0-de5d41c38b6a')
-      .resource('test-resource')
-      .plan(pid)
-      .metric('heavy_api_calls').windows = twindows([112, 122, 132, 142, 152], [11, 12, 13, 14, 15]);
-    agg[1]
-      .space('aaeae239-f3f8-483c-9dd0-de5d41c38b6a')
-      .consumer('external:bbeae239-f3f8-483c-9dd0-de6781c38bab', '0001420286400000/0001420286400000');
-    agg[1]
-      .space('aaeae239-f3f8-483c-9dd0-de5d41c38b6a')
-      .consumer('external:bbeae239-f3f8-483c-9dd0-de6781c38bab', '0001420286400000/0001420286400000');
+      .space('aaeae239-f3f8-483c-9dd0-de5d41c38b6a', seqid.sample('0001525261459051-0-0-1-0', 1));
 
     // Serialize to JSON to simulate db storage and retrieval, and expect
     // the object tree to match
@@ -225,6 +195,7 @@ describe('abacus-usage-aggregator', () => {
   });
 
   it('aggregates usage for an organization', (done) => {
+
     const now = moment.utc().toDate();
     const processed = [
       Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0),
@@ -367,7 +338,7 @@ describe('abacus-usage-aggregator', () => {
         }
       )
     ];
-
+    let allPosts = 0;
     const verify = (secured, done) => {
       // Helper function for creating windows
       const twindows = (dq, mq, dc, mc, pdq, pmq) => {
@@ -404,12 +375,6 @@ describe('abacus-usage-aggregator', () => {
         ];
       };
 
-      // Helper function for creating consumer references
-      const consumer = (u, seq) => ({
-        id: u.consumer_id,
-        t: seqid.pad16(now.getTime()) + seq
-      });
-
       // Define the sequence of aggregated usage we're expecting for an org
       const aggregated = [
         {
@@ -443,21 +408,7 @@ describe('abacus-usage-aggregator', () => {
           spaces: [
             {
               space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
-              resources: resource(
-                12,
-                12,
-                { consumed: 518400000, consuming: 6 },
-                { consumed: 13996800000, consuming: 6 },
-                1.8,
-                1.8,
-                { consumed: 518400000, consuming: 6, price: 0.00014 },
-                { consumed: 13996800000, consuming: 6, price: 0.00014 },
-                null,
-                null,
-                null,
-                null
-              ),
-              consumers: [consumer(usage[0], '-0-0-0-' + (0 + (secured ? 4 : 0)))]
+              t: '0001420286400000'
             }
           ]
         },
@@ -492,21 +443,7 @@ describe('abacus-usage-aggregator', () => {
           spaces: [
             {
               space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
-              resources: resource(
-                22,
-                22,
-                { consumed: 684000000, consuming: 8 },
-                { consumed: 18655200000, consuming: 8 },
-                3.3,
-                3.3,
-                { consumed: 684000000, consuming: 8, price: 0.00014 },
-                { consumed: 18655200000, consuming: 8, price: 0.00014 },
-                12,
-                12,
-                { consumed: 518400000, consuming: 6 },
-                { consumed: 13996800000, consuming: 6 }
-              ),
-              consumers: [consumer(usage[1], '-0-0-0-' + (1 + (secured ? 4 : 0)))]
+              t: '0001420286400000'
             }
           ]
         },
@@ -541,21 +478,7 @@ describe('abacus-usage-aggregator', () => {
           spaces: [
             {
               space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
-              resources: resource(
-                30,
-                30,
-                { consumed: 920400000, consuming: 11 },
-                { consumed: 25630800000, consuming: 11 },
-                4.5,
-                4.5,
-                { consumed: 920400000, consuming: 11, price: 0.00014 },
-                { consumed: 25630800000, consuming: 11, price: 0.00014 },
-                22,
-                22,
-                { consumed: 684000000, consuming: 8 },
-                { consumed: 18655200000, consuming: 8 }
-              ),
-              consumers: [consumer(usage[2], '-0-0-0-' + (2 + (secured ? 4 : 0)))]
+              t: '0001420286400000'
             }
           ]
         },
@@ -590,21 +513,7 @@ describe('abacus-usage-aggregator', () => {
           spaces: [
             {
               space_id: 'aaeae239-f3f8-483c-9dd0-de5d41c38b6a',
-              resources: resource(
-                32,
-                32,
-                { consumed: 845600000, consuming: 10 },
-                { consumed: 23309600000, consuming: 10 },
-                4.8,
-                4.8,
-                { consumed: 845600000, consuming: 10, price: 0.00014 },
-                { consumed: 23309600000, consuming: 10, price: 0.00014 },
-                30,
-                30,
-                { consumed: 920400000, consuming: 11 },
-                { consumed: 25630800000, consuming: 11 }
-              ),
-              consumers: [consumer(usage[3], '-0-0-0-' + (3 + (secured ? 4 : 0)))]
+              t: '0001420286400000'
             }
           ]
         }
@@ -802,14 +711,17 @@ describe('abacus-usage-aggregator', () => {
 
         // Expect aggregated usage to be posted to a sink service
         expect(reqs[0][0]).to.equal('http://localhost:9400/v1/metering/aggregated/usage');
-
         // Expect the test organization aggregated values
         const org = reqs[0][1].body;
-        expect(omit(org, 'id', 'processed', 'processed_id', 'accumulated_usage_id')).to.deep.equal(
-          extend({}, omit(aggregated[posts], 'accumulated_usage_id'), {
+        expect(omit(org, 'id', 'processed', 'processed_id', 'accumulated_usage_id', 'spaces')).to.deep.equal(
+          extend({}, omit(aggregated[posts], 'accumulated_usage_id', 'spaces'), {
             organization_id: ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28', secured ? 1 : 0].join('-')
           })
         );
+        for (let i = 0; i < org.spaces.length; i++) {
+          expect(org.spaces[i].space_id).to.equal(aggregated[posts].spaces[i].space_id);
+          expect(org.spaces[i].t).to.equal(aggregated[posts].spaces[i].t + '-0-0-0-' + allPosts);
+        };
         // Expect the test consumer aggregated values
         const con = reqs[1][1].body;
         expect(omit(con, 'id', 'processed', 'processed_id', 'accumulated_usage_id')).to.deep.equal(
@@ -818,7 +730,7 @@ describe('abacus-usage-aggregator', () => {
           })
         );
         posts = posts + 1;
-
+        allPosts = allPosts + 1;
         cb(undefined, [
           [
             undefined,
@@ -849,7 +761,6 @@ describe('abacus-usage-aggregator', () => {
             const uval = extend({}, u, {
               organization_id: ['a3d7fe4d-3cb1-4cc3-a831-ffe98e20cf28', secured ? 1 : 0].join('-')
             });
-
             // Initialize oauth authorize spy
             authorizespy = spy(function() {});
 
@@ -1332,16 +1243,8 @@ describe('abacus-usage-aggregator', () => {
       records++;
       if (records === 3) {
         const org = reqs[0][1].body;
-        const con = reqs[1][1].body;
-        // Check the org aggregated resources
         expect(org.resources[0].plans[0].aggregated_usage[0]).to.deep.equal(expectedBasic);
         expect(org.resources[0].plans[1].aggregated_usage[0]).to.deep.equal(expectedStandard);
-        // Check the space aggregated resources
-        expect(org.spaces[0].resources[0].plans[0].aggregated_usage[0]).to.deep.equal(expectedBasic);
-        expect(org.spaces[0].resources[0].plans[1].aggregated_usage[0]).to.deep.equal(expectedStandard);
-        // Check the consumer
-        expect(con.resources[0].plans[0].aggregated_usage[0]).to.deep.equal(expectedBasic);
-        expect(con.resources[0].plans[1].aggregated_usage[0]).to.deep.equal(expectedStandard);
         done();
       }
 
@@ -1708,15 +1611,7 @@ describe('abacus-usage-aggregator', () => {
       ]);
       if (records === 4) {
         const org = reqs[0][1].body;
-        const con = reqs[1][1].body;
-        // Check the org aggregated resources
         expect(org.resources[0].plans[0].aggregated_usage[0]).to.deep.equal(expectedBasic);
-
-        // Check the space aggregated resources
-        expect(org.spaces[0].resources[0].plans[0].aggregated_usage[0]).to.deep.equal(expectedBasic);
-
-        // Check the consumer
-        expect(con.resources[0].plans[0].aggregated_usage[0]).to.deep.equal(expectedBasic);
         done();
       }
     };

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -711,6 +711,30 @@ const buildConsumersMap = (consumers, ids, startOfMonthKey, resourceId) => {
   return consumersDocMap;
 };
 
+// Returns a copy of the passed in org usage with the spaces populated
+const spaceUsage = function*(usage) {
+  const ids = [];
+  each(usage.spaces, (space) => {
+    ids.push(['k', usage.organization_id, space.space_id, 't', space.t].join('/'));
+  });
+
+  debug('Retrieving space usage for organization %o and spaces %o', usage.organization_id, ids);
+  const spaces = (yield aggregatordb.allDocs({
+    keys: ids,
+    include_docs: true
+  })).rows;
+
+  const spaceDocs = map(spaces,
+    (s) => ({
+      space_id: s.doc.space_id,
+      resources: s.doc.resources,
+      consumers: s.doc.consumers
+    }));
+
+  console.log(spaceDocs);
+  usage.spaces = spaceDocs;
+};
+
 // Returns a copy of the passed in org usage with the consumers populated
 const consumerUsage = function*(usage, resourceId, startOfMonthKey, counter) {
   // Collect the list of consumer ids to query for
@@ -791,12 +815,15 @@ const getConsumerUsage = function*(orgId, time, auth, resourceId, counter) {
   const usageDoc = doc.rows[0].doc;
   debug('Found rated usage %o', usageDoc);
 
+  yield spaceUsage(usageDoc);
+
   timewindow.shift(usageDoc, { processed: usageDoc.processed }, time);
   purgeOldQuantities(usageDoc);
 
   if (resourceId) {
     debug('Filtering usage document for resource: %s', resourceId);
     usageDoc.resources = filter(usageDoc.resources, (res) => res.resource_id === resourceId);
+    // TODO revise!
     for (let space of usageDoc.spaces)
       space.resources = filter(space.resources, (res) => res.resource_id === resourceId);
   }

--- a/lib/aggregation/reporting/src/index.js
+++ b/lib/aggregation/reporting/src/index.js
@@ -713,9 +713,12 @@ const buildConsumersMap = (consumers, ids, startOfMonthKey, resourceId) => {
 
 // Returns a copy of the passed in org usage with the spaces populated
 const spaceUsage = function*(usage) {
-  const ids = [];
+  const ids = [], orgSpaces = [];
   each(usage.spaces, (space) => {
-    ids.push(['k', usage.organization_id, space.space_id, 't', space.t].join('/'));
+    if (space.resources)
+      orgSpaces.push(space);
+    else
+      ids.push(['k', usage.organization_id, space.space_id, 't', space.t].join('/'));
   });
 
   debug('Retrieving space usage for organization %o and spaces %o', usage.organization_id, ids);
@@ -724,14 +727,17 @@ const spaceUsage = function*(usage) {
     include_docs: true
   })).rows;
 
-  const spaceDocs = map(spaces,
+  let spaceDocs = map(spaces,
     (s) => ({
       space_id: s.doc.space_id,
       resources: s.doc.resources,
       consumers: s.doc.consumers
     }));
 
-  console.log(spaceDocs);
+  if (orgSpaces.length)
+    spaceDocs = spaceDocs.concat(orgSpaces);
+  debug('All space docs: %o', spaceDocs);
+
   usage.spaces = spaceDocs;
 };
 
@@ -1185,6 +1191,7 @@ const retrieveUsage = (req, res, cb) => {
       });
     }
   );
+
 };
 
 // Retrieve a usage report summary for a resource instance given the

--- a/test/aggregation/aggregator/src/test/test.js
+++ b/test/aggregation/aggregator/src/test/test.js
@@ -577,8 +577,8 @@ describe('abacus-usage-aggregator-itest', () => {
             expect(err).to.equal(undefined);
             expect(val.statusCode).to.equal(200);
 
-            expect(omit(val.body, 'id', 'processed', 'processed_id', 'accumulated_usage_id')).to.deep.equal(
-              omit(accumulatedTemplate(o, ri, u), 'id', 'processed', 'processed_id')
+            expect(omit(val.body, 'id', 'processed', 'processed_id', 'accumulated_usage_id', 'spaces')).to.deep.equal(
+              omit(accumulatedTemplate(o, ri, u), 'id', 'processed', 'processed_id', 'spaces')
             );
 
             debug('Verified accumulated usage for org%d instance%d usage%d', o + 1, ri + 1, u + 1);
@@ -634,11 +634,12 @@ describe('abacus-usage-aggregator-itest', () => {
                   '_id',
                   '_rev',
                   'accumulated_usage_id',
-                  'start'
+                  'start',
+                  'spaces'
                 ]),
                 pruneWindows
               )
-            ).to.deep.equal(omit(expected, ['start']));
+            ).to.deep.equal(omit(expected, ['start', 'spaces']));
             done();
           } catch (e) {
             // If the test cannot verify the actual data with the expected
@@ -656,11 +657,12 @@ describe('abacus-usage-aggregator-itest', () => {
                     '_id',
                     '_rev',
                     'accumulated_usage_id',
-                    'start'
+                    'start',
+                    'spaces'
                   ]),
                   pruneWindows
                 )
-              ).to.deep.equal(omit(expected, ['start']));
+              ).to.deep.equal(omit(expected, ['start', 'spaces']));
             } else
               // Try the expected test again
               setTimeout(function() {


### PR DESCRIPTION
Extract spaces into separate documents in order to overcome the 16MB doc size limitations of MongoDB